### PR TITLE
feat(nginx-rift): add autofix that renames unnamed captures to cap1, capN

### DIFF
--- a/plugins/builtin/security/nginx_rift/examples/good.conf
+++ b/plugins/builtin/security/nginx_rift/examples/good.conf
@@ -1,9 +1,9 @@
 http {
   server {
     listen 80;
-    location ~ ^/api/(?<rest>.*)$ {
-      rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
-      set $original_endpoint $rest;
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $original_endpoint $cap1;
     }
   }
 }

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1149,6 +1149,88 @@ http {
     }
 
     #[test]
+    fn test_autofix_bails_when_v_rewrite_regex_has_python_style_named_capture() {
+        // Same bail-out as the `(?<name>...)` form, but via the
+        // `(?P<name>...)` Python-style syntax. The helper unit test
+        // (`test_regex_has_named_capture_helper`) confirms the detector
+        // recognizes both forms; this is the end-to-end check that the
+        // detector actually wires through to the fix builder and
+        // suppresses fix emission.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let bad = r#"http {
+  server {
+    location / {
+      rewrite ^/u/(?P<user>\w+)/(.*)$ /api?user=$user;
+      set $endpoint $1;
+    }
+  }
+}
+"#;
+        let errors = runner.check_string(bad).expect("check");
+        let spec_name = NginxRiftPlugin.spec().name;
+        let rule_errors: Vec<_> = errors.iter().filter(|e| e.rule == spec_name).collect();
+        assert_eq!(rule_errors.len(), 1, "warning should still fire");
+        assert!(
+            rule_errors[0].fixes.is_empty(),
+            "(?P<name>...) in v_rewrite must also bail out, got fixes: {:?}",
+            rule_errors[0].fixes
+        );
+    }
+
+    #[test]
+    fn test_autofix_no_fixes_attached_to_unfixable_consumer_rewrite() {
+        // The complement to `test_autofix_skips_consumer_rewrite_with_named_capture`:
+        // that test verifies the *resulting content* via string compare,
+        // which means a bug that emits a wrong-but-harmless fix could
+        // slip through. Here we look at the fix list directly and
+        // confirm we only emit fixes for the v_rewrite + the early
+        // `set` — nothing targets the unfixable consumer's regex,
+        // its replacement, or the downstream `set`.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let bad = r#"http {
+  server {
+    location / {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $a $1;
+      rewrite ^/u/(?<user>\w+)/(.*)$ /next/$1 last;
+      set $b $1;
+    }
+  }
+}
+"#;
+        let errors = runner.check_string(bad).expect("check");
+        let spec_name = NginxRiftPlugin.spec().name;
+        let rule_errors: Vec<_> = errors.iter().filter(|e| e.rule == spec_name).collect();
+        assert_eq!(rule_errors.len(), 1, "single warning expected");
+
+        // Expect exactly 2 fixes: v_rewrite's regex + the first `set`'s
+        // value. The consumer rewrite (regex + replacement) and the
+        // trailing `set` must contribute 0 fixes.
+        let fix_texts: Vec<&str> = rule_errors[0]
+            .fixes
+            .iter()
+            .map(|f| f.new_text.as_str())
+            .collect();
+        assert_eq!(
+            rule_errors[0].fixes.len(),
+            2,
+            "expected exactly 2 fixes (v_rewrite regex + first set value), got: {:?}",
+            fix_texts
+        );
+        // Sanity: every emitted fix is a `cap1`-renaming. None should
+        // contain `cap` for the unfixable consumer (which has a `user`
+        // named group, not a `cap` group).
+        assert!(
+            rule_errors[0]
+                .fixes
+                .iter()
+                .all(|f| f.new_text.contains("cap1")),
+            "every fix should be a cap1-renaming, got: {:?}",
+            fix_texts
+        );
+    }
+
+    #[test]
     fn test_autofix_skips_consumer_rewrite_with_named_capture() {
         // The vulnerable rewrite itself is autofixable, but a later
         // consumer rewrite uses a named capture, so we (a) skip

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1149,6 +1149,87 @@ http {
     }
 
     #[test]
+    fn test_autofix_handles_nested_unnamed_captures() {
+        // Nested unnamed captures get numbered outer-first in source
+        // order, which happens to match PCRE's positional numbering
+        // (outer = group 1, inner = group 2). No special handling is
+        // needed — `$1` -> `$cap1` and `$2` -> `$cap2` stay
+        // semantically equivalent.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      rewrite ^/x/((.*))$ /target?z=1;
+      set $outer $1;
+      set $inner $2;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      rewrite ^/x/(?<cap1>(?<cap2>.*))$ /target?z=1;
+      set $outer $cap1;
+      set $inner $cap2;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_bails_on_nested_capture_when_any_layer_is_named() {
+        // Once *any* layer of nesting is a named capture, the bail-out
+        // fires — the same uniform conservatism we apply to flat
+        // mixed regexes. Tested for both directions of nesting
+        // (named-wraps-unnamed and unnamed-wraps-named) to make the
+        // boundary explicit for readers.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let rule_name = NginxRiftPlugin.spec().name;
+
+        for bad in [
+            // Named outer, unnamed inner.
+            r#"http {
+  server {
+    location / {
+      rewrite ^/x/(?<outer>(.*))$ /target?z=$outer;
+      set $endpoint $1;
+    }
+  }
+}
+"#,
+            // Unnamed outer, named inner.
+            r#"http {
+  server {
+    location / {
+      rewrite ^/x/((?<inner>.*))$ /target?z=$inner;
+      set $endpoint $1;
+    }
+  }
+}
+"#,
+        ] {
+            let errors = runner.check_string(bad).expect("check");
+            let rule_errors: Vec<_> = errors.iter().filter(|e| e.rule == rule_name).collect();
+            assert_eq!(
+                rule_errors.len(),
+                1,
+                "warning must still fire on nested mixed-capture; config was:\n{}",
+                bad
+            );
+            assert!(
+                rule_errors[0].fixes.is_empty(),
+                "nested regex with any named layer must bail; got fixes {:?} for:\n{}",
+                rule_errors[0].fixes,
+                bad
+            );
+        }
+    }
+
+    #[test]
     fn test_autofix_bails_on_mixed_named_and_unnamed_in_same_regex() {
         // The cornerstone case for the bail-out: a single regex that
         // contains BOTH a named capture AND an unnamed one. Users

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1084,6 +1084,39 @@ http {
     }
 
     #[test]
+    fn test_autofix_with_named_capture_outside_vulnerable_scope() {
+        // Mixed named/unnamed captures only trip our bail-out when they
+        // sit in the rewrite directives we're rewriting. Named captures
+        // in the location header (which we never touch) or named
+        // variable references in `set` values (`$user`, not `$N`)
+        // should be left untouched while the vulnerable chain itself
+        // still gets autofixed.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/u/(?<user>\w+)/api/(.*)$ {
+      rewrite ^/u/.+/api/(.*)$ /backend?migrated=true;
+      set $endpoint $1;
+      set $username $user;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/u/(?<user>\w+)/api/(.*)$ {
+      rewrite ^/u/.+/api/(?<cap1>.*)$ /backend?migrated=true;
+      set $endpoint $cap1;
+      set $username $user;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_autofix_bails_when_v_rewrite_regex_has_named_capture() {
         // `(?<user>...)` in the vulnerable rewrite's regex makes
         // cap-numbering ambiguous: `$1` refers to `user` in PCRE, but

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1149,6 +1149,36 @@ http {
     }
 
     #[test]
+    fn test_autofix_handles_escaped_parens_in_regex() {
+        // `\(` / `\)` are literal parens, not group boundaries. Both
+        // regex walkers skip backslash-escape pairs explicitly, so an
+        // escape inside the regex must not (a) get counted as an
+        // unnamed capture nor (b) shift the cap-numbering of the
+        // genuine `(.*)` that follows.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      rewrite ^/api\(deprecated\)/(.*)$ /new?migrated=true;
+      set $endpoint $1;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      rewrite ^/api\(deprecated\)/(?<cap1>.*)$ /new?migrated=true;
+      set $endpoint $cap1;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_autofix_handles_nested_unnamed_captures() {
         // Nested unnamed captures get numbered outer-first in source
         // order, which happens to match PCRE's positional numbering

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -128,6 +128,12 @@ fn build_named_capture_fixes(v_rewrite: &Directive, rest: &[&Directive]) -> Vec<
     let Some(v_regex_arg) = v_rewrite.args.first() else {
         return fixes;
     };
+    if regex_has_named_capture(&v_regex_arg.raw) {
+        // Mixed named/unnamed captures: our cap-numbering can't safely
+        // map `$N` references — bail on the entire chain. Warning still
+        // fires; user fixes manually.
+        return fixes;
+    }
     let (new_regex_raw, v_cap_count) = build_renamed_regex(&v_regex_arg.raw);
     if v_cap_count == 0 {
         return fixes;
@@ -157,6 +163,16 @@ fn build_named_capture_fixes(v_rewrite: &Directive, rest: &[&Directive]) -> Vec<
             let Some(c_regex_arg) = consumer.args.first() else {
                 continue;
             };
+            if regex_has_named_capture(&c_regex_arg.raw) {
+                // Can't safely rename this rewrite's regex or its
+                // replacement's `$N`. Also force `active_caps = 0` so
+                // subsequent `set` consumers don't rename their `$N`
+                // either — those `$N` refer to this unfixable
+                // rewrite's captures, and renaming them would produce
+                // undefined `$capN` references at nginx-load time.
+                active_caps = 0;
+                continue;
+            }
             let (new_c_regex_raw, c_cap_count) = build_renamed_regex(&c_regex_arg.raw);
             if c_cap_count > 0 {
                 push_arg_fix(&mut fixes, c_regex_arg, new_c_regex_raw);
@@ -193,16 +209,11 @@ fn push_arg_fix(fixes: &mut Vec<Fix>, arg: &Argument, new_raw: String) {
 /// already-named groups `(?<name>...)`/`(?P<name>...)`, escaped `\(`, and `(`
 /// inside character classes `[...]` are all left untouched.
 ///
-/// KNOWN LIMITATION: when a regex mixes named and unnamed captures
-/// (e.g. `(?P<foo>x)(.)`), the cap-number assigned here is the index
-/// among *unnamed* groups, not the PCRE positional group number. So
-/// `(?P<foo>x)(.)` becomes `(?P<foo>x)(?<cap1>.)`, but in PCRE the `.`
-/// is positional group 2 — `$2` still refers to it post-fix. The
-/// partial-fix bail-out (see `rename_positional_refs_in_raw`) prevents
-/// us from silently emitting `$cap2` references in that case, but the
-/// rule will keep firing on the residual `$2` until manually cleaned
-/// up. Configs that mix named and unnamed captures are rare; revisit
-/// if real-world reports surface.
+/// Callers should bail out (via [`regex_has_named_capture`]) before calling
+/// this on a regex that already contains a named capture: the cap-numbering
+/// here is the index among *unnamed* groups, which doesn't match PCRE's
+/// positional numbering once named groups are mixed in. Renaming `$1` based
+/// on this index would silently change which group is referenced.
 fn build_renamed_regex(raw: &str) -> (String, usize) {
     let positions = find_unnamed_capture_positions(raw);
     if positions.is_empty() {
@@ -222,6 +233,62 @@ fn build_renamed_regex(raw: &str) -> (String, usize) {
     }
     out.push_str(std::str::from_utf8(&bytes[cursor..]).expect("ASCII boundary"));
     (out, positions.len())
+}
+
+/// Detect whether a regex source string contains any named capture group
+/// (`(?<name>...)` or `(?P<name>...)`). Lookbehinds `(?<=...)` / `(?<!...)`
+/// are NOT named captures and don't count.
+///
+/// Used to bail out of autofix on regexes that mix named and unnamed
+/// captures: our cap-numbering (index among unnamed) diverges from PCRE's
+/// positional numbering once a named group is present, so a `$1` could end
+/// up renamed to point at a different capture.
+fn regex_has_named_capture(raw: &str) -> bool {
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    let mut in_char_class = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+
+        if in_char_class {
+            if b == b']' {
+                in_char_class = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'[' {
+            in_char_class = true;
+            i += 1;
+            continue;
+        }
+
+        if b == b'(' && i + 3 < bytes.len() && bytes[i + 1] == b'?' {
+            // `(?<name>...)` — named iff the char after `<` is a name-start
+            // byte. `(?<=...)` and `(?<!...)` are lookbehinds; not captures.
+            if bytes[i + 2] == b'<' {
+                let after_lt = bytes[i + 3];
+                if after_lt != b'=' && after_lt != b'!' {
+                    return true;
+                }
+            }
+            // `(?P<name>...)` — Python-style named capture.
+            if bytes[i + 2] == b'P' && i + 4 < bytes.len() && bytes[i + 3] == b'<' {
+                return true;
+            }
+        }
+
+        i += 1;
+    }
+
+    false
 }
 
 /// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
@@ -993,6 +1060,92 @@ http {
 }
 "#,
         );
+    }
+
+    #[test]
+    fn test_autofix_bails_when_v_rewrite_regex_has_named_capture() {
+        // `(?<user>...)` in the vulnerable rewrite's regex makes
+        // cap-numbering ambiguous: `$1` refers to `user` in PCRE, but
+        // our cap-numbering would rename `$1` to `$cap1` and assign
+        // `cap1` to the *next* unnamed group — a different capture.
+        // To avoid silent semantic remap, we bail on the whole chain:
+        // warning fires, no fix attached.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let bad = r#"http {
+  server {
+    location / {
+      rewrite ^/u/(?<user>\w+)/(.*)$ /api?user=$user;
+      set $endpoint $1;
+    }
+  }
+}
+"#;
+        let errors = runner.check_string(bad).expect("check");
+        let spec_name = NginxRiftPlugin.spec().name;
+        let rule_errors: Vec<_> = errors.iter().filter(|e| e.rule == spec_name).collect();
+        assert_eq!(
+            rule_errors.len(),
+            1,
+            "warning should still fire on the vulnerable pattern"
+        );
+        assert!(
+            rule_errors[0].fixes.is_empty(),
+            "no fix should be attached when v_rewrite regex mixes named/unnamed"
+        );
+    }
+
+    #[test]
+    fn test_autofix_skips_consumer_rewrite_with_named_capture() {
+        // The vulnerable rewrite itself is autofixable, but a later
+        // consumer rewrite uses a named capture, so we (a) skip
+        // renaming that consumer's regex/replacement, and (b) force
+        // `active_caps = 0` so a downstream `set $foo $1` is NOT
+        // renamed (its `$1` references the unfixable rewrite's
+        // captures, which we have no name for).
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let bad = r#"http {
+  server {
+    location / {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $a $1;
+      rewrite ^/u/(?<user>\w+)/(.*)$ /next/$1 last;
+      set $b $1;
+    }
+  }
+}
+"#;
+        let good = r#"http {
+  server {
+    location / {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $a $cap1;
+      rewrite ^/u/(?<user>\w+)/(.*)$ /next/$1 last;
+      set $b $1;
+    }
+  }
+}
+"#;
+        runner.assert_fix_produces(bad, good);
+    }
+
+    #[test]
+    fn test_regex_has_named_capture_helper() {
+        // Plain named captures.
+        assert!(regex_has_named_capture("(?<name>.*)"));
+        assert!(regex_has_named_capture("^/api/(?<rest>.*)$"));
+        assert!(regex_has_named_capture("(?P<name>.*)"));
+        assert!(regex_has_named_capture("(?<a>x)(.)"));
+        // Lookbehinds (NOT named captures).
+        assert!(!regex_has_named_capture("(?<=foo)bar"));
+        assert!(!regex_has_named_capture("(?<!foo)bar"));
+        // Unnamed-only.
+        assert!(!regex_has_named_capture("(.*)(.*)"));
+        assert!(!regex_has_named_capture("^/api/(.*)$"));
+        // Non-capturing groups and escapes.
+        assert!(!regex_has_named_capture("(?:foo)(bar)"));
+        assert!(!regex_has_named_capture(r"\(?<not_a_capture>\)"));
+        // Inside character class — bracket eats the `(?<`.
+        assert!(!regex_has_named_capture("[(?<x>]"));
     }
 
     #[test]

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -128,9 +128,7 @@ fn build_named_capture_fixes(v_rewrite: &Directive, rest: &[&Directive]) -> Vec<
     let Some(v_regex_arg) = v_rewrite.args.first() else {
         return fixes;
     };
-    let Some((new_regex_raw, v_cap_count)) = build_renamed_regex(&v_regex_arg.raw) else {
-        return fixes;
-    };
+    let (new_regex_raw, v_cap_count) = build_renamed_regex(&v_regex_arg.raw);
     if v_cap_count == 0 {
         return fixes;
     }
@@ -159,9 +157,7 @@ fn build_named_capture_fixes(v_rewrite: &Directive, rest: &[&Directive]) -> Vec<
             let Some(c_regex_arg) = consumer.args.first() else {
                 continue;
             };
-            let Some((new_c_regex_raw, c_cap_count)) = build_renamed_regex(&c_regex_arg.raw) else {
-                continue;
-            };
+            let (new_c_regex_raw, c_cap_count) = build_renamed_regex(&c_regex_arg.raw);
             if c_cap_count > 0 {
                 push_arg_fix(&mut fixes, c_regex_arg, new_c_regex_raw);
             }
@@ -192,29 +188,40 @@ fn push_arg_fix(fixes: &mut Vec<Fix>, arg: &Argument, new_raw: String) {
 /// becomes a named group `(?<capN>...)`, numbered from 1 in source order.
 ///
 /// Returns the rewritten source plus the number of captures introduced.
-/// Returns `None` if the source is structurally unparseable (currently never;
-/// reserved for future regex-validation extensions).
 ///
 /// Non-capturing groups `(?:...)`, lookarounds `(?=...)`/`(?!...)`/`(?<=...)`,
 /// already-named groups `(?<name>...)`/`(?P<name>...)`, escaped `\(`, and `(`
 /// inside character classes `[...]` are all left untouched.
-fn build_renamed_regex(raw: &str) -> Option<(String, usize)> {
+///
+/// KNOWN LIMITATION: when a regex mixes named and unnamed captures
+/// (e.g. `(?P<foo>x)(.)`), the cap-number assigned here is the index
+/// among *unnamed* groups, not the PCRE positional group number. So
+/// `(?P<foo>x)(.)` becomes `(?P<foo>x)(?<cap1>.)`, but in PCRE the `.`
+/// is positional group 2 — `$2` still refers to it post-fix. The
+/// partial-fix bail-out (see `rename_positional_refs_in_raw`) prevents
+/// us from silently emitting `$cap2` references in that case, but the
+/// rule will keep firing on the residual `$2` until manually cleaned
+/// up. Configs that mix named and unnamed captures are rare; revisit
+/// if real-world reports surface.
+fn build_renamed_regex(raw: &str) -> (String, usize) {
     let positions = find_unnamed_capture_positions(raw);
     if positions.is_empty() {
-        return Some((raw.to_string(), 0));
+        return (raw.to_string(), 0);
     }
 
     let bytes = raw.as_bytes();
     let mut out = String::with_capacity(raw.len() + positions.len() * 8);
     let mut cursor = 0;
     for (idx, &pos) in positions.iter().enumerate() {
-        // Copy bytes up to and including the `(`
-        out.push_str(std::str::from_utf8(&bytes[cursor..=pos]).ok()?);
+        // Copy bytes up to and including the `(`. Slicing on an ASCII
+        // `(` boundary is always valid UTF-8 since `raw: &str` is, so
+        // the from_utf8 conversion is infallible here.
+        out.push_str(std::str::from_utf8(&bytes[cursor..=pos]).expect("ASCII boundary"));
         out.push_str(&format!("?<cap{}>", idx + 1));
         cursor = pos + 1;
     }
-    out.push_str(std::str::from_utf8(&bytes[cursor..]).ok()?);
-    Some((out, positions.len()))
+    out.push_str(std::str::from_utf8(&bytes[cursor..]).expect("ASCII boundary"));
+    (out, positions.len())
 }
 
 /// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
@@ -888,6 +895,103 @@ http {
         assert_eq!(
             find_unnamed_capture_positions("(a)(b)(?:c)(d)"),
             vec![0, 3, 11]
+        );
+    }
+
+    #[test]
+    fn test_autofix_multiple_vulnerable_rewrites_in_one_scope() {
+        // Three vulnerable rewrites in a chain: each is detected
+        // independently (so multiple errors are emitted), and the fix
+        // ranges for the middle/last rewrites overlap between errors.
+        // `apply_fixes_to_content` deduplicates by range, so the final
+        // applied content is still consistent.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      rewrite ^/a/(.*)$ /b?x=$1;
+      rewrite ^/b/(.*)$ /c?y=$1;
+      rewrite ^/c/(.*)$ /d?z=$1;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      rewrite ^/a/(?<cap1>.*)$ /b?x=$cap1;
+      rewrite ^/b/(?<cap1>.*)$ /c?y=$cap1;
+      rewrite ^/c/(?<cap1>.*)$ /d?z=$cap1;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_output_is_rule_clean() {
+        // Round-trip safety: applying the autofix to a complex
+        // vulnerable pattern must produce content that no longer
+        // triggers the rule. We verify by (1) confirming the autofix
+        // output matches the expected good form, then (2) confirming
+        // the good form itself produces zero rule errors.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let bad = r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      rewrite ^/x/(.*)$ /y/$1 last;
+      set $original_endpoint $1;
+      set $combined "prefix-$1-suffix";
+    }
+  }
+}
+"#;
+        let good = r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      rewrite ^/x/(?<cap1>.*)$ /y/$cap1 last;
+      set $original_endpoint $cap1;
+      set $combined "prefix-$cap1-suffix";
+    }
+  }
+}
+"#;
+        runner.assert_fix_produces(bad, good);
+        runner.assert_no_errors(good);
+    }
+
+    #[test]
+    fn test_autofix_in_nested_block() {
+        // Vulnerable pattern lives inside `if {}` nested in `location {}`.
+        // The scope-walker must recurse into both block levels.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      if ($request_method = POST) {
+        rewrite ^/api/(.*)$ /internal?migrated=true;
+        set $original_endpoint $1;
+      }
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      if ($request_method = POST) {
+        rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+        set $original_endpoint $cap1;
+      }
+    }
+  }
+}
+"#,
         );
     }
 

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1149,6 +1149,73 @@ http {
     }
 
     #[test]
