### PR TITLE
fix: unify why modal width on mobile devices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -187,6 +187,7 @@
             border: 1px solid #404040;
             border-radius: 8px;
             padding: 20px;
+            width: 90vw;
             max-width: 600px;
             max-height: 80vh;
             overflow-y: auto;


### PR DESCRIPTION
Add explicit width: 90vw to .rule-modal so the modal has a consistent width regardless of content. Previously, the modal width varied per error because only max-width was set.