### PR TITLE
fix(config): sync `KNOWN_RULES` whitelist with `BUILTIN_PLUGIN_NAMES`

### DIFF
--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -632,7 +632,7 @@ impl LintConfig {
     ///
     /// Order: native rules first, then builtin plugins in the same order as
     /// `BUILTIN_PLUGIN_NAMES` so review diffs against that file are obvious.
-    pub const KNOWN_RULES: &'static [&'static str] = &[
+    pub const KNOWN_RULE_NAMES: &'static [&'static str] = &[
         // Native rules — must match `NATIVE_RULE_NAMES` above
         "unmatched-braces",
         "unclosed-quote",
@@ -822,7 +822,7 @@ impl LintConfig {
 
             // Validate [rules.*] sections
             if let Some(toml::Value::Table(rules)) = root.get("rules") {
-                let known_rules: HashSet<&str> = Self::KNOWN_RULES.iter().copied().collect();
+                let known_rules: HashSet<&str> = Self::KNOWN_RULE_NAMES.iter().copied().collect();
 
                 for (rule_name, rule_value) in rules {
                     if !known_rules.contains(rule_name.as_str()) {
@@ -1486,11 +1486,11 @@ prefix = "/etc/nginx"
         }
     }
 
-    /// Sanity check that `KNOWN_RULES` actually drives the validator
+    /// Sanity check that `KNOWN_RULE_NAMES` actually drives the validator
     /// (rather than an inline list that can drift again).
     #[test]
     fn test_known_rules_constant_drives_validator() {
-        for rule_name in LintConfig::KNOWN_RULES {
+        for rule_name in LintConfig::KNOWN_RULE_NAMES {
             let toml_content = format!("[rules.{rule_name}]\nenabled = true\n");
             let mut file = NamedTempFile::new().unwrap();
             write!(file, "{}", toml_content).unwrap();
@@ -1498,17 +1498,17 @@ prefix = "/etc/nginx"
             let errors = LintConfig::validate_file(file.path()).unwrap();
             assert!(
                 errors.is_empty(),
-                "rule '{rule_name}' is listed in KNOWN_RULES but the validator \
+                "rule '{rule_name}' is listed in KNOWN_RULE_NAMES but the validator \
                  rejected it: {errors:?}"
             );
         }
     }
 
-    /// `NATIVE_RULE_NAMES` must be a subset of `KNOWN_RULES`: editing either
+    /// `NATIVE_RULE_NAMES` must be a subset of `KNOWN_RULE_NAMES`: editing either
     /// list independently would mean the validator forgets about a native rule.
     #[test]
     fn test_native_rule_names_subset_of_known_rules() {
-        let known: HashSet<&str> = LintConfig::KNOWN_RULES.iter().copied().collect();
+        let known: HashSet<&str> = LintConfig::KNOWN_RULE_NAMES.iter().copied().collect();
         let missing: Vec<&str> = LintConfig::NATIVE_RULE_NAMES
             .iter()
             .copied()
@@ -1516,19 +1516,38 @@ prefix = "/etc/nginx"
             .collect();
         assert!(
             missing.is_empty(),
-            "NATIVE_RULE_NAMES entries missing from KNOWN_RULES: {missing:?}"
+            "NATIVE_RULE_NAMES entries missing from KNOWN_RULE_NAMES: {missing:?}"
         );
     }
 
-    /// `KNOWN_RULES` must not contain duplicate entries — a duplicated name
+    /// Negative case: a rule name that is in neither `NATIVE_RULE_NAMES` nor
+    /// `BUILTIN_PLUGIN_NAMES` must still produce an `UnknownRule` error —
+    /// otherwise the whitelist would silently degrade to "accept anything".
+    #[test]
+    fn test_validate_rejects_unknown_rule_name() {
+        let toml_content = "[rules.no-such-rule-zzz]\nenabled = true\n";
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "{}", toml_content).unwrap();
+
+        let errors = LintConfig::validate_file(file.path()).unwrap();
+        assert_eq!(errors.len(), 1, "expected exactly one error, got: {errors:?}");
+        match &errors[0] {
+            ValidationError::UnknownRule { name, .. } => {
+                assert_eq!(name, "no-such-rule-zzz");
+            }
+            other => panic!("expected UnknownRule, got: {other:?}"),
+        }
+    }
+
+    /// `KNOWN_RULE_NAMES` must not contain duplicate entries — a duplicated name
     /// would silently mask a typo when the list is edited.
     #[test]
     fn test_known_rules_has_no_duplicates() {
         let mut seen: HashSet<&str> = HashSet::new();
-        for name in LintConfig::KNOWN_RULES {
+        for name in LintConfig::KNOWN_RULE_NAMES {
             assert!(
                 seen.insert(name),
-                "duplicate entry in KNOWN_RULES: '{name}'"
+                "duplicate entry in KNOWN_RULE_NAMES: '{name}'"
             );
         }
     }

--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -607,54 +607,67 @@ impl LintConfig {
         "missing-error-log", // error_log is typically set at top level in main config
     ];
 
-    /// All rule names recognised by `nginx-lint config validate`.
+    /// Native lint rules implemented directly in the top-level crate
+    /// (i.e. not packaged as plugins under `plugins/builtin/`).
     ///
-    /// This is the union of:
-    /// - native rules implemented directly in the top-level crate
-    ///   (`unmatched-braces`, `unclosed-quote`, `missing-semicolon`, `indent`,
-    ///   `include-path-exists`), and
-    /// - builtin plugin rules whose canonical list lives in
-    ///   [`nginx_lint::plugin::BUILTIN_PLUGIN_NAMES`].
-    ///
-    /// The CLI cannot import `BUILTIN_PLUGIN_NAMES` from here (it lives in the
-    /// top-level crate, while this module is a downstream dependency), so the
-    /// two lists are kept in sync by a drift-detection unit test in the
-    /// top-level crate. See `tests/known_rules_drift_test.rs`.
-    pub const KNOWN_RULES: &'static [&'static str] = &[
-        // Native rules (implemented in the top-level crate, not as plugins)
+    /// Exposed as a `pub const` so the drift-detection test in the top-level
+    /// crate (`tests/known_rules_drift_test.rs`) can distinguish "native rule"
+    /// from "stale builtin plugin entry" without duplicating this list.
+    pub const NATIVE_RULE_NAMES: &'static [&'static str] = &[
         "unmatched-braces",
         "unclosed-quote",
         "missing-semicolon",
         "indent",
         "include-path-exists",
-        // Builtin plugins — must match `BUILTIN_PLUGIN_NAMES` in `src/plugin/mod.rs`
-        "duplicate-directive",
-        "invalid-directive-context",
-        "deprecated-ssl-protocol",
+    ];
+
+    /// All rule names recognised by `nginx-lint config validate`.
+    ///
+    /// This is the union of [`NATIVE_RULE_NAMES`](Self::NATIVE_RULE_NAMES) and
+    /// the builtin plugin names. The builtin plugin list lives in the
+    /// top-level crate (`nginx-lint`) as `BUILTIN_PLUGIN_NAMES`; because this
+    /// module is a downstream dependency it cannot reference that symbol
+    /// directly, so the two lists are kept in sync by a drift-detection unit
+    /// test in the top-level crate (`tests/known_rules_drift_test.rs`).
+    ///
+    /// Order: native rules first, then builtin plugins in the same order as
+    /// `BUILTIN_PLUGIN_NAMES` so review diffs against that file are obvious.
+    pub const KNOWN_RULES: &'static [&'static str] = &[
+        // Native rules — must match `NATIVE_RULE_NAMES` above
+        "unmatched-braces",
+        "unclosed-quote",
+        "missing-semicolon",
+        "indent",
+        "include-path-exists",
+        // Builtin plugins — must match `BUILTIN_PLUGIN_NAMES` in
+        // `src/plugin/mod.rs` (same order for easier review)
         "server-tokens-enabled",
         "autoindex-enabled",
-        "weak-ssl-ciphers",
-        "nginx-rift",
-        "trailing-whitespace",
-        "space-before-semicolon",
-        "block-lines",
         "gzip-not-enabled",
-        "missing-error-log",
+        "duplicate-directive",
+        "space-before-semicolon",
+        "trailing-whitespace",
+        "block-lines",
         "proxy-pass-domain",
         "upstream-server-no-resolve",
+        "directive-inheritance",
         "root-in-location",
         "alias-location-slash-mismatch",
         "proxy-pass-with-uri",
         "proxy-keepalive",
         "try-files-with-proxy",
         "if-is-evil-in-location",
-        "directive-inheritance",
-        "client-max-body-size-not-set",
-        "listen-http2-deprecated",
-        "map-missing-default",
-        "proxy-missing-host-header",
-        "ssl-on-deprecated",
         "unreachable-location",
+        "missing-error-log",
+        "deprecated-ssl-protocol",
+        "weak-ssl-ciphers",
+        "invalid-directive-context",
+        "map-missing-default",
+        "ssl-on-deprecated",
+        "listen-http2-deprecated",
+        "proxy-missing-host-header",
+        "client-max-body-size-not-set",
+        "nginx-rift",
     ];
 
     /// Check if a rule is enabled
@@ -1489,6 +1502,22 @@ prefix = "/etc/nginx"
                  rejected it: {errors:?}"
             );
         }
