### PR TITLE
fix: avoid false 'unused nginx-lint:ignore' warning for late-stage rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,12 +99,12 @@ pub fn pre_parse_checks_from_content(
     content: &str,
     lint_config: Option<&LintConfig>,
 ) -> Vec<LintError> {
-    use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
+    use nginx_lint_common::ignore::{IgnoreTracker, filter_errors};
     use rules::{MissingSemicolon, UnclosedQuote, UnmatchedBraces};
 
     // Build ignore tracker from content without rule name validation
     // (rule name validation is done later in lint_with_content when all plugins are loaded)
-    let (mut tracker, warnings) = IgnoreTracker::from_content(content);
+    let (mut tracker, _warnings) = IgnoreTracker::from_content(content);
 
     let additional_block_directives: Vec<String> = lint_config
         .map(|c| c.additional_block_directives().to_vec())
@@ -124,15 +124,14 @@ pub fn pre_parse_checks_from_content(
     let semicolon_rule = MissingSemicolon;
     errors.extend(semicolon_rule.check_content_with_extras(content, &additional_block_directives));
 
-    // Filter ignored errors
+    // Filter ignored errors using the local tracker.
+    // Note: we intentionally do NOT emit parse warnings or unused-directive
+    // warnings here — those are emitted by `lint_with_content`, whose tracker
+    // sees errors from ALL rules (not just pre-parse ones). Emitting unused
+    // warnings here would falsely flag ignore directives that target later
+    // rules like `include-path-exists`.
     let result = filter_errors(errors, &mut tracker);
-    let mut errors = result.errors;
-
-    // Add warnings from ignore comments (parse warnings + unused warnings)
-    errors.extend(warnings_to_errors(warnings));
-    errors.extend(warnings_to_errors(result.unused_warnings));
-
-    errors
+    result.errors
 }
 
 /// Apply fixes to a file

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1281,7 +1281,8 @@ http {
 fn test_ignore_include_path_exists_not_flagged_as_unused() {
     use nginx_lint::pre_parse_checks_from_content;
 
-    let content = "http {\n    include mime.types; # nginx-lint:ignore include-path-exists versioning\n}\n";
+    let content =
+        "http {\n    include mime.types; # nginx-lint:ignore include-path-exists versioning\n}\n";
 
     let tmp_dir = tempfile::tempdir().expect("create tempdir");
     let conf_path = tmp_dir.path().join("nginx.conf");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -658,7 +658,10 @@ fn test_all_rule_fixtures() {
                 let mut errors = pre_parse_checks(&tc.error_path);
 
                 if let Some(ref config) = error_config {
-                    errors.extend(linter.lint(config, &tc.error_path));
+                    let content = fs::read_to_string(&tc.error_path).unwrap_or_default();
+                    let (lint_errors, _) =
+                        linter.lint_with_content(config, &tc.error_path, &content);
+                    errors.extend(lint_errors);
                 }
 
                 let rule_errors: Vec<_> = errors
@@ -679,7 +682,10 @@ fn test_all_rule_fixtures() {
                 let mut errors = pre_parse_checks(&tc.expected_path);
 
                 if let Some(ref config) = expected_config {
-                    errors.extend(linter.lint(config, &tc.expected_path));
+                    let content = fs::read_to_string(&tc.expected_path).unwrap_or_default();
+                    let (lint_errors, _) =
+                        linter.lint_with_content(config, &tc.expected_path, &content);
+                    errors.extend(lint_errors);
                 }
 
                 let rule_errors: Vec<_> = errors
@@ -704,7 +710,10 @@ fn test_all_rule_fixtures() {
 
                             let mut all_errors = pre_parse_checks(temp_path);
                             if let Ok(config) = parse_config(temp_path) {
-                                all_errors.extend(linter.lint(&config, temp_path));
+                                let content = fs::read_to_string(temp_path).unwrap_or_default();
+                                let (lint_errors, _) =
+                                    linter.lint_with_content(&config, temp_path, &content);
+                                all_errors.extend(lint_errors);
                             }
 
                             let rule_errors_with_fixes: Vec<_> = all_errors
@@ -1260,6 +1269,39 @@ http {
     assert!(
         fixed.contains("        server_tokens off;\n    }\n"),
         "Fix should remove the inline comment"
+    );
+}
+
+// Regression: pre_parse_checks_from_content must not emit "unused" warnings
+// for ignore directives whose target rule only runs later in lint_with_content
+// (e.g. include-path-exists). Previously, pre-parse built its own tracker,
+// filtered only the pre-parse rules, and prematurely flagged such directives
+// as unused.
+#[test]
+fn test_ignore_include_path_exists_not_flagged_as_unused() {
+    use nginx_lint::pre_parse_checks_from_content;
+
+    let content = "http {\n    include mime.types; # nginx-lint:ignore include-path-exists versioning\n}\n";
+
+    let tmp_dir = tempfile::tempdir().expect("create tempdir");
+    let conf_path = tmp_dir.path().join("nginx.conf");
+    fs::write(&conf_path, content).expect("write conf");
+
+    let pre_parse_errors = pre_parse_checks_from_content(content, None);
+    let config = parse_string(content).expect("parse");
+    let linter = get_default_linter();
+    let (mut errors, ignored_count) = linter.lint_with_content(&config, &conf_path, content);
+    errors.extend(pre_parse_errors);
+
+    assert_eq!(ignored_count, 1, "include-path-exists should be ignored");
+    let unused: Vec<_> = errors
+        .iter()
+        .filter(|e| e.rule == "invalid-nginx-lint-ignore")
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "ignore directive for a later-stage rule must not be flagged as unused, got: {:?}",
+        unused,
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1306,6 +1306,41 @@ fn test_ignore_include_path_exists_not_flagged_as_unused() {
     );
 }
 
+// Pre-parse rules (missing-semicolon, unmatched-braces, unclosed-quote) are
+// also registered as LintRule and re-run inside lint_with_content. Verify
+// that a genuinely unused ignore for such a rule is still reported.
+#[test]
+fn test_unused_ignore_for_pre_parse_rule_is_still_reported() {
+    use nginx_lint::pre_parse_checks_from_content;
+
+    // Well-formed file: the missing-semicolon ignore has nothing to suppress.
+    let content =
+        "http {\n    # nginx-lint:ignore missing-semicolon not needed\n    server_tokens off;\n}\n";
+
+    let tmp_dir = tempfile::tempdir().expect("create tempdir");
+    let conf_path = tmp_dir.path().join("nginx.conf");
+    fs::write(&conf_path, content).expect("write conf");
+
+    let pre_parse_errors = pre_parse_checks_from_content(content, None);
+    let config = parse_string(content).expect("parse");
+    let linter = get_default_linter();
+    let (mut errors, _) = linter.lint_with_content(&config, &conf_path, content);
+    errors.extend(pre_parse_errors);
+
+    let unused: Vec<_> = errors
+        .iter()
+        .filter(|e| {
+            e.rule == "invalid-nginx-lint-ignore" && e.message.contains("missing-semicolon")
+        })
+        .collect();
+    assert_eq!(
+        unused.len(),
+        1,
+        "unused ignore for a pre-parse rule must still be flagged, got errors: {:?}",
+        errors,
+    );
+}
+
 // ============================================================================
 // Invalid directive context tests
 // ============================================================================


### PR DESCRIPTION
`pre_parse_checks_from_content` built its own `IgnoreTracker` and emitted `result.unused_warnings` before the main rules had run. Ignore directives targeting rules that only run in `lint_with_content` (e.g. `include-path-exists`) were therefore flagged as unused even when they correctly suppressed an error in the later stage.

Drop the premature warning emission; the tracker inside `lint_with_content` is authoritative since it sees errors from all rules. Update `test_all_rule_fixtures` to drive fixtures through `lint_with_content` so unused-warning fixtures still cover the real CLI path, and add a regression test for the `include-path-exists` case.