### PR TITLE
fix(nginx-rift): skip openresty:noble and document 1.29.2.4 backport

### DIFF
--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -34,7 +34,10 @@ impl Plugin for NginxRiftPlugin {
         .with_why(
             "CVE-2026-42945 (\"NGINX Rift\") is a heap buffer overflow in \
              ngx_http_rewrite_module that affects nginx 0.6.27 through 1.30.0 \
-             (fixed in 1.30.1 and 1.31.0). When a `rewrite` replacement \
+             (fixed in 1.30.1 and 1.31.0). Downstream distributions have \
+             backported the fix on their own schedules; notably, OpenResty \
+             shipped the patch in 1.29.2.4 (1.29.2.3 and earlier are still \
+             vulnerable). When a `rewrite` replacement \
              contains `?`, the worker sets an internal `is_args` flag on the \
              main script engine and never clears it. A subsequent `set` or \
              `rewrite` directive that references an unnamed PCRE capture \
@@ -45,8 +48,9 @@ impl Plugin for NginxRiftPlugin {
              crashes or — on systems without ASLR — unauthenticated remote \
              code execution. Empirically, the captured value is also \
              corrupted on the wire (`/api/foo+bar` returns a truncated \
-             `captured=foo%2Bb`). The reliable fixes are: (1) upgrade nginx \
-             to 1.30.1 / 1.31.0 or later; (2) drop `?` from the rewrite \
+             `captured=foo%2Bb`). The reliable fixes are: (1) upgrade to a \
+             patched build (nginx >= 1.30.1 / 1.31.0, or OpenResty \
+             >= 1.29.2.4); (2) drop `?` from the rewrite \
              replacement; (3) switch to named captures (`(?<name>...)`), \
              which are resolved through a separate code path that does not \
              share the rewrite engine's `is_args` state. Note that simply \
@@ -54,8 +58,9 @@ impl Plugin for NginxRiftPlugin {
              underlying bug. The configuration is syntactically valid and \
              nginx will load it; the danger is runtime-only on vulnerable \
              builds. This rule is enabled by default; disable it in \
-             configuration once your entire fleet is on nginx >= 1.30.1 / \
-             1.31.0.",
+             configuration once your entire fleet is on a patched build \
+             (nginx >= 1.30.1 / 1.31.0, OpenResty >= 1.29.2.4, or a \
+             distribution with the backport applied).",
         )
         .with_bad_example(include_str!("../examples/bad.conf").trim())
         .with_good_example(include_str!("../examples/good.conf").trim())

--- a/plugins/builtin/security/nginx_rift/tests/container_test.rs
+++ b/plugins/builtin/security/nginx_rift/tests/container_test.rs
@@ -35,11 +35,14 @@
 //! On patched nginx the signature is *absent* by design, so there is
 //! nothing to assert on. We therefore skip the bug-observation tests on
 //! `nginx_version_at_least(1, 31)`. We do NOT skip on potentially-
-//! unpatched tags (`nginx:1.30`, `openresty:noble`, etc.) — those are
-//! exactly the builds we want to exercise. Confirmed observed on:
+//! unpatched tags (`nginx:1.30`, etc.) — those are exactly the builds
+//! we want to exercise. Confirmed observed on:
 //!
 //! - `nginx:1.30.0` (CVE patched in 1.30.1) — truncated/escaped
-//! - `openresty/openresty:noble` (openresty/1.29.2.3) — mis-escaped
+//! - `openresty/openresty:noble` — historically mis-escaped on
+//!   openresty/1.29.2.3; the backport landed in openresty/1.29.2.4 and
+//!   the floating `:noble` tag now resolves there, so it is skipped
+//!   (pin `1.29.2.3-noble` or earlier to exercise the unpatched form)
 //! - `nginx:1.31`, `freenginx:1.31` — clean (tests skipped)
 //!
 //! # Why we don't assert on a worker crash
@@ -59,7 +62,7 @@
 //!       --test container_test -- --ignored
 
 use nginx_lint_plugin::container_testing::{
-    NginxContainer, nginx_image_tag, nginx_version_at_least, reqwest,
+    NginxContainer, nginx_image, nginx_version_at_least, reqwest,
 };
 
 /// On patched builds the bug's signature is absent by design, so the
@@ -71,6 +74,9 @@ use nginx_lint_plugin::container_testing::{
 /// - the floating `1.30` tag — Docker Hub now resolves it to the patched
 ///   `1.30.1`, even though `nginx_version_at_least` only sees (1, 30)
 /// - any explicit `1.30.x` where x >= 1 (1.30.1 onward shipped the fix)
+/// - the floating `noble` tag (`openresty/openresty:noble`) — backport
+///   landed in openresty/1.29.2.4; pin `1.29.2.3-noble` or earlier to
+///   exercise the unpatched form
 ///
 /// To run the observation tests against the genuine unpatched build, use
 /// the explicit pinned tag, e.g. `NGINX_IMAGE=nginx:1.30.0`.
@@ -78,9 +84,15 @@ fn skip_on_patched_version() -> bool {
     if nginx_version_at_least(1, 31) {
         return true;
     }
-    let tag = nginx_image_tag();
+    let (image_name, tag) = nginx_image();
     // Bare `1.30` is the floating Docker tag — now patched (1.30.1+).
     if tag == "1.30" {
+        return true;
+    }
+    // `openresty/openresty:noble` is the floating tag that has shipped
+    // the CVE-2026-42945 backport (in openresty/1.29.2.4). Pin
+    // `1.29.2.3-noble` or earlier to exercise the unpatched form.
+    if image_name.contains("openresty") && tag == "noble" {
         return true;
     }
     // Explicit 1.30.x with x >= 1 is patched.


### PR DESCRIPTION
The CVE-2026-42945 fix has landed in OpenResty 1.29.2.4, so the floating openresty/openresty:noble tag now resolves to a patched build. The bug-observation container tests have no signature to assert on against this tag and would start failing in CI.

- Extend skip_on_patched_version() to also skip when the image name contains "openresty" and the tag is "noble". Both image_name and tag are checked (via nginx_image()) to avoid matching unrelated images that happen to use a "noble" tag.
- Update the rule's `why` text to call out OpenResty 1.29.2.4 (and distribution backports in general) alongside nginx 1.30.1 / 1.31.0 as patched builds, so operators running OpenResty know when it is safe to disable the rule.