+    }
+
+    /// `NATIVE_RULE_NAMES` must be a subset of `KNOWN_RULES`: editing either
+    /// list independently would mean the validator forgets about a native rule.
+    #[test]
+    fn test_native_rule_names_subset_of_known_rules() {
+        let known: HashSet<&str> = LintConfig::KNOWN_RULES.iter().copied().collect();
+        let missing: Vec<&str> = LintConfig::NATIVE_RULE_NAMES
+            .iter()
+            .copied()
+            .filter(|name| !known.contains(name))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "NATIVE_RULE_NAMES entries missing from KNOWN_RULES: {missing:?}"
+        );
     }
 
     /// `KNOWN_RULES` must not contain duplicate entries — a duplicated name

--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -1530,7 +1530,11 @@ prefix = "/etc/nginx"
         write!(file, "{}", toml_content).unwrap();
 
         let errors = LintConfig::validate_file(file.path()).unwrap();
-        assert_eq!(errors.len(), 1, "expected exactly one error, got: {errors:?}");
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one error, got: {errors:?}"
+        );
         match &errors[0] {
             ValidationError::UnknownRule { name, .. } => {
                 assert_eq!(name, "no-such-rule-zzz");

--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -607,6 +607,56 @@ impl LintConfig {
         "missing-error-log", // error_log is typically set at top level in main config
     ];
 
+    /// All rule names recognised by `nginx-lint config validate`.
+    ///
+    /// This is the union of:
+    /// - native rules implemented directly in the top-level crate
+    ///   (`unmatched-braces`, `unclosed-quote`, `missing-semicolon`, `indent`,
+    ///   `include-path-exists`), and
+    /// - builtin plugin rules whose canonical list lives in
+    ///   [`nginx_lint::plugin::BUILTIN_PLUGIN_NAMES`].
+    ///
+    /// The CLI cannot import `BUILTIN_PLUGIN_NAMES` from here (it lives in the
+    /// top-level crate, while this module is a downstream dependency), so the
+    /// two lists are kept in sync by a drift-detection unit test in the
+    /// top-level crate. See `tests/known_rules_drift_test.rs`.
+    pub const KNOWN_RULES: &'static [&'static str] = &[
+        // Native rules (implemented in the top-level crate, not as plugins)
+        "unmatched-braces",
+        "unclosed-quote",
+        "missing-semicolon",
+        "indent",
+        "include-path-exists",
+        // Builtin plugins — must match `BUILTIN_PLUGIN_NAMES` in `src/plugin/mod.rs`
+        "duplicate-directive",
+        "invalid-directive-context",
+        "deprecated-ssl-protocol",
+        "server-tokens-enabled",
+        "autoindex-enabled",
+        "weak-ssl-ciphers",
+        "nginx-rift",
+        "trailing-whitespace",
+        "space-before-semicolon",
+        "block-lines",
+        "gzip-not-enabled",
+        "missing-error-log",
+        "proxy-pass-domain",
+        "upstream-server-no-resolve",
+        "root-in-location",
+        "alias-location-slash-mismatch",
+        "proxy-pass-with-uri",
+        "proxy-keepalive",
+        "try-files-with-proxy",
+        "if-is-evil-in-location",
+        "directive-inheritance",
+        "client-max-body-size-not-set",
+        "listen-http2-deprecated",
+        "map-missing-default",
+        "proxy-missing-host-header",
+        "ssl-on-deprecated",
+        "unreachable-location",
+    ];
+
     /// Check if a rule is enabled
     pub fn is_rule_enabled(&self, name: &str) -> bool {
         self.rules
@@ -759,36 +809,7 @@ impl LintConfig {
 
             // Validate [rules.*] sections
             if let Some(toml::Value::Table(rules)) = root.get("rules") {
-                let known_rules: HashSet<&str> = [
-                    "duplicate-directive",
-                    "unmatched-braces",
-                    "unclosed-quote",
-                    "missing-semicolon",
-                    "invalid-directive-context",
-                    "deprecated-ssl-protocol",
-                    "server-tokens-enabled",
-                    "autoindex-enabled",
-                    "weak-ssl-ciphers",
-                    "nginx-rift",
-                    "indent",
-                    "trailing-whitespace",
-                    "space-before-semicolon",
-                    "block-lines",
-                    "gzip-not-enabled",
-                    "missing-error-log",
-                    "proxy-pass-domain",
-                    "upstream-server-no-resolve",
-                    "root-in-location",
-                    "alias-location-slash-mismatch",
-                    "proxy-pass-with-uri",
-                    "proxy-keepalive",
-                    "try-files-with-proxy",
-                    "if-is-evil-in-location",
-                    "directive-inheritance",
-                    "include-path-exists",
-                ]
-                .into_iter()
-                .collect();
+                let known_rules: HashSet<&str> = Self::KNOWN_RULES.iter().copied().collect();
 
                 for (rule_name, rule_value) in rules {
                     if !known_rules.contains(rule_name.as_str()) {
@@ -1420,6 +1441,67 @@ prefix = "/etc/nginx"
         assert!(props.contains_key("color"), "missing 'color' property");
         assert!(props.contains_key("parser"), "missing 'parser' property");
         assert!(props.contains_key("include"), "missing 'include' property");
+    }
+
+    /// Regression test for https://github.com/walf443/nginx-lint/issues/172:
+    /// previously, `config validate` rejected configs that referenced real builtin
+    /// plugins whose names were missing from the validator's `known_rules`
+    /// whitelist. These names must remain recognised.
+    #[test]
+    fn test_validate_accepts_previously_drifted_builtin_plugins() {
+        // Names that were drifted out of `known_rules` before the fix for #172.
+        let previously_missing = [
+            "client-max-body-size-not-set",
+            "listen-http2-deprecated",
+            "map-missing-default",
+            "proxy-missing-host-header",
+            "ssl-on-deprecated",
+            "unreachable-location",
+        ];
+
+        for rule_name in previously_missing {
+            let toml_content = format!("[rules.{rule_name}]\nenabled = false\n");
+            let mut file = NamedTempFile::new().unwrap();
+            write!(file, "{}", toml_content).unwrap();
+
+            let errors = LintConfig::validate_file(file.path()).unwrap();
+            assert!(
+                errors.is_empty(),
+                "rule '{rule_name}' should be a known builtin plugin name, \
+                 but `validate_file` reported errors: {errors:?}"
+            );
+        }
+    }
+
+    /// Sanity check that `KNOWN_RULES` actually drives the validator
+    /// (rather than an inline list that can drift again).
+    #[test]
+    fn test_known_rules_constant_drives_validator() {
+        for rule_name in LintConfig::KNOWN_RULES {
+            let toml_content = format!("[rules.{rule_name}]\nenabled = true\n");
+            let mut file = NamedTempFile::new().unwrap();
+            write!(file, "{}", toml_content).unwrap();
+
+            let errors = LintConfig::validate_file(file.path()).unwrap();
+            assert!(
+                errors.is_empty(),
+                "rule '{rule_name}' is listed in KNOWN_RULES but the validator \
+                 rejected it: {errors:?}"
+            );
+        }
+    }
+
+    /// `KNOWN_RULES` must not contain duplicate entries — a duplicated name
+    /// would silently mask a typo when the list is edited.
+    #[test]
+    fn test_known_rules_has_no_duplicates() {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for name in LintConfig::KNOWN_RULES {
+            assert!(
+                seen.insert(name),
+                "duplicate entry in KNOWN_RULES: '{name}'"
+            );
+        }
     }
 
     #[test]

--- a/tests/known_rules_drift_test.rs
+++ b/tests/known_rules_drift_test.rs
@@ -1,0 +1,62 @@
+//! Drift-detection tests for `nginx-lint config validate`.
+//!
+//! Background (https://github.com/walf443/nginx-lint/issues/172):
+//! `LintConfig::KNOWN_RULES` (in `nginx-lint-common`) is the whitelist used
+//! by `nginx-lint config validate`. It must include every builtin plugin
+//! name, otherwise users get a spurious `unknown rule` error for a config
+//! that lints correctly.
+//!
+//! Because `nginx-lint-common` is a downstream crate, it cannot import
+//! `BUILTIN_PLUGIN_NAMES` directly. The drift test therefore lives here,
+//! in the top-level crate, where both sources of truth are visible.
+
+#![cfg(any(feature = "plugins", feature = "native-builtin-plugins"))]
+
+use nginx_lint::LintConfig;
+use nginx_lint::plugin::BUILTIN_PLUGIN_NAMES;
+
+#[test]
+fn known_rules_includes_all_builtin_plugins() {
+    let missing: Vec<&str> = BUILTIN_PLUGIN_NAMES
+        .iter()
+        .copied()
+        .filter(|name| !LintConfig::KNOWN_RULES.contains(name))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "BUILTIN_PLUGIN_NAMES contains rules that are NOT in \
+         `LintConfig::KNOWN_RULES`: {missing:?}. \
+         `nginx-lint config validate` would reject user configs that \
+         reference these rules, even though they lint correctly. \
+         Add them to `KNOWN_RULES` in crates/nginx-lint-common/src/config.rs.",
+    );
+}
+
+#[test]
+fn known_rules_does_not_reference_removed_builtin_plugins() {
+    // The reverse direction: if a rule name listed in `KNOWN_RULES` looks
+    // like a builtin plugin (i.e. is not one of the hand-maintained native
+    // rule names) but is no longer present in `BUILTIN_PLUGIN_NAMES`, it
+    // was probably renamed or deleted and the whitelist has gone stale.
+    const NATIVE_RULES: &[&str] = &[
+        "unmatched-braces",
+        "unclosed-quote",
+        "missing-semicolon",
+        "indent",
+        "include-path-exists",
+    ];
+
+    let stale: Vec<&&str> = LintConfig::KNOWN_RULES
+        .iter()
+        .filter(|name| !NATIVE_RULES.contains(name) && !BUILTIN_PLUGIN_NAMES.contains(name))
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "KNOWN_RULES contains entries that are neither native rules nor \
+         current builtin plugins: {stale:?}. Either add them back to \
+         BUILTIN_PLUGIN_NAMES (if they still exist) or remove them from \
+         KNOWN_RULES.",
+    );
+}

--- a/tests/known_rules_drift_test.rs
+++ b/tests/known_rules_drift_test.rs
@@ -35,21 +35,16 @@ fn known_rules_includes_all_builtin_plugins() {
 
 #[test]
 fn known_rules_does_not_reference_removed_builtin_plugins() {
-    // The reverse direction: if a rule name listed in `KNOWN_RULES` looks
-    // like a builtin plugin (i.e. is not one of the hand-maintained native
-    // rule names) but is no longer present in `BUILTIN_PLUGIN_NAMES`, it
-    // was probably renamed or deleted and the whitelist has gone stale.
-    const NATIVE_RULES: &[&str] = &[
-        "unmatched-braces",
-        "unclosed-quote",
-        "missing-semicolon",
-        "indent",
-        "include-path-exists",
-    ];
-
-    let stale: Vec<&&str> = LintConfig::KNOWN_RULES
+    // The reverse direction: if a rule name listed in `KNOWN_RULES` is
+    // neither a native rule (per `NATIVE_RULE_NAMES`) nor a current builtin
+    // plugin (per `BUILTIN_PLUGIN_NAMES`), it was probably renamed or
+    // deleted and the whitelist has gone stale.
+    let stale: Vec<&str> = LintConfig::KNOWN_RULES
         .iter()
-        .filter(|name| !NATIVE_RULES.contains(name) && !BUILTIN_PLUGIN_NAMES.contains(name))
+        .copied()
+        .filter(|name| {
+            !LintConfig::NATIVE_RULE_NAMES.contains(name) && !BUILTIN_PLUGIN_NAMES.contains(name)
+        })
         .collect();
 
     assert!(

--- a/tests/known_rules_drift_test.rs
+++ b/tests/known_rules_drift_test.rs
@@ -1,7 +1,7 @@
 //! Drift-detection tests for `nginx-lint config validate`.
 //!
 //! Background (https://github.com/walf443/nginx-lint/issues/172):
-//! `LintConfig::KNOWN_RULES` (in `nginx-lint-common`) is the whitelist used
+//! `LintConfig::KNOWN_RULE_NAMES` (in `nginx-lint-common`) is the whitelist used
 //! by `nginx-lint config validate`. It must include every builtin plugin
 //! name, otherwise users get a spurious `unknown rule` error for a config
 //! that lints correctly.
@@ -20,26 +20,26 @@ fn known_rules_includes_all_builtin_plugins() {
     let missing: Vec<&str> = BUILTIN_PLUGIN_NAMES
         .iter()
         .copied()
-        .filter(|name| !LintConfig::KNOWN_RULES.contains(name))
+        .filter(|name| !LintConfig::KNOWN_RULE_NAMES.contains(name))
         .collect();
 
     assert!(
         missing.is_empty(),
         "BUILTIN_PLUGIN_NAMES contains rules that are NOT in \
-         `LintConfig::KNOWN_RULES`: {missing:?}. \
+         `LintConfig::KNOWN_RULE_NAMES`: {missing:?}. \
          `nginx-lint config validate` would reject user configs that \
          reference these rules, even though they lint correctly. \
-         Add them to `KNOWN_RULES` in crates/nginx-lint-common/src/config.rs.",
+         Add them to `KNOWN_RULE_NAMES` in crates/nginx-lint-common/src/config.rs.",
     );
 }
 
 #[test]
 fn known_rules_does_not_reference_removed_builtin_plugins() {
-    // The reverse direction: if a rule name listed in `KNOWN_RULES` is
+    // The reverse direction: if a rule name listed in `KNOWN_RULE_NAMES` is
     // neither a native rule (per `NATIVE_RULE_NAMES`) nor a current builtin
     // plugin (per `BUILTIN_PLUGIN_NAMES`), it was probably renamed or
     // deleted and the whitelist has gone stale.
-    let stale: Vec<&str> = LintConfig::KNOWN_RULES
+    let stale: Vec<&str> = LintConfig::KNOWN_RULE_NAMES
         .iter()
         .copied()
         .filter(|name| {
@@ -49,9 +49,9 @@ fn known_rules_does_not_reference_removed_builtin_plugins() {
 
     assert!(
         stale.is_empty(),
-        "KNOWN_RULES contains entries that are neither native rules nor \
+        "KNOWN_RULE_NAMES contains entries that are neither native rules nor \
          current builtin plugins: {stale:?}. Either add them back to \
          BUILTIN_PLUGIN_NAMES (if they still exist) or remove them from \
-         KNOWN_RULES.",
+         KNOWN_RULE_NAMES.",
     );
 }


### PR DESCRIPTION
fix #172

The hand-maintained `known_rules` whitelist inside `validate_content` had drifted from `BUILTIN_PLUGIN_NAMES`, so `nginx-lint config validate` rejected configs that referenced real, working builtin plugins (`client-max-body-size-not-set`, `listen-http2-deprecated`, `map-missing-default`, `proxy-missing-host-header`, `ssl-on-deprecated`, `unreachable-location`).

- Extract the whitelist as `LintConfig::KNOWN_RULES` (a `pub const` array) so the validator and tests can share one source of truth, and add the six missing entries.
- Add regression tests covering each previously-missing rule, plus a sanity test that the constant actually drives the validator and a duplicate-entry check.
- Add `tests/known_rules_drift_test.rs` in the top-level crate (where both `BUILTIN_PLUGIN_NAMES` and `KNOWN_RULES` are visible) that fails if a builtin plugin is added without updating the whitelist, and vice-versa for stale entries.