+    fn test_autofix_bails_on_mixed_named_and_unnamed_in_same_regex() {
+        // The cornerstone case for the bail-out: a single regex that
+        // contains BOTH a named capture AND an unnamed one. Users
+        // hitting this in the wild will want to know what the autofix
+        // does. Answer: nothing — the warning fires, no fix is
+        // attached, and they fix it manually.
+        //
+        // Both orderings are tested:
+        //
+        //  - named first (`(?<user>\w+)/(.*)`): a downstream `$1` in
+        //    PCRE refers to the *named* `user` group, but our
+        //    cap-numbering would assign `cap1` to the *unnamed* `(.*)`
+        //    (positional group 2). Renaming `$1` -> `$cap1` would
+        //    silently point the consumer at a different capture.
+        //
+        //  - unnamed first (`(.*)/(?<rest>\w+)`): here `$1` does
+        //    actually refer to the unnamed `(.*)` (positional group
+        //    1), so renaming would *coincidentally* be correct. We
+        //    still bail — the helper has no way to distinguish the
+        //    safe ordering from the unsafe one without a full PCRE
+        //    parser, and it's better to be uniformly conservative
+        //    than to ship a partial heuristic that handles one
+        //    ordering and not the other.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let rule_name = NginxRiftPlugin.spec().name;
+
+        for bad in [
+            // Named first, then unnamed.
+            r#"http {
+  server {
+    location / {
+      rewrite ^/u/(?<user>\w+)/(.*)$ /api?user=$user;
+      set $endpoint $1;
+    }
+  }
+}
+"#,
+            // Unnamed first, then named.
+            r#"http {
+  server {
+    location / {
+      rewrite ^/(.*)/(?<rest>\w+)$ /api?path=$rest;
+      set $endpoint $1;
+    }
+  }
+}
+"#,
+        ] {
+            let errors = runner.check_string(bad).expect("check");
+            let rule_errors: Vec<_> = errors.iter().filter(|e| e.rule == rule_name).collect();
+            assert_eq!(
+                rule_errors.len(),
+                1,
+                "warning must still fire on mixed-capture regex; config was:\n{}",
+                bad
+            );
+            assert!(
+                rule_errors[0].fixes.is_empty(),
+                "mixed named + unnamed in same regex must bail regardless of order; \
+                 got fixes {:?} for config:\n{}",
+                rule_errors[0].fixes,
+                bad
+            );
+        }
+    }
+
+    #[test]
     fn test_autofix_bails_when_v_rewrite_regex_has_python_style_named_capture() {
         // Same bail-out as the `(?<name>...)` form, but via the
         // `(?P<name>...)` Python-style syntax. The helper unit test

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -280,7 +280,9 @@ fn regex_has_named_capture(raw: &str) -> bool {
                 }
             }
             // `(?P<name>...)` — Python-style named capture.
