### PR TITLE
fix: resolve clippy warnings for workspace build

### DIFF
--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -41,7 +41,7 @@ fn display_profile(profiles: &[RuleProfile]) {
 
     // Convert to vec and sort by duration (descending)
     let mut sorted: Vec<_> = aggregated.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.0.cmp(&a.1.0));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.0));
 
     // Calculate total time
     let total_time: Duration = sorted.iter().map(|(_, (d, _, _))| *d).sum();

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -41,7 +41,7 @@ fn display_profile(profiles: &[RuleProfile]) {
 
     // Convert to vec and sort by duration (descending)
     let mut sorted: Vec<_> = aggregated.into_iter().collect();
-    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.0));
+    sorted.sort_by_key(|entry| std::cmp::Reverse(entry.1.0));
 
     // Calculate total time
     let total_time: Duration = sorted.iter().map(|(_, (d, _, _))| *d).sum();

--- a/src/plugin/component_rule.rs
+++ b/src/plugin/component_rule.rs
@@ -18,7 +18,9 @@ pub struct PluginSpec {
     pub name: String,
     pub category: String,
     pub description: String,
+    #[allow(dead_code)]
     pub api_version: String,
+    #[allow(dead_code)]
     pub severity: Option<String>,
     pub why: Option<String>,
     pub bad_example: Option<String>,


### PR DESCRIPTION
- Use sort_by_key with Reverse instead of sort_by closure in display_profile
- Add #[allow(dead_code)] to unused PluginSpec fields (api_version, severity)