### PR TITLE
refactor: use native-builtin-plugins for pages build instead of wasm-builtin-plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,74 +60,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
-  build-plugins:
-    name: Build Plugins (${{ matrix.chunk }})
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        chunk: [0, 1, 2, 3, 4, 5, 6, 7]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "plugins-${{ matrix.chunk }}"
-      - name: Build plugin chunk
-        run: |
-          plugins=(plugins/builtin/*/*/)
-          total=${#plugins[@]}
-          chunks=8
-          chunk=${{ matrix.chunk }}
-          start=$(( chunk * total / chunks ))
-          end=$(( (chunk + 1) * total / chunks ))
-
-          mkdir -p target/builtin-plugins
-          for (( i=start; i<end; i++ )); do
-            dir="${plugins[$i]}"
-            if [ -f "$dir/Cargo.toml" ]; then
-              name=$(basename "$dir")
-              echo "Building $name..."
-              cargo build --manifest-path "$dir/Cargo.toml" \
-                --target wasm32-unknown-unknown \
-                --target-dir "$dir/target" \
-                --release
-              wasm_file="$dir/target/wasm32-unknown-unknown/release/$(echo $name | tr '-' '_')_plugin.wasm"
-              if [ -f "$wasm_file" ]; then
-                cp "$wasm_file" "target/builtin-plugins/${name}.wasm"
-                echo "  Collected ${name}.wasm"
-              fi
-            fi
-          done
-      - uses: actions/upload-artifact@v4
-        with:
-          name: builtin-plugins-${{ matrix.chunk }}
-          path: target/builtin-plugins/
-          retention-days: 1
-          if-no-files-found: ignore
-
-  merge-plugins:
-    name: Merge Plugins
-    needs: build-plugins
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: builtin-plugins-*
-          path: target/builtin-plugins/
-          merge-multiple: true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: builtin-plugins
-          path: target/builtin-plugins/
-          retention-days: 1
-
   pages-build:
     name: Pages Build
-    needs: merge-plugins
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -136,14 +70,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
-        with:
-          name: builtin-plugins
-          path: target/builtin-plugins/
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM for web
-        run: wasm-pack build --target web --out-dir web/pkg --no-default-features --features wasm,wasm-builtin-plugins
+        run: wasm-pack build --target web --out-dir web/pkg --no-default-features --features wasm,native-builtin-plugins
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v4
       - name: Upload Pages artifact

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -222,9 +222,8 @@ pub fn lint_with_config(content: &str, config_toml: &str) -> Result<WasmLintResu
         errors.extend(indent_rule.check_content(content));
     }
 
-    // Note: trailing-whitespace and space-before-semicolon are now WASM plugins.
-    // They are loaded through Linter::with_config() above when wasm-builtin-plugins feature is enabled,
-    // and executed via wasmi interpreter (which works inside browser WASM).
+    // Note: trailing-whitespace and space-before-semicolon are plugin rules.
+    // They are loaded through Linter::with_config() above when native-builtin-plugins feature is enabled.
 
     // Filter ignored errors and track count
     let result = filter_errors(errors, &mut tracker);
@@ -341,23 +340,9 @@ pub fn get_rule_categories() -> String {
 /// Debug function to check plugin loading status
 #[wasm_bindgen]
 pub fn debug_plugin_status() -> String {
-    #[cfg(feature = "wasm-builtin-plugins")]
-    {
-        use crate::linter::LintRule;
-        use crate::plugin::builtin::load_builtin_plugins;
-        match load_builtin_plugins() {
-            Ok(plugins) => format!(
-                "Loaded {} plugins: {:?}",
-                plugins.len(),
-                plugins.iter().map(|p| p.name()).collect::<Vec<_>>()
-            ),
-            Err(e) => format!("Failed to load plugins: {}", e),
-        }
-    }
-    #[cfg(not(feature = "wasm-builtin-plugins"))]
-    {
-        "wasm-builtin-plugins feature not enabled".to_string()
-    }
+    let linter = Linter::with_default_rules();
+    let names: Vec<&str> = linter.rules().iter().map(|r| r.name()).collect();
+    format!("Loaded {} rules: {:?}", names.len(), names)
 }
 
 /// Get the default configuration template


### PR DESCRIPTION

Remove build-plugins and merge-plugins CI jobs that were only needed for the pages build. By switching to native-builtin-plugins, plugins are compiled directly as Rust code instead of being pre-built as WASM and embedded via include_bytes!(), eliminating the WASM-in-WASM overhead and simplifying the CI pipeline.