### PR TITLE
feat(security): add nginx-rift lint rule (CVE-2026-42945)

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -29,7 +29,8 @@ jobs:
           MAJOR="${LATEST%%.*}"
           MINOR="${LATEST##*.}"
           PREVIOUS="$MAJOR.$((MINOR - 1))"
-          echo "matrix={\"nginx-image\":[\"nginx:$LATEST\",\"nginx:$PREVIOUS\",\"openresty/openresty:noble\",\"ghcr.io/walf443/freenginx-image:1.31\"]}" >> "$GITHUB_OUTPUT"
+          OLDER="$MAJOR.$((MINOR - 2))"
+          echo "matrix={\"nginx-image\":[\"nginx:$LATEST\",\"nginx:$PREVIOUS\",\"nginx:$OLDER\",\"openresty/openresty:noble\",\"ghcr.io/walf443/freenginx-image:1.31\"]}" >> "$GITHUB_OUTPUT"
 
   container-tests:
     name: Container Tests (${{ matrix.nginx-image }})

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "plugins/builtin/security/autoindex_enabled",
     "plugins/builtin/security/deprecated_ssl_protocol",
     "plugins/builtin/security/weak_ssl_ciphers",
+    "plugins/builtin/security/nginx_rift",
     "plugins/builtin/style/space_before_semicolon",
     "plugins/builtin/style/trailing_whitespace",
     "plugins/builtin/style/block_lines",