-            if bytes[i + 2] == b'P' && i + 4 < bytes.len() && bytes[i + 3] == b'<' {
+            // (Only `bytes[i + 3]` is read; the outer `i + 3 < bytes.len()`
+            // guard is already sufficient.)
+            if bytes[i + 2] == b'P' && bytes[i + 3] == b'<' {
                 return true;
             }
         }
@@ -293,10 +295,12 @@ fn regex_has_named_capture(raw: &str) -> bool {
 
 /// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
 ///
-/// Skips: escapes (`\(`), character classes (`[...]`), and the `(?...)`
-/// family — non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
+/// Skips: escapes (`\(`), character classes (`[...]`), the `(?...)` family —
+/// non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
 /// lookarounds `(?=...)` / `(?!...)` / `(?<=...)` / `(?<!...)`, atomic
-/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)`.
+/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)` — and the
+/// `(*VERB)` family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`,
+/// `(*FAIL)`, `(*MARK:name)`, etc.
 fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     let bytes = regex.as_bytes();
     let mut positions = Vec::new();
@@ -328,9 +332,9 @@ fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
 
         if b == b'(' {
             let next = bytes.get(i + 1).copied();
-            if next == Some(b'?') {
-                // Some kind of (?...) construct — never an unnamed capture.
-            } else {
+            // `(?...)` constructs and `(*VERB)` control verbs are never
+            // unnamed captures.
+            if next != Some(b'?') && next != Some(b'*') {
                 positions.push(i);
             }
         }
@@ -963,6 +967,23 @@ http {
             find_unnamed_capture_positions("(a)(b)(?:c)(d)"),
             vec![0, 3, 11]
         );
+        // PCRE control verbs like (*PRUNE) / (*FAIL) / (*MARK:tag) start
+        // with `(*` and must not be treated as unnamed captures —
+        // otherwise we'd emit `(?<cap1>*PRUNE)` which is invalid PCRE.
+        assert_eq!(find_unnamed_capture_positions("(*PRUNE)(.*)"), vec![8]);
+        assert_eq!(find_unnamed_capture_positions("(*MARK:tag)(.*)"), vec![11]);
+    }
+
+    #[test]
+    fn test_regex_has_named_capture_handles_truncated_p_form() {
+        // Regression: the old `i + 4 < bytes.len()` guard required a
+        // byte we never read, so a regex ending exactly with `(?P<`
+        // would slip through without bail-out. (nginx itself rejects
+        // such malformed regex, but the helper should still answer
+        // correctly.)
+        assert!(regex_has_named_capture("(?P<"));
+        // And the normal case still returns true.
+        assert!(regex_has_named_capture("(?P<x>y)"));
     }
 
     #[test]

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -87,18 +87,23 @@ fn check_items(items: &[ConfigItem], errors: &mut Vec<LintError>, err: &ErrorBui
 
     for (i, dir) in directives.iter().enumerate() {
         if is_rewrite_with_question_mark(dir) {
-            for next in directives.iter().skip(i + 1) {
-                if is_capture_consumer(next) && uses_unnamed_capture(next) {
-                    errors.push(err.warning_at(
-                        "CVE-2026-42945: `rewrite` replacement contains `?` and is \
-                         followed by a directive that references an unnamed capture \
-                         ($1..$9) in the same scope — this triggers a heap buffer \
-                         overflow on nginx <1.30.1/<1.31.0. Upgrade nginx, switch to \
-                         named captures, or remove `?` from the replacement.",
-                        *dir,
-                    ));
-                    break;
+            let rest = &directives[i + 1..];
+            let triggers = rest
+                .iter()
+                .any(|next| is_capture_consumer(next) && uses_unnamed_capture(next));
+            if triggers {
+                let mut error = err.warning_at(
+                    "CVE-2026-42945: `rewrite` replacement contains `?` and is \
+                     followed by a directive that references an unnamed capture \
+                     ($1..$9) in the same scope — this triggers a heap buffer \
+                     overflow on nginx <1.30.1/<1.31.0. Upgrade nginx, switch to \
+                     named captures, or remove `?` from the replacement.",
+                    *dir,
+                );
+                for fix in build_named_capture_fixes(dir, rest) {
+                    error = error.with_fix(fix);
                 }
+                errors.push(error);
             }
         }
 
@@ -108,11 +113,234 @@ fn check_items(items: &[ConfigItem], errors: &mut Vec<LintError>, err: &ErrorBui
     }
 }
 
+/// Build autofix entries that rewrite unnamed captures to named ones (`cap1`,
+/// `cap2`, ..., `capN`) across the vulnerable rewrite and the subsequent
+/// capture-consuming directives in the same scope.
+///
+/// The fix preserves the surrounding token (including quotes) and only edits
+/// inside each argument's source span. If any sub-fix cannot be safely
+/// generated (e.g. a `set $foo $5` referencing a capture index that doesn't
+/// exist), that one sub-fix is skipped — the rest are still emitted, so the
+/// user gets a partial autofix and the rule keeps flagging the residual.
+fn build_named_capture_fixes(v_rewrite: &Directive, rest: &[&Directive]) -> Vec<Fix> {
+    let mut fixes = Vec::new();
+
+    let Some(v_regex_arg) = v_rewrite.args.first() else {
+        return fixes;
+    };
+    let Some((new_regex_raw, v_cap_count)) = build_renamed_regex(&v_regex_arg.raw) else {
+        return fixes;
+    };
+    if v_cap_count == 0 {
+        return fixes;
+    }
+    push_arg_fix(&mut fixes, v_regex_arg, new_regex_raw);
+
+    // The vulnerable rewrite's own replacement may also use $N.
+    for arg in v_rewrite.args.iter().skip(1) {
+        if let Some(new_raw) = rename_positional_refs_in_raw(&arg.raw, v_cap_count) {
+            push_arg_fix(&mut fixes, arg, new_raw);
+        }
+    }
+
+    // The "active capture context" is the number of unnamed captures
+    // available to a subsequent `set` directive. It starts at the vulnerable
+    // rewrite's count and is replaced whenever a later `rewrite` runs.
+    let mut active_caps = v_cap_count;
+
+    for consumer in rest {
+        if consumer.is("set") {
+            for arg in consumer.args.iter().skip(1) {
+                if let Some(new_raw) = rename_positional_refs_in_raw(&arg.raw, active_caps) {
+                    push_arg_fix(&mut fixes, arg, new_raw);
+                }
+            }
+        } else if consumer.is("rewrite") {
+            let Some(c_regex_arg) = consumer.args.first() else {
+                continue;
+            };
+            let Some((new_c_regex_raw, c_cap_count)) = build_renamed_regex(&c_regex_arg.raw) else {
+                continue;
+            };
+            if c_cap_count > 0 {
+                push_arg_fix(&mut fixes, c_regex_arg, new_c_regex_raw);
+            }
+            for arg in consumer.args.iter().skip(1) {
+                if let Some(new_raw) = rename_positional_refs_in_raw(&arg.raw, c_cap_count) {
+                    push_arg_fix(&mut fixes, arg, new_raw);
+                }
+            }
+            active_caps = c_cap_count;
+        }
+    }
+
+    fixes
+}
+
+fn push_arg_fix(fixes: &mut Vec<Fix>, arg: &Argument, new_raw: String) {
+    if new_raw == arg.raw {
+        return;
+    }
+    fixes.push(Fix::replace_range(
+        arg.span.start.offset,
+        arg.span.end.offset,
+        &new_raw,
+    ));
+}
+
+/// Rewrite a regex source string so that each unnamed capture group `(...)`
+/// becomes a named group `(?<capN>...)`, numbered from 1 in source order.
+///
+/// Returns the rewritten source plus the number of captures introduced.
+/// Returns `None` if the source is structurally unparseable (currently never;
+/// reserved for future regex-validation extensions).
+///
+/// Non-capturing groups `(?:...)`, lookarounds `(?=...)`/`(?!...)`/`(?<=...)`,
+/// already-named groups `(?<name>...)`/`(?P<name>...)`, escaped `\(`, and `(`
+/// inside character classes `[...]` are all left untouched.
+fn build_renamed_regex(raw: &str) -> Option<(String, usize)> {
+    let positions = find_unnamed_capture_positions(raw);
+    if positions.is_empty() {
+        return Some((raw.to_string(), 0));
+    }
+
+    let bytes = raw.as_bytes();
+    let mut out = String::with_capacity(raw.len() + positions.len() * 8);
+    let mut cursor = 0;
+    for (idx, &pos) in positions.iter().enumerate() {
+        // Copy bytes up to and including the `(`
+        out.push_str(std::str::from_utf8(&bytes[cursor..=pos]).ok()?);
+        out.push_str(&format!("?<cap{}>", idx + 1));
+        cursor = pos + 1;
+    }
+    out.push_str(std::str::from_utf8(&bytes[cursor..]).ok()?);
+    Some((out, positions.len()))
+}
+
+/// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
+///
+/// Skips: escapes (`\(`), character classes (`[...]`), and the `(?...)`
+/// family — non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
+/// lookarounds `(?=...)` / `(?!...)` / `(?<=...)` / `(?<!...)`, atomic
+/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)`.
+fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
+    let bytes = regex.as_bytes();
+    let mut positions = Vec::new();
+    let mut i = 0;
+    let mut in_char_class = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'\\' && i + 1 < bytes.len() {
+            // Escaped byte — skip both bytes.
+            i += 2;
+            continue;
+        }
+
+        if in_char_class {
+            if b == b']' {
+                in_char_class = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'[' {
+            in_char_class = true;
+            i += 1;
+            continue;
+        }
+
+        if b == b'(' {
+            let next = bytes.get(i + 1).copied();
+            if next == Some(b'?') {
+                // Some kind of (?...) construct — never an unnamed capture.
+            } else {
+                positions.push(i);
+            }
+        }
+
+        i += 1;
+    }
+
+    positions
+}
+
+/// Rewrite `$1`..`$9` and `${1}`..`${9}` references inside a raw argument
+/// source to `$cap1`..`$capN` (using `${capN}` brace form when followed by
+/// a name-continuation byte, to keep the variable boundary unambiguous).
+///
+/// Returns `Some(new_raw)` when every reference can be rewritten safely; the
+/// caller still needs to compare against the original to detect "nothing
+/// changed". Returns `None` when any `$N` references a position greater than
+/// `max_captures` — i.e. the rewrite would create an undefined variable
+/// reference, so it's safer to leave that argument alone.
+fn rename_positional_refs_in_raw(raw: &str, max_captures: usize) -> Option<String> {
+    let bytes = raw.as_bytes();
+    let mut out = String::with_capacity(raw.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b != b'$' || i + 1 >= bytes.len() {
+            out.push(b as char);
+            i += 1;
+            continue;
+        }
+
+        let after = bytes[i + 1];
+        // `${N}` form
+        if after == b'{'
+            && i + 3 < bytes.len()
+            && matches!(bytes[i + 2], b'1'..=b'9')
+            && bytes[i + 3] == b'}'
+        {
+            let n = (bytes[i + 2] - b'0') as usize;
+            if n > max_captures {
+                return None;
+            }
+            out.push_str(&format!("${{cap{}}}", n));
+            i += 4;
+            continue;
+        }
+        // `$N` form
+        if matches!(after, b'1'..=b'9') {
+            let n = (after - b'0') as usize;
+            if n > max_captures {
+                return None;
+            }
+            // If the next byte continues a variable name, switch to brace
+            // form to avoid `$cap1abc` collapsing into a single var name.
+            let follow = bytes.get(i + 2).copied();
+            let needs_braces = matches!(
+                follow,
+                Some(b'_') | Some(b'a'..=b'z') | Some(b'A'..=b'Z') | Some(b'0'..=b'9')
+            );
+            if needs_braces {
+                out.push_str(&format!("${{cap{}}}", n));
+            } else {
+                out.push_str(&format!("$cap{}", n));
+            }
+            i += 2;
+            continue;
+        }
+
+        out.push('$');
+        i += 1;
+    }
+
+    Some(out)
+}
+
 fn is_rewrite_with_question_mark(dir: &Directive) -> bool {
     if !dir.is("rewrite") || dir.args.len() < 2 {
         return false;
     }
-    dir.args[1].as_str().contains('?')
+    // The replacement string is logically one nginx token, but our parser
+    // splits it on variable boundaries (e.g. `/backend/$1?foo` →
+    // `/backend/`, `$1`, `?foo`). Scan every arg after the regex.
+    dir.args.iter().skip(1).any(|a| a.raw.contains('?'))
 }
 
 /// Directives that, on vulnerable nginx, hit the buggy script-engine path
@@ -439,6 +667,246 @@ http {
     fn test_fixtures() {
         let runner = PluginTestRunner::new(NginxRiftPlugin);
         runner.test_fixtures(nginx_lint_plugin::fixtures_dir!());
+    }
+
+    #[test]
+    fn test_autofix_basic_rewrite_then_set() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $original_endpoint $1;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $original_endpoint $cap1;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_rewrite_then_rewrite_with_capture() {
+        // Second rewrite has its own regex; its $1 in the replacement
+        // refers to its OWN capture, which we rename to cap1 locally.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/foo/(.*)$ {
+      rewrite ^/foo/(.*)$ /bar?x=1;
+      rewrite ^/bar/(.*)$ /baz/$1 last;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/foo/(.*)$ {
+      rewrite ^/foo/(?<cap1>.*)$ /bar?x=1;
+      rewrite ^/bar/(?<cap1>.*)$ /baz/$cap1 last;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_brace_form_of_unnamed_capture() {
+        // ${1}_suffix must use the brace form on the renamed side too
+        // (`${cap1}_suffix`) — and our rewriter also auto-promotes plain
+        // `$1` to `${cap1}` when followed by a name-continuation byte.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $combined "${1}_suffix";
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $combined "${cap1}_suffix";
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_capture_inside_quoted_string() {
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $combined "prefix-$1-suffix";
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $combined "prefix-$cap1-suffix";
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_partial_when_consumer_exceeds_captures() {
+        // The vulnerable rewrite has only 1 capture; `set $b $2` references
+        // a non-existent positional capture. We MUST NOT rename `$2` to
+        // `$cap2` (would create an undefined variable reference at
+        // nginx-load time). The other fixes still apply.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $a $1;
+      set $b $2;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $a $cap1;
+      set $b $2;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_does_not_touch_other_blocks() {
+        // A `set $foo $1` in a different scope must not be renamed —
+        // its $1 binds to that scope's own (non-vulnerable) context.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $a $1;
+    }
+    location ~ ^/other/(.*)$ {
+      set $b $1;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $a $cap1;
+    }
+    location ~ ^/other/(.*)$ {
+      set $b $1;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_autofix_skips_non_capturing_groups_in_regex() {
+        // `(?:...)` is non-capturing — keep it untouched. Real captures
+        // remain numbered in source order (cap1, cap2).
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location / {
+      rewrite ^/(?:api)/(.*)/(.*)$ /backend/$1/$2?migrated=true;
+      set $a $1;
+      set $b $2;
+    }
+  }
+}
+"#,
+            r#"http {
+  server {
+    location / {
+      rewrite ^/(?:api)/(?<cap1>.*)/(?<cap2>.*)$ /backend/$cap1/$cap2?migrated=true;
+      set $a $cap1;
+      set $b $cap2;
+    }
+  }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_find_unnamed_captures_skips_constructs() {
+        // Direct check on the regex parser helper.
+        assert_eq!(find_unnamed_capture_positions("^/api/(.*)$"), vec![6]);
+        assert_eq!(find_unnamed_capture_positions("^/(?:api)/(.*)$"), vec![10]);
+        assert_eq!(
+            find_unnamed_capture_positions("^/(?<name>.*)/(.*)$"),
+            vec![14]
+        );
+        assert_eq!(
+            find_unnamed_capture_positions("^/(?P<name>.*)/(.*)$"),
+            vec![15]
+        );
+        assert_eq!(
+            find_unnamed_capture_positions(r"\(literal\)"),
+            Vec::<usize>::new()
+        );
+        assert_eq!(find_unnamed_capture_positions("[()]"), Vec::<usize>::new());
+        assert_eq!(
+            find_unnamed_capture_positions("(a)(b)(?:c)(d)"),
+            vec![0, 3, 11]
+        );
+    }
+
+    #[test]
+    fn test_rename_positional_refs_bail_when_exceeding_captures() {
+        // $5 with max_captures=1 must return None.
+        assert!(rename_positional_refs_in_raw("$5", 1).is_none());
+        assert!(rename_positional_refs_in_raw("${5}", 1).is_none());
+        assert!(rename_positional_refs_in_raw("prefix-$5-suffix", 1).is_none());
+
+        // No-op cases.
+        assert_eq!(
+            rename_positional_refs_in_raw("static", 1).as_deref(),
+            Some("static")
+        );
+        assert_eq!(
+            rename_positional_refs_in_raw("$foo", 1).as_deref(),
+            Some("$foo")
+        );
     }
 
     #[test]

--- a/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
+++ b/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
@@ -1,9 +1,9 @@
 http {
   server {
     listen 80;
-    location ~ ^/api/(?<rest>.*)$ {
-      rewrite ^/api/(?<rest>.*)$ /internal?migrated=true;
-      set $original_endpoint $rest;
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $original_endpoint $cap1;
     }
   }
 }


### PR DESCRIPTION
Rewrites the vulnerable `rewrite` regex and every subsequent capture- consuming `set`/`rewrite` in the same scope to use PCRE named captures (`(?<cap1>.*)` / `$cap1`), which bypasses the buggy script-engine code path responsible for CVE-2026-42945.

When a `$N` reference would target a position that doesn't exist in the governing regex (e.g. `set $b $2` with a 1-capture rewrite), that sub-fix is skipped so the autofix never creates an undefined variable reference at config-load time — the rule keeps flagging the residual.

Also fixes a latent detection gap: the parser splits an unquoted replacement on `$` boundaries (`/backend/$1?foo` -> `/backend/`, `$1`, `?foo`), so checking only `args[1]` missed the `?` in multi-variable replacements. Detection now scans every arg after the regex.