### PR TITLE
fix: prevent editor line number misalignment on mobile by disabling text wrap

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -115,6 +115,10 @@
             border-radius: 0;
             padding: 12px;
             padding-left: 8px;
+            white-space: pre;
+            overflow-wrap: normal;
+            word-break: normal;
+            overflow-x: auto;
         }
         textarea.editor:focus {
             outline: none;
@@ -356,7 +360,7 @@
                 </div>
                 <div class="editor-wrapper">
                     <div id="line-numbers" class="line-numbers"></div>
-                    <textarea id="editor" class="editor" spellcheck="false"># Demo: Try clicking rule names for details, or "Fix All" to auto-fix issues
+                    <textarea id="editor" class="editor" spellcheck="false" wrap="off"># Demo: Try clicking rule names for details, or "Fix All" to auto-fix issues
 http {
   server_tokens on;
   autoindex on;


### PR DESCRIPTION
On narrow viewports, long lines in the textarea would wrap to multiple visual lines while line numbers stayed at one div per logical line, causing them to drift out of sync. Disable wrapping with CSS and wrap="off" so each logical line is exactly one visual line, with horizontal scrolling for overflow.