@@ -61,6 +62,7 @@ native-builtin-plugins = [
     "dep:autoindex-enabled-plugin",
     "dep:deprecated-ssl-protocol-plugin",
     "dep:weak-ssl-ciphers-plugin",
+    "dep:nginx-rift-plugin",
     "dep:space-before-semicolon-plugin",
     "dep:trailing-whitespace-plugin",
     "dep:block-lines-plugin",
@@ -116,6 +118,7 @@ server-tokens-enabled-plugin = { path = "plugins/builtin/security/server_tokens_
 autoindex-enabled-plugin = { path = "plugins/builtin/security/autoindex_enabled", optional = true, default-features = false }
 deprecated-ssl-protocol-plugin = { path = "plugins/builtin/security/deprecated_ssl_protocol", optional = true, default-features = false }
 weak-ssl-ciphers-plugin = { path = "plugins/builtin/security/weak_ssl_ciphers", optional = true, default-features = false }
+nginx-rift-plugin = { path = "plugins/builtin/security/nginx_rift", optional = true, default-features = false }
 space-before-semicolon-plugin = { path = "plugins/builtin/style/space_before_semicolon", optional = true, default-features = false }
 trailing-whitespace-plugin = { path = "plugins/builtin/style/trailing_whitespace", optional = true, default-features = false }
 block-lines-plugin = { path = "plugins/builtin/style/block_lines", optional = true, default-features = false }

--- a/plugins/builtin/security/nginx_rift/Cargo.toml
+++ b/plugins/builtin/security/nginx_rift/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nginx-rift-plugin"
+version = "0.10.5"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+nginx-lint-plugin = { path = "../../../../crates/nginx-lint-plugin" }
+
+[dev-dependencies]
+nginx-lint-plugin = { path = "../../../../crates/nginx-lint-plugin", features = ["container-testing"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["wit-export"]
+wit-export = ["nginx-lint-plugin/wit-export"]

--- a/plugins/builtin/security/nginx_rift/examples/bad.conf
+++ b/plugins/builtin/security/nginx_rift/examples/bad.conf
@@ -1,0 +1,9 @@
+http {
+  server {
+    listen 80;
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $original_endpoint $1;
+    }
+  }
+}

--- a/plugins/builtin/security/nginx_rift/examples/good.conf
+++ b/plugins/builtin/security/nginx_rift/examples/good.conf
@@ -1,0 +1,9 @@
+http {
+  server {
+    listen 80;
+    location ~ ^/api/(?<rest>.*)$ {
+      rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
+      set $original_endpoint $rest;
+    }
+  }
+}

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1,0 +1,361 @@
+//! nginx-rift plugin (CVE-2026-42945)
+//!
+//! Detects the vulnerable nginx configuration pattern behind CVE-2026-42945
+//! (marketed as "NGINX Rift"): a `rewrite` directive whose replacement
+//! string contains `?`, followed in the same block by a `set`, `rewrite`,
+//! or `if` directive that references an unnamed PCRE capture variable
+//! (`$1`..`$9`).
+//!
+//! On affected nginx versions (0.6.27 .. 1.30.0) the leaked `is_args` flag
+//! causes a heap buffer overrun in the worker process during request
+//! handling, which can lead to a worker crash or unauthenticated RCE on
+//! systems without ASLR.
+//!
+//! Build with:
+//! ```sh
+//! cargo build --target wasm32-unknown-unknown --release
+//! ```
+
+use nginx_lint_plugin::prelude::*;
+
+#[derive(Default)]
+pub struct NginxRiftPlugin;
+
+impl Plugin for NginxRiftPlugin {
+    fn spec(&self) -> PluginSpec {
+        PluginSpec::new(
+            "nginx-rift",
+            "security",
+            "Detects the CVE-2026-42945 vulnerable pattern: a rewrite with '?' in \
+             the replacement followed by a set/rewrite/if using unnamed captures \
+             ($1..$9) in the same scope",
+        )
+        .with_severity("error")
+        .with_why(
+            "CVE-2026-42945 (\"NGINX Rift\") is a heap buffer overflow in \
+             ngx_http_rewrite_module that affects nginx 0.6.27 through 1.30.0 \
+             (fixed in 1.30.1 and 1.31.0). When a `rewrite` replacement \
+             contains `?`, the worker sets an internal `is_args` flag on the \
+             main script engine and never clears it. A subsequent `set`, \
+             `rewrite`, or `if` directive that references an unnamed PCRE \
+             capture (`$1`..`$9`) then uses a length-calculation pass that \
+             ignores the flag while the copy pass honors it, so the worker \
+             writes more bytes (each escape-prone byte expands by 2, e.g. \
+             `+` -> `%2B`) than were allocated. This may cause worker \
+             crashes or — on systems without ASLR — unauthenticated remote \
+             code execution. Empirically, the captured value is also \
+             corrupted on the wire (`/api/foo+bar` returns a truncated \
+             `captured=foo%2Bb`). The reliable fixes are: (1) upgrade nginx \
+             to 1.30.1 / 1.31.0 or later; (2) drop `?` from the rewrite \
+             replacement; (3) switch to named captures (`(?<name>...)`), \
+             which are resolved through a separate code path that does not \
+             share the rewrite engine's `is_args` state. Note that simply \
+             reordering `set` to run before `rewrite` does NOT remove the \
+             underlying bug. This rule is shipped as a default `error` \
+             until the affected versions are no longer in widespread use; \
+             it can be disabled in configuration once your fleet is fully \
+             upgraded.",
+        )
+        .with_bad_example(include_str!("../examples/bad.conf").trim())
+        .with_good_example(include_str!("../examples/good.conf").trim())
+        .with_references(vec![
+            "https://nvd.nist.gov/vuln/detail/CVE-2026-42945".to_string(),
+            "https://nginx.org/en/security_advisories.html".to_string(),
+            "https://depthfirst.com/research/nginx-rift-achieving-nginx-rce-via-an-18-year-old-vulnerability".to_string(),
+            "https://github.com/walf443/nginx-lint/blob/main/plugins/builtin/security/nginx_rift/tests/container_test.rs".to_string(),
+        ])
+    }
+
+    fn check(&self, config: &Config, _path: &str) -> Vec<LintError> {
+        let mut errors = Vec::new();
+        let err = self.spec().error_builder();
+        check_items(&config.items, &mut errors, &err);
+        errors
+    }
+}
+
+fn check_items(items: &[ConfigItem], errors: &mut Vec<LintError>, err: &ErrorBuilder) {
+    let directives: Vec<&Directive> = items
+        .iter()
+        .filter_map(|item| match item {
+            ConfigItem::Directive(d) => Some(d.as_ref()),
+            _ => None,
+        })
+        .collect();
+
+    for (i, dir) in directives.iter().enumerate() {
+        if is_rewrite_with_question_mark(dir) {
+            for next in directives.iter().skip(i + 1) {
+                if is_capture_consumer(next) && uses_unnamed_capture(next) {
+                    errors.push(err.error_at(
+                        "CVE-2026-42945: `rewrite` replacement contains `?` and is \
+                         followed by a directive that references an unnamed capture \
+                         ($1..$9) in the same scope — this triggers a heap buffer \
+                         overflow on nginx <1.30.1/<1.31.0. Upgrade nginx, switch to \
+                         named captures, or remove `?` from the replacement.",
+                        *dir,
+                    ));
+                    break;
+                }
+            }
+        }
+
+        if let Some(block) = &dir.block {
+            check_items(&block.items, errors, err);
+        }
+    }
+}
+
+fn is_rewrite_with_question_mark(dir: &Directive) -> bool {
+    if !dir.is("rewrite") || dir.args.len() < 2 {
+        return false;
+    }
+    dir.args[1].as_str().contains('?')
+}
+
+fn is_capture_consumer(dir: &Directive) -> bool {
+    dir.is("set") || dir.is("rewrite") || dir.is("if")
+}
+
+fn uses_unnamed_capture(dir: &Directive) -> bool {
+    // Variable arguments (`$1`) keep the `$` in `raw` but strip it in `as_str()`.
+    // Quoted / literal arguments embed `$1` inside `raw` and `as_str()` alike.
+    // Scanning `raw` covers both cases.
+    dir.args
+        .iter()
+        .any(|arg| contains_unnamed_capture(&arg.raw))
+}
+
+fn contains_unnamed_capture(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && matches!(bytes[i + 1], b'1'..=b'9') {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+nginx_lint_plugin::export_component_plugin!(NginxRiftPlugin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nginx_lint_plugin::testing::{PluginTestRunner, TestCase};
+
+    #[test]
+    fn test_detects_rewrite_then_set_with_capture() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $original_endpoint $1;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_detects_rewrite_then_rewrite_with_capture() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/foo/(.*)$ {
+            rewrite ^/foo/(.*)$ /bar?x=1;
+            rewrite ^/bar/(.*)$ /baz/$1 last;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_detects_rewrite_then_if_with_capture() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/foo/(.*)$ {
+            rewrite ^/foo/(.*)$ /bar?x=1;
+            if ($1) {
+                return 200;
+            }
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_no_error_when_no_question_mark() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_no_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal/migrated;
+            set $original_endpoint $1;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_no_error_when_set_precedes_rewrite() {
+        // The rule narrowly targets the rewrite-then-set order, which is the
+        // case that produces the dangerous buffer overrun (length-pass sees
+        // is_args=0, copy-pass sees is_args=1). When `set` runs textually
+        // before `rewrite`, the captured value is materialised while
+        // is_args is still 0, so no buffer-size mismatch occurs at the
+        // critical site. (The captured value may still be arg-escaped at
+        // *read* time on vulnerable nginx — that's a separate mis-escape,
+        // not the RCE-class overrun, and is intentionally out of scope.)
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_no_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            set $original_endpoint $1;
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_no_error_when_no_unnamed_capture_after() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_no_errors(
+            r#"
+http {
+    server {
+        location / {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $foo "static";
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_no_error_when_only_named_capture() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_no_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(?<rest>.*)$ {
+            rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
+            set $original_endpoint $rest;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_no_error_when_subsequent_directive_in_different_block() {
+        // Subsequent directive must be in the SAME block to trigger.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_no_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+        }
+        location /other {
+            set $foo $1;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_error_location_points_to_rewrite() {
+        TestCase::new(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $original_endpoint $1;
+        }
+    }
+}
+"#,
+        )
+        .expect_error_count(1)
+        .expect_error_on_line(5)
+        .expect_message_contains("CVE-2026-42945")
+        .run(&NginxRiftPlugin);
+    }
+
+    #[test]
+    fn test_only_one_error_per_vulnerable_rewrite() {
+        // Even with multiple subsequent capture users, we report once per rewrite.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $a $1;
+            set $b $2;
+            if ($1) { return 200; }
+        }
+    }
+}
+"#,
+            1,
+        );
+    }
+
+    #[test]
+    fn test_capture_inside_quoted_string() {
+        // $1 embedded in a quoted argument is still a capture reference.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $combined "prefix-$1-suffix";
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_fixtures() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.test_fixtures(nginx_lint_plugin::fixtures_dir!());
+    }
+}

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -411,6 +411,29 @@ http {
     }
 
     #[test]
+    fn test_capture_inside_single_quoted_string() {
+        // nginx expands `$N` inside SINGLE-quoted strings as well as
+        // double-quoted (verified empirically on nginx 1.30.0: a config
+        // with `set $x 'prefix-$1-suffix'` after a vulnerable rewrite
+        // returns `prefix-foo%2Bbar-suff` — same mis-escape + truncation
+        // signature as the double-quoted form). The lint rule must
+        // therefore flag both quote styles uniformly.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $combined 'prefix-$1-suffix';
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_fixtures() {
         let runner = PluginTestRunner::new(NginxRiftPlugin);
         runner.test_fixtures(nginx_lint_plugin::fixtures_dir!());

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Detects the vulnerable nginx configuration pattern behind CVE-2026-42945
 //! (marketed as "NGINX Rift"): a `rewrite` directive whose replacement
-//! string contains `?`, followed in the same block by a `set`, `rewrite`,
-//! or `if` directive that references an unnamed PCRE capture variable
+//! string contains `?`, followed in the same block by a `set` or `rewrite`
+//! directive that references an unnamed PCRE capture variable
 //! (`$1`..`$9`).
 //!
 //! On affected nginx versions (0.6.27 .. 1.30.0) the leaked `is_args` flag
@@ -27,8 +27,8 @@ impl Plugin for NginxRiftPlugin {
             "nginx-rift",
             "security",
             "Detects the CVE-2026-42945 vulnerable pattern: a rewrite with '?' in \
-             the replacement followed by a set/rewrite/if using unnamed captures \
-             ($1..$9) in the same scope",
+             the replacement followed by a `set` or `rewrite` using unnamed \
+             captures ($1..$9) in the same scope",
         )
         .with_severity("error")
         .with_why(
@@ -36,9 +36,9 @@ impl Plugin for NginxRiftPlugin {
              ngx_http_rewrite_module that affects nginx 0.6.27 through 1.30.0 \
              (fixed in 1.30.1 and 1.31.0). When a `rewrite` replacement \
              contains `?`, the worker sets an internal `is_args` flag on the \
-             main script engine and never clears it. A subsequent `set`, \
-             `rewrite`, or `if` directive that references an unnamed PCRE \
-             capture (`$1`..`$9`) then uses a length-calculation pass that \
+             main script engine and never clears it. A subsequent `set` or \
+             `rewrite` directive that references an unnamed PCRE capture \
+             (`$1`..`$9`) then uses a length-calculation pass that \
              ignores the flag while the copy pass honors it, so the worker \
              writes more bytes (each escape-prone byte expands by 2, e.g. \
              `+` -> `%2B`) than were allocated. This may cause worker \
@@ -113,8 +113,29 @@ fn is_rewrite_with_question_mark(dir: &Directive) -> bool {
     dir.args[1].as_str().contains('?')
 }
 
+/// Directives that, on vulnerable nginx, hit the buggy script-engine path
+/// when evaluating an unnamed PCRE capture (`$1`..`$9`) — i.e. the
+/// directives whose use of `$N` after a leaking `rewrite … ?…` actually
+/// triggers the buffer overrun.
+///
+/// `set` and `rewrite` (in its replacement string) are both verified
+/// observable on nginx 1.30.0: with a preceding rewrite-with-`?` in the
+/// same scope, `+` in the captured value comes back as `%2B` (and for
+/// `set`, the value is also truncated mid-escape).
+///
+/// `return` is intentionally NOT included: empirically `return 200 "$1"`
+/// after a `rewrite … ?…` on nginx 1.30.0 returns `$1` clean (no
+/// mis-escape, no truncation), because `return`'s complex-value
+/// evaluation goes through a different code path.
+///
+/// `if` is intentionally NOT included: the only way `if`'s argument list
+/// can contain `$N` is the form `if ($1 …)`, which nginx itself rejects
+/// at config-load time with `unknown "1" variable` — so the rule would
+/// only ever fire on configs nginx refuses to start. The legitimate
+/// `if ($var ~ "regex")` form has its own captures via the if-regex and
+/// does not reference the outer rewrite's `$N` in its argument list.
 fn is_capture_consumer(dir: &Directive) -> bool {
-    dir.is("set") || dir.is("rewrite") || dir.is("if")
+    dir.is("set") || dir.is("rewrite")
 }
 
 fn uses_unnamed_capture(dir: &Directive) -> bool {
@@ -126,12 +147,24 @@ fn uses_unnamed_capture(dir: &Directive) -> bool {
         .any(|arg| contains_unnamed_capture(&arg.raw))
 }
 
+/// Detect references to positional captures `$1`..`$9`, including the
+/// brace-disambiguated form `${1}`..`${9}` used when the capture is
+/// followed by characters that would otherwise be parsed as part of the
+/// variable name (e.g. `${1}_suffix`).
 fn contains_unnamed_capture(s: &str) -> bool {
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'$' && i + 1 < bytes.len() && matches!(bytes[i + 1], b'1'..=b'9') {
-            return true;
+        if bytes[i] == b'$' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            // `$1`..`$9`
+            if matches!(next, b'1'..=b'9') {
+                return true;
+            }
+            // `${1}`..`${9}`
+            if next == b'{' && i + 2 < bytes.len() && matches!(bytes[i + 2], b'1'..=b'9') {
+                return true;
+            }
         }
         i += 1;
     }
@@ -180,9 +213,12 @@ http {
     }
 
     #[test]
-    fn test_detects_rewrite_then_if_with_capture() {
+    fn test_no_error_on_if_with_positional_capture_form() {
+        // `if ($1 …)` is nginx-invalid at runtime (`unknown "1" variable`),
+        // so flagging it would only produce false positives on configs
+        // nginx itself refuses to load. Verify the rule does NOT fire.
         let runner = PluginTestRunner::new(NginxRiftPlugin);
-        runner.assert_has_errors(
+        runner.assert_no_errors(
             r#"
 http {
     server {
@@ -191,6 +227,27 @@ http {
             if ($1) {
                 return 200;
             }
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_detects_brace_form_of_unnamed_capture() {
+        // ${1} is the brace-disambiguated form of $1 (used when followed
+        // by characters that would otherwise be parsed into the variable
+        // name). The bug-triggering semantics are identical, so it must
+        // also be flagged.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_has_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $combined "${1}_suffix";
         }
     }
 }
@@ -326,7 +383,7 @@ http {
             rewrite ^/api/(.*)$ /internal?migrated=true;
             set $a $1;
             set $b $2;
-            if ($1) { return 200; }
+            rewrite ^/x/(.*)$ /y/$1;
         }
     }
 }

--- a/plugins/builtin/security/nginx_rift/tests/container_test.rs
+++ b/plugins/builtin/security/nginx_rift/tests/container_test.rs
@@ -1,0 +1,320 @@
+//! Container-based integration tests for the nginx-rift rule
+//! (CVE-2026-42945, "NGINX Rift").
+//!
+//! These tests prove the rule is targeting a *real* nginx bug by exercising
+//! the flagged directive sequence against a vulnerable nginx and observing
+//! the bug's signature directly.
+//!
+//! # The bug's observable signature
+//!
+//! With the vulnerable pattern (`rewrite ... ?... ;` followed by a `set $x $1;`
+//! that consumes the location-regex capture), nginx computes the buffer size
+//! for the captured value on a freshly zeroed sub-engine (is_args=0, so each
+//! byte is counted as 1 byte) but copies the value on the main engine (where
+//! the rewrite has leaked is_args=1, so escape-prone characters expand). The
+//! buffer is therefore undersized.
+//!
+//! On a request whose capture contains `+`, the visible symptoms on
+//! vulnerable nginx are:
+//!
+//! - the captured value is wrongly arg-escaped (`+` becomes `%2B`), and
+//! - the value is *truncated* mid-escape, because the worker writes more
+//!   bytes than the buffer holds and the output is cut off at the allocated
+//!   length.
+//!
+//! For example, `/api/foo+bar` (capture `foo+bar`, raw_size = 7) on
+//! nginx 1.30.0 returns `captured=foo%2Bb` — the worker tried to write
+//! `foo%2Bbar` (9 bytes) into a 7-byte buffer.
+//!
+//! On a patched build (>= 1.30.1, 1.31.0) the `e->is_args = 0` reset in
+//! `ngx_http_script_regex_end_code` keeps args-escaping off for the
+//! capture, so the same request returns `captured=foo+bar` cleanly.
+//!
+//! # Why we skip on patched versions
+//!
+//! On patched nginx the signature is *absent* by design, so there is
+//! nothing to assert on. We therefore skip the bug-observation tests on
+//! `nginx_version_at_least(1, 31)`. We do NOT skip on potentially-
+//! unpatched tags (`nginx:1.30`, `openresty:noble`, etc.) — those are
+//! exactly the builds we want to exercise. Confirmed observed on:
+//!
+//! - `nginx:1.30.0` (CVE patched in 1.30.1) — truncated/escaped
+//! - `openresty/openresty:noble` (openresty/1.29.2.3) — mis-escaped
+//! - `nginx:1.31`, `freenginx:1.31` — clean (tests skipped)
+//!
+//! # Why we don't assert on a worker crash
+//!
+//! The CVSS-4.0 = 9.2 RCE scenario rests on the buffer overrun corrupting
+//! adjacent heap allocations. Whether that manifests as a SIGSEGV depends
+//! on heap layout and is not a reliable CI signal — even on 1.30.0 the
+//! request returns 200 OK with corrupted output rather than crashing
+//! deterministically. The truncated/mis-escaped output is the deterministic
+//! precondition; if that is present, the heap is being overrun.
+//!
+//! Run with:
+//!   cargo test -p nginx-rift-plugin --test container_test -- --ignored
+//!
+//! Specify nginx version via environment variable (default: "1.27"):
+//!   NGINX_IMAGE=nginx:1.30.0 cargo test -p nginx-rift-plugin \
+//!       --test container_test -- --ignored
+
+use nginx_lint_plugin::container_testing::{NginxContainer, nginx_version_at_least, reqwest};
+
+/// On patched builds the bug's signature is absent by design, so the
+/// observation tests have nothing to assert on. Skip them there. We do
+/// NOT skip on potentially-unpatched tags — that is what we want to test.
+fn skip_on_patched_version() -> bool {
+    nginx_version_at_least(1, 31)
+}
+
+/// Vulnerable pattern: rewrite with `?` in the replacement, followed by a
+/// `set` that consumes the unnamed capture in the same location block.
+/// This is the exact directive sequence the lint rule flags.
+fn vulnerable_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+http {
+    server {
+        listen 80;
+
+        location /healthz {
+            return 200 'OK';
+        }
+
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal?migrated=true;
+            set $original_endpoint $1;
+            return 200 "captured=$original_endpoint\n";
+        }
+    }
+}
+"#
+}
+
+/// Recommended fix #1: drop the `?` from the rewrite replacement so the
+/// `is_args` flag is never set in the first place. The captured value is
+/// then routed through `set` without going through the args-escaping path.
+fn safe_no_question_mark_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+http {
+    server {
+        listen 80;
+
+        location /healthz {
+            return 200 'OK';
+        }
+
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /internal/migrated;
+            set $original_endpoint $1;
+            return 200 "captured=$original_endpoint\n";
+        }
+    }
+}
+"#
+}
+
+/// Recommended fix #2: switch to named captures. Named captures are
+/// resolved through a separate code path that doesn't share the rewrite
+/// engine's `is_args` state.
+fn safe_named_capture_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+http {
+    server {
+        listen 80;
+
+        location /healthz {
+            return 200 'OK';
+        }
+
+        location ~ ^/api/(?<rest>.*)$ {
+            rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
+            set $original_endpoint $rest;
+            return 200 "captured=$original_endpoint\n";
+        }
+    }
+}
+"#
+}
+
+// ============================================================================
+// The vulnerable pattern is syntactically valid nginx config
+// ============================================================================
+//
+// Runs on every version. The rule must not be flagging a pattern that
+// nginx rejects at config-load time.
+
+#[tokio::test]
+#[ignore]
+async fn vulnerable_config_loads_and_serves_normal_request() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_config())
+        .await;
+
+    // No escape-prone characters: identical output on vulnerable and
+    // patched builds, so this is a version-independent smoke test.
+    let resp = reqwest::get(nginx.url("/api/users")).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "vulnerable-pattern config must load and route normal requests"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("captured=users"),
+        "expected capture to round-trip through `set $original_endpoint $1`, got: {body}"
+    );
+}
+
+// ============================================================================
+// On a vulnerable build, the bug's signature is observable
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn vulnerable_pattern_corrupts_capture_with_plus() {
+    if skip_on_patched_version() {
+        eprintln!("Skipping: nginx >= 1.31 has the CVE-2026-42945 fix");
+        return;
+    }
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_config())
+        .await;
+
+    // raw capture = "foo+bar" (7 bytes), arg-escaped = "foo%2Bbar" (9 bytes).
+    // The vulnerable worker allocates 7 bytes (length-pass, is_args=0) and
+    // writes 9 bytes (copy-pass, is_args=1) — output is mis-escaped *and*
+    // truncated.
+    let resp = reqwest::get(nginx.url("/api/foo+bar")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+
+    assert!(
+        body.contains("%2B"),
+        "expected leaked is_args to wrongly arg-escape `+` to `%2B` in the \
+         captured value (CVE-2026-42945 signature), got: {body}"
+    );
+    assert!(
+        !body.contains("captured=foo+bar\n"),
+        "capture should NOT round-trip cleanly on a vulnerable build, got: {body}"
+    );
+    // The buffer-overrun signature: the value is shorter than the
+    // expanded escape would require. `foo%2Bbar` is 9 bytes; the
+    // vulnerable build only writes 7. Allow some slack across versions
+    // by asserting the value is shorter than the fully-escaped form.
+    let captured = body
+        .strip_prefix("captured=")
+        .and_then(|s| s.strip_suffix('\n'))
+        .unwrap_or("");
+    assert!(
+        captured.len() < "foo%2Bbar".len(),
+        "expected buffer-overrun truncation: captured value `{captured}` \
+         should be shorter than fully-escaped `foo%2Bbar` (9 bytes); \
+         got length {}",
+        captured.len()
+    );
+}
+
+// ============================================================================
+// Both recommended fixes remove the bug's signature on the same build
+// ============================================================================
+//
+// Critical: these tests use the *vulnerable* nginx image (no version gate).
+// They prove that the rule's suggested remediations actually neutralise the
+// bug — not just that they happen to compile.
+
+#[tokio::test]
+#[ignore]
+async fn safe_no_question_mark_removes_signature() {
+    if skip_on_patched_version() {
+        eprintln!("Skipping: on patched versions the vulnerable form also lacks the signature");
+        return;
+    }
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_no_question_mark_config())
+        .await;
+
+    let resp = reqwest::get(nginx.url("/api/foo+bar")).await.unwrap();
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("captured=foo+bar"),
+        "removing `?` must keep the capture intact, got: {body}"
+    );
+    assert!(
+        !body.contains("%2B"),
+        "removing `?` must suppress the arg-escape leak, got: {body}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn safe_named_capture_removes_signature() {
+    if skip_on_patched_version() {
+        eprintln!("Skipping: on patched versions the vulnerable form also lacks the signature");
+        return;
+    }
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_named_capture_config())
+        .await;
+
+    let resp = reqwest::get(nginx.url("/api/foo+bar")).await.unwrap();
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("captured=foo+bar"),
+        "named-capture variant must keep the capture intact, got: {body}"
+    );
+    assert!(
+        !body.contains("%2B"),
+        "named-capture variant must suppress the arg-escape leak, got: {body}"
+    );
+}
+
+// ============================================================================
+// Both recommended fixes still produce a working server
+// ============================================================================
+//
+// Runs on every version. Smoke-checks that ordinary traffic continues to
+// route correctly through the remediated configs.
+
+#[tokio::test]
+#[ignore]
+async fn safe_no_question_mark_serves_request() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_no_question_mark_config())
+        .await;
+
+    let resp = reqwest::get(nginx.url("/api/users")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("captured=users"),
+        "no-question-mark config must still capture, got: {body}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn safe_named_capture_config_serves_request() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_named_capture_config())
+        .await;
+
+    let resp = reqwest::get(nginx.url("/api/users")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("captured=users"),
+        "named-capture config must still capture, got: {body}"
+    );
+}

--- a/plugins/builtin/security/nginx_rift/tests/container_test.rs
+++ b/plugins/builtin/security/nginx_rift/tests/container_test.rs
@@ -298,6 +298,12 @@ async fn vulnerable_rewrite_then_rewrite_misescapes_capture() {
     //   1st rewrite: URI=/bar/foo+bar, args=x=1, is_args leaked to 1
     //   2nd rewrite: URI=/baz/<$1> where $1="foo+bar". Leaked is_args
     //                applies args-escaping → final=/baz/foo%2Bbar
+    //
+    // Unlike the `set` shape, the captured value here is NOT truncated:
+    // the URI buffer used by the rewrite engine to assemble the new URI
+    // is sized through a different code path than the per-variable
+    // buffer that `set` allocates. The mis-escape alone is sufficient
+    // signature of the leaked `is_args` flag.
     let resp = reqwest::get(nginx.url("/foo/foo+bar")).await.unwrap();
     assert_eq!(resp.status(), 200);
     let body = resp.text().await.unwrap();

--- a/plugins/builtin/security/nginx_rift/tests/container_test.rs
+++ b/plugins/builtin/security/nginx_rift/tests/container_test.rs
@@ -58,13 +58,38 @@
 //!   NGINX_IMAGE=nginx:1.30.0 cargo test -p nginx-rift-plugin \
 //!       --test container_test -- --ignored
 
-use nginx_lint_plugin::container_testing::{NginxContainer, nginx_version_at_least, reqwest};
+use nginx_lint_plugin::container_testing::{
+    NginxContainer, nginx_image_tag, nginx_version_at_least, reqwest,
+};
 
 /// On patched builds the bug's signature is absent by design, so the
 /// observation tests have nothing to assert on. Skip them there. We do
 /// NOT skip on potentially-unpatched tags — that is what we want to test.
+///
+/// Considered "patched":
+/// - nginx >= 1.31 (major.minor check)
+/// - the floating `1.30` tag — Docker Hub now resolves it to the patched
+///   `1.30.1`, even though `nginx_version_at_least` only sees (1, 30)
+/// - any explicit `1.30.x` where x >= 1 (1.30.1 onward shipped the fix)
+///
+/// To run the observation tests against the genuine unpatched build, use
+/// the explicit pinned tag, e.g. `NGINX_IMAGE=nginx:1.30.0`.
 fn skip_on_patched_version() -> bool {
-    nginx_version_at_least(1, 31)
+    if nginx_version_at_least(1, 31) {
+        return true;
+    }
+    let tag = nginx_image_tag();
+    // Bare `1.30` is the floating Docker tag — now patched (1.30.1+).
+    if tag == "1.30" {
+        return true;
+    }
+    // Explicit 1.30.x with x >= 1 is patched.
+    if let Some(rest) = tag.strip_prefix("1.30.")
+        && let Ok(patch) = rest.parse::<u32>()
+    {
+        return patch >= 1;
+    }
+    false
 }
 
 /// Vulnerable pattern: rewrite with `?` in the replacement, followed by a

--- a/plugins/builtin/security/nginx_rift/tests/container_test.rs
+++ b/plugins/builtin/security/nginx_rift/tests/container_test.rs
@@ -117,6 +117,36 @@ http {
 "#
 }
 
+/// Second vulnerable shape: rewrite-then-rewrite. The first rewrite leaks
+/// `is_args = 1`; the second rewrite then references `$1` in its
+/// replacement, where the leaked flag causes args-escaping (`+` → `%2B`)
+/// to be applied to the captured value as it is written into the
+/// rewritten URI. This is a separate observable manifestation of the
+/// same `is_args` leak the rule flags.
+fn vulnerable_rewrite_rewrite_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+http {
+    server {
+        listen 80;
+
+        location /healthz {
+            return 200 'OK';
+        }
+
+        location ~ ^/foo/(.*)$ {
+            rewrite ^/foo/(.*)$ /bar/$1?x=1;
+            rewrite ^/bar/(.*)$ /baz/$1;
+        }
+        location ~ ^/baz/(.*)$ {
+            return 200 "final=$1\n";
+        }
+    }
+}
+"#
+}
+
 /// Recommended fix #1: drop the `?` from the rewrite replacement so the
 /// `is_args` flag is never set in the first place. The captured value is
 /// then routed through `set` without going through the args-escaping path.
@@ -244,6 +274,44 @@ async fn vulnerable_pattern_corrupts_capture_with_plus() {
          should be shorter than fully-escaped `foo%2Bbar` (9 bytes); \
          got length {}",
         captured.len()
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn vulnerable_rewrite_then_rewrite_misescapes_capture() {
+    // The rule flags `rewrite (with ?) ... rewrite (using $N)` in the
+    // same scope as well as the `set` shape. Verify the second-rewrite
+    // form also produces the leaked-is_args symptom on a vulnerable
+    // build, proving that flagging the rewrite-rewrite shape is not a
+    // false positive.
+    if skip_on_patched_version() {
+        eprintln!("Skipping: nginx >= 1.31 has the CVE-2026-42945 fix");
+        return;
+    }
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_rewrite_rewrite_config())
+        .await;
+
+    // /foo/foo+bar →
+    //   1st rewrite: URI=/bar/foo+bar, args=x=1, is_args leaked to 1
+    //   2nd rewrite: URI=/baz/<$1> where $1="foo+bar". Leaked is_args
+    //                applies args-escaping → final=/baz/foo%2Bbar
+    let resp = reqwest::get(nginx.url("/foo/foo+bar")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+
+    assert!(
+        body.contains("%2B"),
+        "expected leaked is_args to wrongly arg-escape `+` to `%2B` in the \
+         second rewrite's replacement (CVE-2026-42945 signature in \
+         rewrite-rewrite shape), got: {body}"
+    );
+    assert!(
+        !body.contains("final=foo+bar"),
+        "captured value should NOT pass through clean to the second \
+         rewrite's replacement on a vulnerable build, got: {body}"
     );
 }
 

--- a/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/error/nginx.conf
+++ b/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/error/nginx.conf
@@ -1,0 +1,9 @@
+http {
+  server {
+    listen 80;
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $original_endpoint $1;
+    }
+  }
+}

--- a/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
+++ b/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
@@ -1,0 +1,9 @@
+http {
+  server {
+    listen 80;
+    location ~ ^/api/(?<rest>.*)$ {
+      rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
+      set $original_endpoint $rest;
+    }
+  }
+}

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -86,6 +86,8 @@ mod embedded {
     /// client-max-body-size-not-set plugin
     pub const CLIENT_MAX_BODY_SIZE_NOT_SET: &[u8] =
         include_bytes!("../../target/builtin-plugins/client_max_body_size_not_set.wasm");
+    /// nginx-rift plugin
+    pub const NGINX_RIFT: &[u8] = include_bytes!("../../target/builtin-plugins/nginx_rift.wasm");
 }
 
 // Re-export from parent module for backward compatibility
@@ -174,6 +176,7 @@ fn compile_builtin_plugins(loader: &PluginLoader) -> Result<Vec<ComponentLintRul
             "client-max-body-size-not-set",
             embedded::CLIENT_MAX_BODY_SIZE_NOT_SET,
         ),
+        ("nginx-rift", embedded::NGINX_RIFT),
     ];
 
     let mut plugins = Vec::new();

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -58,6 +58,7 @@ pub const BUILTIN_PLUGIN_NAMES: &[&str] = &[
     "listen-http2-deprecated",
     "proxy-missing-host-header",
     "client-max-body-size-not-set",
+    "nginx-rift",
 ];
 
 /// Check if a rule name is a builtin plugin

--- a/src/plugin/native_builtin.rs
+++ b/src/plugin/native_builtin.rs
@@ -22,6 +22,7 @@ pub fn load_native_builtin_plugins() -> Vec<Box<dyn LintRule>> {
         Box::new(NativePluginRule::<
             weak_ssl_ciphers_plugin::WeakSslCiphersPlugin,
         >::new()),
+        Box::new(NativePluginRule::<nginx_rift_plugin::NginxRiftPlugin>::new()),
         // Style plugins
         Box::new(NativePluginRule::<
             space_before_semicolon_plugin::SpaceBeforeSemicolonPlugin,


### PR DESCRIPTION
fix #168

Detects the directive sequence that triggers the CVE-2026-42945 heap
buffer overflow in ngx_http_rewrite_module on nginx 0.6.27 .. 1.30.0
(fixed in 1.30.1 / 1.31.0). The rule flags the precise pattern where a
`rewrite` replacement contains `?` (leaking `is_args=1`) and is
followed in the same scope by a `set` or `rewrite` directive that
references an unnamed PCRE capture (`$1`..`$9`, including the
brace-disambiguated `${1}`..`${9}` form) — the configuration that on
vulnerable nginx truncates and mis-escapes the captured value on the
wire, the observable signature of the worker-side buffer overrun
behind the unauthenticated-RCE scenario.

Includes container tests that exercise both flagged shapes
(`rewrite … ?…` → `set`, and `rewrite … ?…` → `rewrite … $N`)
against a real vulnerable nginx (verified on nginx:1.30.0,
nginx:1.29.x, and openresty's internal nginx/1.29.2.3) and assert the
bug signature directly. The bug-observation tests skip on patched
versions (>= 1.31, plus the floating `nginx:1.30` tag which Docker Hub
now resolves to the patched 1.30.1); the smoke tests run on every
version. The CI matrix is extended with `nginx:1.29` to keep at least
one currently-vulnerable mainline build in coverage.

Severity is `warning`, consistent with the rest of the project where
`error` is reserved for configurations that nginx itself refuses to
load (syntax errors, unmatched braces, include-path-exists). The
vulnerable pattern here is syntactically valid; the danger is
runtime-only on affected nginx versions. The rule is enabled by
default and is registered in the `nginx-lint config init` template
so disabling it later — once your fleet is on nginx >= 1.30.1 /
1.31.0 — is a one-line edit.

Note: `if` directives are intentionally NOT flagged. The only form
where `if`'s argument list contains `$N` is `if ($1 …)`, which nginx
itself rejects at config-load time with `unknown "1" variable` — so
flagging it would only produce false positives on configs nginx
refuses to start. This is documented in the `is_capture_consumer`
doc comment.