### PR TITLE
feat: add `--rule-only` flag to run a single rule

### DIFF
--- a/crates/nginx-lint-common/src/ignore.rs
+++ b/crates/nginx-lint-common/src/ignore.rs
@@ -235,8 +235,12 @@ impl IgnoreTracker {
 
     /// Mark rule names as dormant — unused ignore directives targeting these
     /// rules will be excluded from [`unused_warnings`](Self::unused_warnings).
-    pub fn set_dormant_rules(&mut self, dormant: HashSet<String>) {
-        self.dormant_rules = dormant;
+    ///
+    /// Takes a borrowed set so the caller can reuse it across many trackers
+    /// (e.g. when linting an include tree) without paying a clone per call
+    /// site; the tracker stores its own copy internally.
+    pub fn set_dormant_rules(&mut self, dormant: &HashSet<String>) {
+        self.dormant_rules = dormant.clone();
     }
 
     /// Get warnings for unused ignore directives
@@ -862,7 +866,7 @@ server_tokens off;
         // even though no error consumed the directive.
         let mut dormant = HashSet::new();
         dormant.insert("server-tokens-enabled".to_string());
-        tracker.set_dormant_rules(dormant);
+        tracker.set_dormant_rules(&dormant);
 
         let result = filter_errors(Vec::<LintError>::new(), &mut tracker);
 
@@ -890,7 +894,7 @@ server_tokens off;
         // the unused warning.
         let mut dormant = HashSet::new();
         dormant.insert("server-tokens-enabled".to_string());
-        tracker.set_dormant_rules(dormant);
+        tracker.set_dormant_rules(&dormant);
 
         let result = filter_errors(Vec::<LintError>::new(), &mut tracker);
 

--- a/crates/nginx-lint-common/src/ignore.rs
+++ b/crates/nginx-lint-common/src/ignore.rs
@@ -60,6 +60,11 @@ pub struct IgnoreTracker {
     ignored_lines: HashMap<usize, HashSet<String>>,
     /// All ignore directives for tracking usage
     directives: Vec<IgnoreDirective>,
+    /// Rule names that are intentionally not running in this invocation
+    /// (e.g. filtered out by `--rule-only`). Ignore directives targeting
+    /// these rules are excluded from "unused" warnings so the caller can
+    /// disable rules per-invocation without churning the user's config.
+    dormant_rules: HashSet<String>,
 }
 
 impl IgnoreTracker {
@@ -228,11 +233,17 @@ impl IgnoreTracker {
         }
     }
 
+    /// Mark rule names as dormant — unused ignore directives targeting these
+    /// rules will be excluded from [`unused_warnings`](Self::unused_warnings).
+    pub fn set_dormant_rules(&mut self, dormant: HashSet<String>) {
+        self.dormant_rules = dormant;
+    }
+
     /// Get warnings for unused ignore directives
     pub fn unused_warnings(&self) -> Vec<IgnoreWarning> {
         self.directives
             .iter()
-            .filter(|d| !d.used)
+            .filter(|d| !d.used && !self.dormant_rules.contains(&d.rule_name))
             .map(|d| {
                 let fix =
                     Fix::replace_range(d.fix_start_offset, d.fix_end_offset, &d.fix_replacement);
@@ -836,6 +847,58 @@ server_tokens off;
             result.unused_warnings[0]
                 .message
                 .contains("server-tokens-enabled")
+        );
+    }
+
+    #[test]
+    fn test_dormant_rule_suppresses_unused_warning() {
+        let content = r#"
+# nginx-lint:ignore server-tokens-enabled reason
+server_tokens off;
+"#;
+        let (mut tracker, _) = IgnoreTracker::from_content(content);
+
+        // Marking the rule as dormant should suppress the unused warning
+        // even though no error consumed the directive.
+        let mut dormant = HashSet::new();
+        dormant.insert("server-tokens-enabled".to_string());
+        tracker.set_dormant_rules(dormant);
+
+        let result = filter_errors(Vec::<LintError>::new(), &mut tracker);
+
+        assert!(
+            result.unused_warnings.is_empty(),
+            "dormant rule should suppress unused-ignore warning, got: {:?}",
+            result
+                .unused_warnings
+                .iter()
+                .map(|w| &w.message)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_dormant_rule_does_not_affect_other_rules() {
+        let content = r#"
+# nginx-lint:ignore server-tokens-enabled reason
+# nginx-lint:ignore autoindex-enabled reason
+server_tokens off;
+"#;
+        let (mut tracker, _) = IgnoreTracker::from_content(content);
+
+        // Only mark one rule dormant; the other should still produce
+        // the unused warning.
+        let mut dormant = HashSet::new();
+        dormant.insert("server-tokens-enabled".to_string());
+        tracker.set_dormant_rules(dormant);
+
+        let result = filter_errors(Vec::<LintError>::new(), &mut tracker);
+
+        assert_eq!(result.unused_warnings.len(), 1);
+        assert!(
+            result.unused_warnings[0]
+                .message
+                .contains("autoindex-enabled")
         );
     }
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -102,7 +102,20 @@ nginx-lint --rule-only indent --rule-only missing-semicolon /etc/nginx/nginx.con
 ```
 
 If a name doesn't match any registered rule, nginx-lint exits with code 2
-and lists the available rules. Use `nginx-lint why --list` to discover them.
+and lists the loaded rules. Use `nginx-lint why --list` to discover them.
+If the name exists in the builtin catalog but is not currently loaded
+(e.g. disabled in `.nginx-lint.toml`, or not built into this binary), the
+error message distinguishes that case from a true typo.
+
+> **Note:** Pre-parse syntax checks (`unmatched-braces`, `unclosed-quote`,
+> `missing-semicolon`) always run, even under `--rule-only`. Their findings
+> are prerequisites for further parsing, so they are reported regardless of
+> the filter.
+
+`# nginx-lint:ignore <rule>` directives that target rules filtered out by
+`--rule-only` are kept dormant for the invocation: they neither suppress
+anything (the rule isn't running) nor get reported as "unused", so you can
+toggle `--rule-only` without churning the surrounding config.
 
 
 ## Configuration (.nginx-lint.toml)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -82,6 +82,29 @@ Rules are grouped into categories:
 | deprecation | deprecated directives (ssl on, listen http2) |
 
 
+## Running a Single Rule (`--rule-only`)
+
+`--rule-only` runs the linter with only the specified rule(s) enabled,
+ignoring every other rule (including those enabled via `.nginx-lint.toml`).
+Useful when evaluating a newly added plugin or applying `--fix` for one
+rule at a time without touching the rest of the config.
+
+```bash
+# Run only the indent rule
+nginx-lint --rule-only indent /etc/nginx/nginx.conf
+
+# Apply --fix for one rule only
+nginx-lint --fix --rule-only indent /etc/nginx/nginx.conf
+
+# Multiple rules (repeat the flag or comma-separate)
+nginx-lint --rule-only indent,missing-semicolon /etc/nginx/nginx.conf
+nginx-lint --rule-only indent --rule-only missing-semicolon /etc/nginx/nginx.conf
+```
+
+If a name doesn't match any registered rule, nginx-lint exits with code 2
+and lists the available rules. Use `nginx-lint why --list` to discover them.
+
+
 ## Configuration (.nginx-lint.toml)
 
 Generate a default configuration file:

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -23,6 +23,20 @@ enum FileResult {
     },
 }
 
+/// Check whether a rule name corresponds to a known builtin rule, regardless
+/// of whether it is currently registered on the linter. Used by `--rule-only`
+/// validation to distinguish "disabled in config" from "no such rule".
+fn rule_exists_in_catalog(name: &str) -> bool {
+    #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
+    {
+        nginx_lint::docs::get_rule_doc_with_plugins(name).is_some()
+    }
+    #[cfg(not(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins")))]
+    {
+        nginx_lint::docs::all_rule_names().contains(&name)
+    }
+}
+
 /// Display profiling results
 fn display_profile(profiles: &[RuleProfile]) {
     use colored::Colorize;
@@ -465,34 +479,56 @@ pub fn run_lint(cli: Cli) -> ExitCode {
     }
 
     // Apply --rule-only filter: keep only the requested rules, validate that
-    // every requested name corresponds to a registered rule.
+    // every requested name corresponds to a registered rule, and surface the
+    // filtered-out rules to the ignore-comment parser so existing
+    // `# nginx-lint:ignore <other-rule>` directives keep working.
     if !cli.rule_only.is_empty() {
         let registered = linter.rule_names();
-        let unknown: Vec<&String> = cli
-            .rule_only
-            .iter()
-            .filter(|name| !registered.contains(name.as_str()))
-            .collect();
-        if !unknown.is_empty() {
-            eprintln!(
-                "Error: --rule-only references unknown rule(s): {}",
-                unknown
-                    .iter()
-                    .map(|s| s.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            let mut available: Vec<String> = registered.into_iter().collect();
+
+        // Split unknown names into "exists but not loaded" vs "no such rule"
+        // by consulting the full builtin catalog (rules + plugins).
+        let mut not_loaded: Vec<&str> = Vec::new();
+        let mut no_such_rule: Vec<&str> = Vec::new();
+        for name in &cli.rule_only {
+            if registered.contains(name) {
+                continue;
+            }
+            if rule_exists_in_catalog(name) {
+                not_loaded.push(name);
+            } else {
+                no_such_rule.push(name);
+            }
+        }
+
+        if !not_loaded.is_empty() || !no_such_rule.is_empty() {
+            if !no_such_rule.is_empty() {
+                eprintln!(
+                    "Error: --rule-only references unknown rule(s): {}",
+                    no_such_rule.join(", ")
+                );
+            }
+            if !not_loaded.is_empty() {
+                eprintln!(
+                    "Error: --rule-only rule(s) not loaded in this build (disabled in config or unsupported by the current feature set): {}",
+                    not_loaded.join(", ")
+                );
+            }
+            let mut available: Vec<&str> = registered.iter().map(String::as_str).collect();
             available.sort();
-            eprintln!("Available rules:");
+            eprintln!("Loaded rules:");
             for name in &available {
                 eprintln!("  - {}", name);
             }
             return ExitCode::from(2);
         }
 
-        let keep: std::collections::HashSet<String> = cli.rule_only.iter().cloned().collect();
+        let keep: std::collections::HashSet<&str> =
+            cli.rule_only.iter().map(String::as_str).collect();
         linter.remove_rules_by_name(|name| !keep.contains(name));
+        // Preserve the pre-filter rule set as "valid for ignore comments" so
+        // that existing `# nginx-lint:ignore <other-rule>` directives in the
+        // user's config do not get reported as referencing unknown rules.
+        linter.set_extra_valid_rule_names(registered);
 
         if cli.verbose {
             eprintln!("Running only rule(s): {}", cli.rule_only.join(", "));

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -506,6 +506,13 @@ pub fn run_lint(cli: Cli) -> ExitCode {
                     "Error: --rule-only references unknown rule(s): {}",
                     no_such_rule.join(", ")
                 );
+                #[cfg(not(any(
+                    feature = "wasm-builtin-plugins",
+                    feature = "native-builtin-plugins"
+                )))]
+                eprintln!(
+                    "Note: this binary was built without builtin plugins, so plugin rule names cannot be recognised even if they exist in other builds."
+                );
             }
             if !not_loaded.is_empty() {
                 eprintln!(
@@ -525,10 +532,17 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         let keep: std::collections::HashSet<&str> =
             cli.rule_only.iter().map(String::as_str).collect();
         linter.remove_rules_by_name(|name| !keep.contains(name));
-        // Preserve the pre-filter rule set as "valid for ignore comments" so
-        // that existing `# nginx-lint:ignore <other-rule>` directives in the
-        // user's config do not get reported as referencing unknown rules.
-        linter.set_extra_valid_rule_names(registered);
+        // Surface *filtered-out* rules to the ignore-comment parser so
+        // existing `# nginx-lint:ignore <other-rule>` directives stay quiet
+        // (valid names + dormant for unused-warning suppression). The kept
+        // rules are intentionally excluded — their own unused-ignore
+        // directives must still produce warnings.
+        let inactive: std::collections::HashSet<String> = registered
+            .iter()
+            .filter(|name| !keep.contains(name.as_str()))
+            .cloned()
+            .collect();
+        linter.set_inactive_rules(inactive);
 
         if cli.verbose {
             eprintln!("Running only rule(s): {}", cli.rule_only.join(", "));

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -8,7 +8,7 @@ use nginx_lint::{
     pre_parse_checks_from_content, syntax_errors_to_lint_errors,
 };
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -529,18 +529,16 @@ pub fn run_lint(cli: Cli) -> ExitCode {
             return ExitCode::from(2);
         }
 
-        let keep: std::collections::HashSet<&str> =
-            cli.rule_only.iter().map(String::as_str).collect();
+        let keep: HashSet<&str> = cli.rule_only.iter().map(String::as_str).collect();
         linter.remove_rules_by_name(|name| !keep.contains(name));
         // Surface *filtered-out* rules to the ignore-comment parser so
         // existing `# nginx-lint:ignore <other-rule>` directives stay quiet
         // (valid names + dormant for unused-warning suppression). The kept
         // rules are intentionally excluded — their own unused-ignore
         // directives must still produce warnings.
-        let inactive: std::collections::HashSet<String> = registered
-            .iter()
+        let inactive: HashSet<String> = registered
+            .into_iter()
             .filter(|name| !keep.contains(name.as_str()))
-            .cloned()
             .collect();
         linter.set_inactive_rules(inactive);
 

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -464,6 +464,41 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         }
     }
 
+    // Apply --rule-only filter: keep only the requested rules, validate that
+    // every requested name corresponds to a registered rule.
+    if !cli.rule_only.is_empty() {
+        let registered = linter.rule_names();
+        let unknown: Vec<&String> = cli
+            .rule_only
+            .iter()
+            .filter(|name| !registered.contains(name.as_str()))
+            .collect();
+        if !unknown.is_empty() {
+            eprintln!(
+                "Error: --rule-only references unknown rule(s): {}",
+                unknown
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            let mut available: Vec<String> = registered.into_iter().collect();
+            available.sort();
+            eprintln!("Available rules:");
+            for name in &available {
+                eprintln!("  - {}", name);
+            }
+            return ExitCode::from(2);
+        }
+
+        let keep: std::collections::HashSet<String> = cli.rule_only.iter().cloned().collect();
+        linter.remove_rules_by_name(|name| !keep.contains(name));
+
+        if cli.verbose {
+            eprintln!("Running only rule(s): {}", cli.rule_only.join(", "));
+        }
+    }
+
     // 8. Build results: stdin mode vs file mode
     let results: Vec<FileResult> = if let Some(ref content) = stdin_content {
         vec![lint_content(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -66,6 +66,13 @@ pub struct Cli {
     /// Overrides include.prefix in .nginx-lint.toml.
     #[arg(short = 'p', long, value_name = "DIR")]
     pub prefix: Option<PathBuf>,
+
+    /// Run only the specified rule(s). Other rules (including those enabled via
+    /// .nginx-lint.toml) are disabled for this invocation. Useful for evaluating a
+    /// new plugin or applying --fix for a single rule. Can be repeated or
+    /// comma-separated, e.g. `--rule-only indent` or `--rule-only indent,gzip-not-enabled`.
+    #[arg(long, value_name = "RULE", value_delimiter = ',')]
+    pub rule_only: Vec<String>,
 }
 
 #[derive(Subcommand)]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -274,10 +274,7 @@ impl Linter {
     fn make_ignore_tracker(
         &self,
         content: &str,
-    ) -> (
-        IgnoreTracker,
-        Vec<nginx_lint_common::ignore::IgnoreWarning>,
-    ) {
+    ) -> (IgnoreTracker, Vec<nginx_lint_common::ignore::IgnoreWarning>) {
         let valid_rules = self.valid_rule_names_for_ignore();
         let (mut tracker, warnings) =
             IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -8,11 +8,19 @@ use std::path::Path;
 
 pub struct Linter {
     rules: Vec<Box<dyn LintRule>>,
+    /// Rule names that should be treated as valid by ignore-comment parsing
+    /// even though they are not registered as runnable rules. Used by the CLI
+    /// when `--rule-only` filters out rules the user's config still references
+    /// in `# nginx-lint:ignore` comments.
+    extra_valid_rule_names: std::collections::HashSet<String>,
 }
 
 impl Linter {
     pub fn new() -> Self {
-        Self { rules: Vec::new() }
+        Self {
+            rules: Vec::new(),
+            extra_valid_rule_names: std::collections::HashSet::new(),
+        }
     }
 
     pub fn with_default_rules() -> Self {
@@ -234,6 +242,22 @@ impl Linter {
         self.rules.iter().map(|r| r.name().to_string()).collect()
     }
 
+    /// Register additional rule names that ignore comments may reference even
+    /// though no matching rule is registered to run. This prevents spurious
+    /// "unknown rule" warnings when callers (e.g. the CLI's `--rule-only`
+    /// filter) intentionally remove rules from this linter.
+    pub fn set_extra_valid_rule_names(&mut self, names: std::collections::HashSet<String>) {
+        self.extra_valid_rule_names = names;
+    }
+
+    /// Names recognised by the ignore-comment parser: registered rules plus
+    /// any extras supplied via [`set_extra_valid_rule_names`].
+    fn valid_rule_names_for_ignore(&self) -> std::collections::HashSet<String> {
+        let mut names = self.rule_names();
+        names.extend(self.extra_valid_rule_names.iter().cloned());
+        names
+    }
+
     /// Run all lint rules and collect errors
     ///
     /// Uses parallel iteration when the cli feature is enabled (via rayon)
@@ -276,9 +300,12 @@ impl Linter {
     ) -> (Vec<LintError>, usize) {
         use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
 
-        let valid_rules = self.rule_names();
+        let valid_rules = self.valid_rule_names_for_ignore();
         let (mut tracker, warnings) =
             IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
+        if !self.extra_valid_rule_names.is_empty() {
+            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
+        }
         let errors = self.lint(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
@@ -297,9 +324,12 @@ impl Linter {
     ) -> (Vec<LintError>, usize) {
         use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
 
-        let valid_rules = self.rule_names();
+        let valid_rules = self.valid_rule_names_for_ignore();
         let (mut tracker, warnings) =
             IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
+        if !self.extra_valid_rule_names.is_empty() {
+            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
+        }
         let errors = self.lint(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
@@ -356,9 +386,12 @@ impl Linter {
     ) -> (Vec<LintError>, usize, Vec<RuleProfile>) {
         use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
 
-        let valid_rules = self.rule_names();
+        let valid_rules = self.valid_rule_names_for_ignore();
         let (mut tracker, warnings) =
             IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
+        if !self.extra_valid_rule_names.is_empty() {
+            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
+        }
         let (errors, profiles) = self.lint_with_profile(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -1,25 +1,28 @@
 // Re-export core types from nginx-lint-common
 use nginx_lint_common::config::LintConfig;
+use nginx_lint_common::ignore::IgnoreTracker;
 pub use nginx_lint_common::linter::{Fix, LintError, LintRule, Severity};
 use nginx_lint_common::parser::ast::Config;
 #[cfg(feature = "cli")]
 use rayon::prelude::*;
+use std::collections::HashSet;
 use std::path::Path;
 
 pub struct Linter {
     rules: Vec<Box<dyn LintRule>>,
-    /// Rule names that should be treated as valid by ignore-comment parsing
-    /// even though they are not registered as runnable rules. Used by the CLI
-    /// when `--rule-only` filters out rules the user's config still references
-    /// in `# nginx-lint:ignore` comments.
-    extra_valid_rule_names: std::collections::HashSet<String>,
+    /// Rule names that exist in the catalog but are intentionally not running
+    /// in this `Linter` (e.g. filtered out by the CLI's `--rule-only`). They
+    /// are still recognised by ignore-comment parsing — both as valid rule
+    /// names *and* as dormant rules whose unused ignore directives are
+    /// suppressed — so toggling the filter does not churn the user's config.
+    inactive_rules: HashSet<String>,
 }
 
 impl Linter {
     pub fn new() -> Self {
         Self {
             rules: Vec::new(),
-            extra_valid_rule_names: std::collections::HashSet::new(),
+            inactive_rules: HashSet::new(),
         }
     }
 
@@ -238,24 +241,50 @@ impl Linter {
     }
 
     /// Get a set of all rule names registered in this linter
-    pub fn rule_names(&self) -> std::collections::HashSet<String> {
+    pub fn rule_names(&self) -> HashSet<String> {
         self.rules.iter().map(|r| r.name().to_string()).collect()
     }
 
-    /// Register additional rule names that ignore comments may reference even
-    /// though no matching rule is registered to run. This prevents spurious
-    /// "unknown rule" warnings when callers (e.g. the CLI's `--rule-only`
-    /// filter) intentionally remove rules from this linter.
-    pub fn set_extra_valid_rule_names(&mut self, names: std::collections::HashSet<String>) {
-        self.extra_valid_rule_names = names;
+    /// Register rule names that are intentionally not running in this linter
+    /// but should still be honoured by ignore-comment parsing — they will be
+    /// treated as valid rule names *and* as dormant rules (so their unused
+    /// ignore directives are suppressed). Used by the CLI's `--rule-only`
+    /// filter to keep existing `# nginx-lint:ignore` directives quiet for
+    /// rules the user has temporarily filtered out.
+    ///
+    /// Pass only the rules that are *not* currently running; including a
+    /// rule that *is* running would incorrectly suppress its own unused
+    /// ignore warnings.
+    pub fn set_inactive_rules(&mut self, names: HashSet<String>) {
+        self.inactive_rules = names;
     }
 
     /// Names recognised by the ignore-comment parser: registered rules plus
-    /// any extras supplied via [`set_extra_valid_rule_names`].
-    fn valid_rule_names_for_ignore(&self) -> std::collections::HashSet<String> {
+    /// any inactive rules supplied via [`set_inactive_rules`].
+    fn valid_rule_names_for_ignore(&self) -> HashSet<String> {
         let mut names = self.rule_names();
-        names.extend(self.extra_valid_rule_names.iter().cloned());
+        names.extend(self.inactive_rules.iter().cloned());
         names
+    }
+
+    /// Build an `IgnoreTracker` for the given content, wiring up both the
+    /// valid-rule-name set (for unknown-rule warnings) and the dormant-rule
+    /// set (for unused-ignore suppression). Centralised so the three
+    /// `lint_with_content*` entry points stay in sync.
+    fn make_ignore_tracker(
+        &self,
+        content: &str,
+    ) -> (
+        IgnoreTracker,
+        Vec<nginx_lint_common::ignore::IgnoreWarning>,
+    ) {
+        let valid_rules = self.valid_rule_names_for_ignore();
+        let (mut tracker, warnings) =
+            IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
+        if !self.inactive_rules.is_empty() {
+            tracker.set_dormant_rules(&self.inactive_rules);
+        }
+        (tracker, warnings)
     }
 
     /// Run all lint rules and collect errors
@@ -298,14 +327,9 @@ impl Linter {
         path: &Path,
         content: &str,
     ) -> (Vec<LintError>, usize) {
-        use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
+        use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
-        let valid_rules = self.valid_rule_names_for_ignore();
-        let (mut tracker, warnings) =
-            IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
-        if !self.extra_valid_rule_names.is_empty() {
-            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
-        }
+        let (mut tracker, warnings) = self.make_ignore_tracker(content);
         let errors = self.lint(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
@@ -322,14 +346,9 @@ impl Linter {
         path: &Path,
         content: &str,
     ) -> (Vec<LintError>, usize) {
-        use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
+        use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
-        let valid_rules = self.valid_rule_names_for_ignore();
-        let (mut tracker, warnings) =
-            IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
-        if !self.extra_valid_rule_names.is_empty() {
-            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
-        }
+        let (mut tracker, warnings) = self.make_ignore_tracker(content);
         let errors = self.lint(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
@@ -384,14 +403,9 @@ impl Linter {
         path: &Path,
         content: &str,
     ) -> (Vec<LintError>, usize, Vec<RuleProfile>) {
-        use nginx_lint_common::ignore::{IgnoreTracker, filter_errors, warnings_to_errors};
+        use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
-        let valid_rules = self.valid_rule_names_for_ignore();
-        let (mut tracker, warnings) =
-            IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
-        if !self.extra_valid_rule_names.is_empty() {
-            tracker.set_dormant_rules(self.extra_valid_rule_names.clone());
-        }
+        let (mut tracker, warnings) = self.make_ignore_tracker(content);
         let (errors, profiles) = self.lint_with_profile(config, path);
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2386,3 +2386,132 @@ fn test_lint_detects_both_syntax_and_lint_errors() {
         "Expected syntax-error in combined results"
     );
 }
+
+// ============================================================================
+// --rule-only behavior (Linter::remove_rules_by_name +
+// set_extra_valid_rule_names): mirrors what `nginx-lint --rule-only` does
+// from the CLI but exercised at the library level so it works regardless of
+// the builtin-plugin feature configuration.
+// ============================================================================
+
+#[test]
+fn test_rule_only_filters_other_rules() {
+    let content = "http {\nserver_tokens on;\nlocation / {\n}\n}\n";
+    let (config, _) = parse_string_with_errors(content);
+    let path = PathBuf::from("test.conf");
+
+    // Baseline: default linter reports multiple rules' findings for this snippet.
+    let baseline = get_default_linter();
+    let (baseline_errors, _) = baseline.lint_with_content(&config, &path, content);
+    let baseline_rules: std::collections::HashSet<_> =
+        baseline_errors.iter().map(|e| e.rule.clone()).collect();
+
+    // Skip the test if `indent` is not loaded in this build configuration.
+    if !baseline_rules.contains("indent") {
+        return;
+    }
+
+    // Construct a linter restricted to the `indent` rule, simulating
+    // `nginx-lint --rule-only indent`.
+    let mut linter = Linter::with_default_rules();
+    let pre_filter_names = linter.rule_names();
+    linter.remove_rules_by_name(|name| name != "indent");
+    linter.set_extra_valid_rule_names(pre_filter_names);
+
+    let (errors, _) = linter.lint_with_content(&config, &path, content);
+
+    assert!(
+        !errors.is_empty(),
+        "indent rule should still find issues in this snippet"
+    );
+    for err in &errors {
+        assert_eq!(
+            err.rule, "indent",
+            "After --rule-only filter, only indent errors should remain, found: {}",
+            err.rule
+        );
+    }
+}
+
+#[test]
+fn test_rule_only_keeps_ignore_for_dormant_rule_quiet() {
+    // Ignore directive targets a rule that is filtered out. With the
+    // dormant-rules mechanism, this should neither suppress anything nor
+    // emit an "unused nginx-lint:ignore" warning.
+    let content = concat!(
+        "# nginx-lint:ignore server-tokens-enabled rule-only test reason\n",
+        "http {\n",
+        "server_tokens on;\n",
+        "}\n",
+    );
+    let (config, _) = parse_string_with_errors(content);
+    let path = PathBuf::from("test.conf");
+
+    let mut linter = Linter::with_default_rules();
+    let pre_filter_names = linter.rule_names();
+
+    // Skip if indent is not loaded.
+    if !pre_filter_names.contains("indent") {
+        return;
+    }
+    // Skip if server-tokens-enabled is not loaded in this build (then there
+    // would be no dormant-rule semantics to test here).
+    if !pre_filter_names.contains("server-tokens-enabled") {
+        return;
+    }
+
+    linter.remove_rules_by_name(|name| name != "indent");
+    linter.set_extra_valid_rule_names(pre_filter_names);
+
+    let (errors, _) = linter.lint_with_content(&config, &path, content);
+
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        "--rule-only should not emit unused-ignore warnings for filtered rules; got: {:?}",
+        errors.iter().map(|e| (&e.rule, &e.message)).collect::<Vec<_>>()
+    );
+    assert!(
+        !errors.iter().any(|e| e.rule == "server-tokens-enabled"),
+        "filtered-out rule must not run"
+    );
+}
+
+#[test]
+fn test_rule_only_without_extra_valid_warns_about_unknown_ignore_target() {
+    // Sanity check: without set_extra_valid_rule_names, filtering rules out
+    // would (correctly, by the tracker's own contract) cause ignore comments
+    // for those rules to be reported as referencing unknown rules. This test
+    // documents the baseline that motivates the dormant-rules wiring.
+    let content = concat!(
+        "# nginx-lint:ignore server-tokens-enabled rule-only test reason\n",
+        "http {\n",
+        "server_tokens on;\n",
+        "}\n",
+    );
+    let (config, _) = parse_string_with_errors(content);
+    let path = PathBuf::from("test.conf");
+
+    let mut linter = Linter::with_default_rules();
+    let pre_filter_names = linter.rule_names();
+    if !pre_filter_names.contains("indent")
+        || !pre_filter_names.contains("server-tokens-enabled")
+    {
+        return;
+    }
+    linter.remove_rules_by_name(|name| name != "indent");
+    // Intentionally do NOT call set_extra_valid_rule_names.
+
+    let (errors, _) = linter.lint_with_content(&config, &path, content);
+
+    // The ignore tracker now treats server-tokens-enabled as an unknown rule
+    // because it is no longer registered. This is the spurious-warning case
+    // the CLI wiring exists to avoid.
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        "Without extra_valid_rule_names, filtered ignore targets should warn"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2415,8 +2415,13 @@ fn test_rule_only_filters_other_rules() {
     // `nginx-lint --rule-only indent`.
     let mut linter = Linter::with_default_rules();
     let pre_filter_names = linter.rule_names();
+    let inactive: std::collections::HashSet<String> = pre_filter_names
+        .iter()
+        .filter(|n| n.as_str() != "indent")
+        .cloned()
+        .collect();
     linter.remove_rules_by_name(|name| name != "indent");
-    linter.set_extra_valid_rule_names(pre_filter_names);
+    linter.set_inactive_rules(inactive);
 
     let (errors, _) = linter.lint_with_content(&config, &path, content);
 
@@ -2460,8 +2465,13 @@ fn test_rule_only_keeps_ignore_for_dormant_rule_quiet() {
         return;
     }
 
+    let inactive: std::collections::HashSet<String> = pre_filter_names
+        .iter()
+        .filter(|n| n.as_str() != "indent")
+        .cloned()
+        .collect();
     linter.remove_rules_by_name(|name| name != "indent");
-    linter.set_extra_valid_rule_names(pre_filter_names);
+    linter.set_inactive_rules(inactive);
 
     let (errors, _) = linter.lint_with_content(&config, &path, content);
 
@@ -2479,11 +2489,11 @@ fn test_rule_only_keeps_ignore_for_dormant_rule_quiet() {
 }
 
 #[test]
-fn test_rule_only_without_extra_valid_warns_about_unknown_ignore_target() {
-    // Sanity check: without set_extra_valid_rule_names, filtering rules out
-    // would (correctly, by the tracker's own contract) cause ignore comments
-    // for those rules to be reported as referencing unknown rules. This test
-    // documents the baseline that motivates the dormant-rules wiring.
+fn test_rule_only_without_inactive_rules_warns_about_unknown_ignore_target() {
+    // Sanity check: without set_inactive_rules, filtering rules out would
+    // (correctly, by the tracker's own contract) cause ignore comments for
+    // those rules to be reported as referencing unknown rules. This test
+    // documents the baseline that motivates the inactive-rules wiring.
     let content = concat!(
         "# nginx-lint:ignore server-tokens-enabled rule-only test reason\n",
         "http {\n",
@@ -2501,7 +2511,7 @@ fn test_rule_only_without_extra_valid_warns_about_unknown_ignore_target() {
         return;
     }
     linter.remove_rules_by_name(|name| name != "indent");
-    // Intentionally do NOT call set_extra_valid_rule_names.
+    // Intentionally do NOT call set_inactive_rules.
 
     let (errors, _) = linter.lint_with_content(&config, &path, content);
 
@@ -2512,6 +2522,48 @@ fn test_rule_only_without_extra_valid_warns_about_unknown_ignore_target() {
         errors
             .iter()
             .any(|e| e.rule == "invalid-nginx-lint-ignore"),
-        "Without extra_valid_rule_names, filtered ignore targets should warn"
+        "Without set_inactive_rules, filtered ignore targets should warn"
+    );
+}
+
+#[test]
+fn test_rule_only_kept_rule_still_emits_unused_ignore_warning() {
+    // Regression test: inactive_rules must contain only the FILTERED-OUT
+    // rules, not the kept rule. If the kept rule were in the dormant set,
+    // its own unused ignore directives would be silently suppressed.
+    //
+    // Here the ignore directive targets `indent` on a line that has no
+    // indent issue (a blank line), so the directive is genuinely unused
+    // and the warning must still fire even under --rule-only indent.
+    let content = "# nginx-lint:ignore indent rule-only kept-rule reason\n\nhttp {\n}\n";
+    let (config, _) = parse_string_with_errors(content);
+    let path = PathBuf::from("test.conf");
+
+    let mut linter = Linter::with_default_rules();
+    let pre_filter_names = linter.rule_names();
+    if !pre_filter_names.contains("indent") {
+        return;
+    }
+
+    let inactive: std::collections::HashSet<String> = pre_filter_names
+        .iter()
+        .filter(|n| n.as_str() != "indent")
+        .cloned()
+        .collect();
+    linter.remove_rules_by_name(|name| name != "indent");
+    linter.set_inactive_rules(inactive);
+
+    let (errors, _) = linter.lint_with_content(&config, &path, content);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.rule == "invalid-nginx-lint-ignore"
+                && e.message.contains("indent")),
+        "unused ignore for kept rule should still warn; got: {:?}",
+        errors
+            .iter()
+            .map(|e| (&e.rule, &e.message))
+            .collect::<Vec<_>>()
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2476,11 +2476,12 @@ fn test_rule_only_keeps_ignore_for_dormant_rule_quiet() {
     let (errors, _) = linter.lint_with_content(&config, &path, content);
 
     assert!(
-        !errors
-            .iter()
-            .any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        !errors.iter().any(|e| e.rule == "invalid-nginx-lint-ignore"),
         "--rule-only should not emit unused-ignore warnings for filtered rules; got: {:?}",
-        errors.iter().map(|e| (&e.rule, &e.message)).collect::<Vec<_>>()
+        errors
+            .iter()
+            .map(|e| (&e.rule, &e.message))
+            .collect::<Vec<_>>()
     );
     assert!(
         !errors.iter().any(|e| e.rule == "server-tokens-enabled"),
@@ -2505,9 +2506,7 @@ fn test_rule_only_without_inactive_rules_warns_about_unknown_ignore_target() {
 
     let mut linter = Linter::with_default_rules();
     let pre_filter_names = linter.rule_names();
-    if !pre_filter_names.contains("indent")
-        || !pre_filter_names.contains("server-tokens-enabled")
-    {
+    if !pre_filter_names.contains("indent") || !pre_filter_names.contains("server-tokens-enabled") {
         return;
     }
     linter.remove_rules_by_name(|name| name != "indent");
@@ -2519,9 +2518,7 @@ fn test_rule_only_without_inactive_rules_warns_about_unknown_ignore_target() {
     // because it is no longer registered. This is the spurious-warning case
     // the CLI wiring exists to avoid.
     assert!(
-        errors
-            .iter()
-            .any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        errors.iter().any(|e| e.rule == "invalid-nginx-lint-ignore"),
         "Without set_inactive_rules, filtered ignore targets should warn"
     );
 }
@@ -2558,8 +2555,7 @@ fn test_rule_only_kept_rule_still_emits_unused_ignore_warning() {
     assert!(
         errors
             .iter()
-            .any(|e| e.rule == "invalid-nginx-lint-ignore"
-                && e.message.contains("indent")),
+            .any(|e| e.rule == "invalid-nginx-lint-ignore" && e.message.contains("indent")),
         "unused ignore for kept rule should still warn; got: {:?}",
         errors
             .iter()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2388,10 +2388,10 @@ fn test_lint_detects_both_syntax_and_lint_errors() {
 }
 
 // ============================================================================
-// --rule-only behavior (Linter::remove_rules_by_name +
-// set_extra_valid_rule_names): mirrors what `nginx-lint --rule-only` does
-// from the CLI but exercised at the library level so it works regardless of
-// the builtin-plugin feature configuration.
+// --rule-only behavior (Linter::remove_rules_by_name + set_inactive_rules):
+// mirrors what `nginx-lint --rule-only` does from the CLI but exercised at
+// the library level so it works regardless of the builtin-plugin feature
+// configuration.
 // ============================================================================
 
 #[test]
@@ -2403,11 +2403,9 @@ fn test_rule_only_filters_other_rules() {
     // Baseline: default linter reports multiple rules' findings for this snippet.
     let baseline = get_default_linter();
     let (baseline_errors, _) = baseline.lint_with_content(&config, &path, content);
-    let baseline_rules: std::collections::HashSet<_> =
-        baseline_errors.iter().map(|e| e.rule.clone()).collect();
 
     // Skip the test if `indent` is not loaded in this build configuration.
-    if !baseline_rules.contains("indent") {
+    if !baseline_errors.iter().any(|e| e.rule == "indent") {
         return;
     }
 


### PR DESCRIPTION
Adds a CLI flag that filters the linter to only the requested rule(s), ignoring all others including those enabled via .nginx-lint.toml. The flag is repeatable and accepts comma-separated values, and unknown rule names exit with code 2 alongside the list of registered rules.

Useful for evaluating a newly added plugin in isolation or applying `--fix` for a single rule without disturbing other parts of the config.