### PR TITLE
chore(nginx-rift): warn severity, config template, references cleanup

### DIFF
--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -226,6 +226,14 @@ weak_ciphers = [
 # Required exclusion patterns
 required_exclusions = ["!aNULL", "!eNULL", "!EXPORT", "!DES", "!RC4", "!MD5"]
 
+[rules.nginx-rift]
+# CVE-2026-42945: detects the rewrite-with-`?` + capture-consumer pattern
+# that triggers a heap buffer overflow on nginx 0.6.27 .. 1.30.0
+# (fixed in 1.30.1 / 1.31.0). Disable this rule once your entire fleet
+# is on nginx >= 1.30.1 / 1.31.0 and the vulnerable pattern no longer
+# poses an RCE risk in your environment.
+enabled = true
+
 # =============================================================================
 # Best Practices
 # =============================================================================
@@ -761,6 +769,7 @@ impl LintConfig {
                     "server-tokens-enabled",
                     "autoindex-enabled",
                     "weak-ssl-ciphers",
+                    "nginx-rift",
                     "indent",
                     "trailing-whitespace",
                     "space-before-semicolon",

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -30,7 +30,7 @@ impl Plugin for NginxRiftPlugin {
              the replacement followed by a `set` or `rewrite` using unnamed \
              captures ($1..$9) in the same scope",
         )
-        .with_severity("error")
+        .with_severity("warning")
         .with_why(
             "CVE-2026-42945 (\"NGINX Rift\") is a heap buffer overflow in \
              ngx_http_rewrite_module that affects nginx 0.6.27 through 1.30.0 \
@@ -51,10 +51,11 @@ impl Plugin for NginxRiftPlugin {
              which are resolved through a separate code path that does not \
              share the rewrite engine's `is_args` state. Note that simply \
              reordering `set` to run before `rewrite` does NOT remove the \
-             underlying bug. This rule is shipped as a default `error` \
-             until the affected versions are no longer in widespread use; \
-             it can be disabled in configuration once your fleet is fully \
-             upgraded.",
+             underlying bug. Severity is `warning` (the configuration is \
+             syntactically valid and nginx will load it; the danger is \
+             runtime-only on vulnerable builds). This rule is enabled by \
+             default; disable it in configuration once your entire fleet \
+             is on nginx >= 1.30.1 / 1.31.0.",
         )
         .with_bad_example(include_str!("../examples/bad.conf").trim())
         .with_good_example(include_str!("../examples/good.conf").trim())
@@ -87,7 +88,7 @@ fn check_items(items: &[ConfigItem], errors: &mut Vec<LintError>, err: &ErrorBui
         if is_rewrite_with_question_mark(dir) {
             for next in directives.iter().skip(i + 1) {
                 if is_capture_consumer(next) && uses_unnamed_capture(next) {
-                    errors.push(err.error_at(
+                    errors.push(err.warning_at(
                         "CVE-2026-42945: `rewrite` replacement contains `?` and is \
                          followed by a directive that references an unnamed capture \
                          ($1..$9) in the same scope — this triggers a heap buffer \

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -51,11 +51,11 @@ impl Plugin for NginxRiftPlugin {
              which are resolved through a separate code path that does not \
              share the rewrite engine's `is_args` state. Note that simply \
              reordering `set` to run before `rewrite` does NOT remove the \
-             underlying bug. Severity is `warning` (the configuration is \
-             syntactically valid and nginx will load it; the danger is \
-             runtime-only on vulnerable builds). This rule is enabled by \
-             default; disable it in configuration once your entire fleet \
-             is on nginx >= 1.30.1 / 1.31.0.",
+             underlying bug. The configuration is syntactically valid and \
+             nginx will load it; the danger is runtime-only on vulnerable \
+             builds. This rule is enabled by default; disable it in \
+             configuration once your entire fleet is on nginx >= 1.30.1 / \
+             1.31.0.",
         )
         .with_bad_example(include_str!("../examples/bad.conf").trim())
         .with_good_example(include_str!("../examples/good.conf").trim())

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -61,7 +61,6 @@ impl Plugin for NginxRiftPlugin {
         .with_good_example(include_str!("../examples/good.conf").trim())
         .with_references(vec![
             "https://nvd.nist.gov/vuln/detail/CVE-2026-42945".to_string(),
-            "https://nginx.org/en/security_advisories.html".to_string(),
             "https://depthfirst.com/research/nginx-rift-achieving-nginx-rce-via-an-18-year-old-vulnerability".to_string(),
             "https://github.com/walf443/nginx-lint/blob/main/plugins/builtin/security/nginx_rift/tests/container_test.rs".to_string(),
         ])


### PR DESCRIPTION
Follow-up to #169.

* **chore**: register `nginx-rift` in the `nginx-lint config init` template
  and in the validator's known-rule whitelist, so users can include
  `[rules.nginx-rift]` in their config without hitting `UnknownRule`. The
  template entry documents the retirement criterion (disable once your
  fleet is on nginx >= 1.30.1 / 1.31.0) inline so the disable is a
  one-line edit on the generated config.
* **refactor**: downgrade severity from `error` to `warning`. In this
  project `error` is reserved for configurations that nginx itself
  refuses to load (`invalid-directive-context`, `unmatched-braces`,
  `unclosed-quote`, `missing-semicolon`, `include-path-exists`). The
  nginx-rift pattern is syntactically valid and nginx loads it; the
  danger is runtime-only on affected versions. `warning` matches the
  severity already used by every other security rule
  (`deprecated-ssl-protocol`, `server-tokens-enabled`,
  `weak-ssl-ciphers`, `autoindex-enabled`).
* **docs**: drop the generic
  `https://nginx.org/en/security_advisories.html` link from the rule's
  references (it is the upstream advisory index, not CVE-2026-42945-
  specific); drop the redundant "Severity is `warning`" prefix from the
  `why` text (the UI already shows the severity header).