### PR TITLE
fix: make proxy-pass-with-uri good example correspond to bad example

### DIFF
--- a/plugins/builtin/best_practices/proxy_pass_with_uri/examples/good.conf
+++ b/plugins/builtin/best_practices/proxy_pass_with_uri/examples/good.conf
@@ -7,9 +7,10 @@ http {
             proxy_pass http://backend;
         }
 
-        # With port, no URI - request path is preserved
+        # Use rewrite to explicitly handle URI rewriting
         location /web/ {
-            proxy_pass http://frontend:3000;
+            rewrite ^/web/(.*) /app/$1 break;
+            proxy_pass http://frontend;
         }
 
         # Regex location with capture group - OK (variable detected)


### PR DESCRIPTION
The good example for `location /web/` was using a completely different backend (http://frontend:3000) instead of showing how to fix the bad example's `proxy_pass http://frontend/app/;`. Use explicit rewrite to preserve the /web/ -> /app/ path mapping without relying on proxy_pass URI rewriting.