### PR TITLE
fix: single-digit $1..$9 capture lexing + braced nginx-rift autofix

### DIFF
--- a/crates/nginx-lint-parser/src/lexer_rowan.rs
+++ b/crates/nginx-lint-parser/src/lexer_rowan.rs
@@ -605,6 +605,44 @@ mod tests {
     }
 
     #[test]
+    fn dollar_nine_is_top_of_capture_range() {
+        // `$9` is the top of the single-digit range, so `$9foo` splits into
+        // the capture `$9` and the literal `foo`.
+        let tokens = tokenize("set $x $9foo;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$9"),
+                (SyntaxKind::IDENT, "foo"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dollar_zero_is_not_a_single_digit_capture() {
+        // `$0` is below the `$1`..`$9` capture range, so it takes the normal
+        // greedy variable-name path: `$0redirect` is one variable token
+        // (nginx also treats `$0` as a name, not a positional capture).
+        let tokens = tokenize("set $x $0redirect;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$0redirect"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
     fn comment() {
         let tokens = tokenize("# this is a comment\nlisten 80;");
         assert_eq!(

--- a/crates/nginx-lint-parser/src/lexer_rowan.rs
+++ b/crates/nginx-lint-parser/src/lexer_rowan.rs
@@ -238,6 +238,11 @@ impl<'a> RowanLexer<'a> {
                 }
                 self.advance_char();
             }
+        } else if matches!(self.peek(), Some('1'..='9')) {
+            // Positional capture `$1`..`$9`: nginx reads exactly one digit,
+            // so `$1redirect` is the capture `$1` followed by literal
+            // `redirect`, and `$12` is `$1` then `2`. Consume just the digit.
+            self.advance_char();
         } else {
             // $var syntax
             while let Some(ch) = self.peek() {
@@ -501,6 +506,99 @@ mod tests {
                 (SyntaxKind::ARGUMENT, "200"),
                 (SyntaxKind::WHITESPACE, " "),
                 (SyntaxKind::VARIABLE, "${request_uri}"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn positional_capture_stops_at_one_digit() {
+        // nginx reads `$1`..`$9` as a single-digit positional capture, so
+        // `$1redirect` is the capture `$1` followed by the literal text
+        // `redirect`, not one variable named `1redirect`.
+        let tokens = tokenize("set $x $1redirect;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$1"),
+                (SyntaxKind::IDENT, "redirect"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn positional_capture_followed_by_digit() {
+        // `$12` is the capture `$1` then a literal `2`; the `$N` form has no
+        // multi-digit captures (use the brace form `${12}` for those).
+        let tokens = tokenize("set $x $12;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$1"),
+                (SyntaxKind::ARGUMENT, "2"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn positional_capture_then_digit_and_letters() {
+        // `$12redirect` is the capture `$1` then the literal `2redirect`:
+        // the single digit is the capture, the remainder is plain text.
+        let tokens = tokenize("set $x $12redirect;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$1"),
+                (SyntaxKind::ARGUMENT, "2redirect"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn brace_capture_keeps_multiple_digits() {
+        // The brace form is unaffected: `${12}` stays one variable token.
+        let tokens = tokenize("set $x ${12};");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "${12}"),
+                (SyntaxKind::SEMICOLON, ";"),
+            ]
+        );
+    }
+
+    #[test]
+    fn letter_first_variable_with_digits_unaffected() {
+        // Only digit-FIRST names are single-digit captures; a normal name
+        // containing digits (`$arg_1`) is still one variable token.
+        let tokens = tokenize("set $x $arg_1;");
+        assert_eq!(
+            tokens,
+            vec![
+                (SyntaxKind::IDENT, "set"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$x"),
+                (SyntaxKind::WHITESPACE, " "),
+                (SyntaxKind::VARIABLE, "$arg_1"),
                 (SyntaxKind::SEMICOLON, ";"),
             ]
         );

--- a/plugins/builtin/security/nginx_rift/examples/good.conf
+++ b/plugins/builtin/security/nginx_rift/examples/good.conf
@@ -3,7 +3,7 @@ http {
     listen 80;
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $original_endpoint $cap1;
+      set $original_endpoint ${cap1};
     }
   }
 }

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -393,8 +393,15 @@ fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
 }
 
 /// Rewrite `$1`..`$9` and `${1}`..`${9}` references inside a raw argument
-/// source to `$cap1`..`$capN` (using `${capN}` brace form when followed by
-/// a name-continuation byte, to keep the variable boundary unambiguous).
+/// source to the braced named form `${cap1}`..`${capN}`.
+///
+/// The brace form is used unconditionally (never the bare `$capN`) so the
+/// rename is safe no matter what follows the reference — including a
+/// name-continuation character in the *next* argument. The parser splits a
+/// replacement on variable boundaries, so `$1path` becomes the two args `$1`
+/// and `path`; renaming `$1` to a bare `$capN` would then collapse with the
+/// following `path` into one different, undefined variable. The braced
+/// `${capN}` form cannot collapse.
 ///
 /// Returns `Some(new_raw)` when every reference can be rewritten safely; the
 /// caller still needs to compare against the original to detect "nothing
@@ -429,24 +436,16 @@ fn rename_positional_refs_in_raw(raw: &str, max_captures: usize) -> Option<Strin
             i += 4;
             continue;
         }
-        // `$N` form
+        // `$N` form. Always emit the braced `${capN}` form: the parser may
+        // have split a following name-continuation run into a separate arg
+        // (e.g. `$1path` -> `$1` + `path`), so a bare `$capN` could collapse
+        // with it into a different variable. Braces keep the boundary firm.
         if matches!(after, b'1'..=b'9') {
             let n = (after - b'0') as usize;
             if n > max_captures {
                 return None;
             }
-            // If the next byte continues a variable name, switch to brace
-            // form to avoid `$cap1abc` collapsing into a single var name.
-            let follow = bytes.get(i + 2).copied();
-            let needs_braces = matches!(
-                follow,
-                Some(b'_') | Some(b'a'..=b'z') | Some(b'A'..=b'Z') | Some(b'0'..=b'9')
-            );
-            if needs_braces {
-                out.push_str(&format!("${{cap{}}}", n));
-            } else {
-                out.push_str(&format!("$cap{}", n));
-            }
+            out.push_str(&format!("${{cap{}}}", n));
             i += 2;
             continue;
         }
@@ -1084,7 +1083,7 @@ http {
             r#"http {
   server {
     location ~ ^/api/(.*)$ {
-      rewrite ^/api/(?<cap1>.*)$ https://example.com/$cap1?x=1 redirect;
+      rewrite ^/api/(?<cap1>.*)$ https://example.com/${cap1}?x=1 redirect;
     }
   }
 }
@@ -1095,7 +1094,7 @@ http {
             r#"http {
   server {
     location ~ ^/api/(.*)$ {
-      rewrite ^/api/(?<cap1>.*)$ https://example.com/$cap1?x=1 redirect;
+      rewrite ^/api/(?<cap1>.*)$ https://example.com/${cap1}?x=1 redirect;
     }
   }
 }
@@ -1138,7 +1137,7 @@ http {
         let good = r#"http {
   server {
     location ~ ^/api/(.*)$ {
-      rewrite ^/api/(?<cap1>.*)$ $scheme://example.com/$cap1?x=1;
+      rewrite ^/api/(?<cap1>.*)$ $scheme://example.com/${cap1}?x=1;
     }
   }
 }
@@ -1166,7 +1165,7 @@ http {
         let good = r#"http {
   server {
     location ~ ^/api/(.*)$ {
-      rewrite ^/api/(?<cap1>.*)$ 'https://example.com/$cap1?x=1';
+      rewrite ^/api/(?<cap1>.*)$ 'https://example.com/${cap1}?x=1';
     }
   }
 }
@@ -1176,6 +1175,64 @@ http {
   server {
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(.*)$ 'https://example.com/$1?x=1';
+    }
+  }
+}
+"#,
+            good,
+        );
+        runner.assert_no_errors(good);
+    }
+
+    #[test]
+    fn test_autofix_redirect_capture_adjacent_to_text() {
+        // `$1path` is a capture immediately followed by name characters. The
+        // parser tokenizes it as `$1` + `path`, so the rename MUST brace the
+        // capture (`${cap1}`) — a bare `$cap1` would merge with the adjacent
+        // `path` into `$cap1path` (a different, undefined variable).
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let good = r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ https://example.com/${cap1}path?x=1 redirect;
+    }
+  }
+}
+"#;
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ https://example.com/$1path?x=1 redirect;
+    }
+  }
+}
+"#,
+            good,
+        );
+        runner.assert_no_errors(good);
+    }
+
+    #[test]
+    fn test_autofix_consumer_capture_adjacent_to_text() {
+        // Same adjacency hazard on the consumer path: `set $x $1suffix` must
+        // become `${cap1}suffix`, not `$cap1suffix`.
+        let runner = PluginTestRunner::new(NginxRiftPlugin);
+        let good = r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
+      set $x ${cap1}suffix;
+    }
+  }
+}
+"#;
+        runner.assert_fix_produces(
+            r#"http {
+  server {
+    location ~ ^/api/(.*)$ {
+      rewrite ^/api/(.*)$ /internal?migrated=true;
+      set $x $1suffix;
     }
   }
 }
@@ -1208,7 +1265,7 @@ http {
   server {
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $original_endpoint $cap1;
+      set $original_endpoint ${cap1};
     }
   }
 }
@@ -1235,7 +1292,7 @@ http {
   server {
     location ~ ^/foo/(.*)$ {
       rewrite ^/foo/(?<cap1>.*)$ /bar?x=1;
-      rewrite ^/bar/(?<cap1>.*)$ /baz/$cap1 last;
+      rewrite ^/bar/(?<cap1>.*)$ /baz/${cap1} last;
     }
   }
 }
@@ -1288,7 +1345,7 @@ http {
   server {
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $combined "prefix-$cap1-suffix";
+      set $combined "prefix-${cap1}-suffix";
     }
   }
 }
@@ -1300,7 +1357,7 @@ http {
     fn test_autofix_partial_when_consumer_exceeds_captures() {
         // The vulnerable rewrite has only 1 capture; `set $b $2` references
         // a non-existent positional capture. We MUST NOT rename `$2` to
-        // `$cap2` (would create an undefined variable reference at
+        // `${cap2}` (would create an undefined variable reference at
         // nginx-load time). The other fixes still apply.
         let runner = PluginTestRunner::new(NginxRiftPlugin);
         runner.assert_fix_produces(
@@ -1318,7 +1375,7 @@ http {
   server {
     location / {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $a $cap1;
+      set $a ${cap1};
       set $b $2;
     }
   }
@@ -1349,7 +1406,7 @@ http {
   server {
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $a $cap1;
+      set $a ${cap1};
     }
     location ~ ^/other/(.*)$ {
       set $b $1;
@@ -1379,9 +1436,9 @@ http {
             r#"http {
   server {
     location / {
-      rewrite ^/(?:api)/(?<cap1>.*)/(?<cap2>.*)$ /backend/$cap1/$cap2?migrated=true;
-      set $a $cap1;
-      set $b $cap2;
+      rewrite ^/(?:api)/(?<cap1>.*)/(?<cap2>.*)$ /backend/${cap1}/${cap2}?migrated=true;
+      set $a ${cap1};
+      set $b ${cap2};
     }
   }
 }
@@ -1452,9 +1509,9 @@ http {
             r#"http {
   server {
     location / {
-      rewrite ^/a/(?<cap1>.*)$ /b?x=$cap1;
-      rewrite ^/b/(?<cap1>.*)$ /c?y=$cap1;
-      rewrite ^/c/(?<cap1>.*)$ /d?z=$cap1;
+      rewrite ^/a/(?<cap1>.*)$ /b?x=${cap1};
+      rewrite ^/b/(?<cap1>.*)$ /c?y=${cap1};
+      rewrite ^/c/(?<cap1>.*)$ /d?z=${cap1};
     }
   }
 }
@@ -1485,9 +1542,9 @@ http {
   server {
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      rewrite ^/x/(?<cap1>.*)$ /y/$cap1 last;
-      set $original_endpoint $cap1;
-      set $combined "prefix-$cap1-suffix";
+      rewrite ^/x/(?<cap1>.*)$ /y/${cap1} last;
+      set $original_endpoint ${cap1};
+      set $combined "prefix-${cap1}-suffix";
     }
   }
 }
@@ -1518,7 +1575,7 @@ http {
     location / {
       if ($request_method = POST) {
         rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-        set $original_endpoint $cap1;
+        set $original_endpoint ${cap1};
       }
     }
   }
@@ -1551,7 +1608,7 @@ http {
   server {
     location ~ ^/u/(?<user>\w+)/api/(.*)$ {
       rewrite ^/u/.+/api/(?<cap1>.*)$ /backend?migrated=true;
-      set $endpoint $cap1;
+      set $endpoint ${cap1};
       set $username $user;
     }
   }
@@ -1564,7 +1621,7 @@ http {
     fn test_autofix_bails_when_v_rewrite_regex_has_named_capture() {
         // `(?<user>...)` in the vulnerable rewrite's regex makes
         // cap-numbering ambiguous: `$1` refers to `user` in PCRE, but
-        // our cap-numbering would rename `$1` to `$cap1` and assign
+        // our cap-numbering would rename `$1` to `${cap1}` and assign
         // `cap1` to the *next* unnamed group — a different capture.
         // To avoid silent semantic remap, we bail on the whole chain:
         // warning fires, no fix attached.
@@ -1614,7 +1671,7 @@ http {
   server {
     location / {
       rewrite ^/api\(deprecated\)/(?<cap1>.*)$ /new?migrated=true;
-      set $endpoint $cap1;
+      set $endpoint ${cap1};
     }
   }
 }
@@ -1627,7 +1684,7 @@ http {
         // Nested unnamed captures get numbered outer-first in source
         // order, which happens to match PCRE's positional numbering
         // (outer = group 1, inner = group 2). No special handling is
-        // needed — `$1` -> `$cap1` and `$2` -> `$cap2` stay
+        // needed — `$1` -> `${cap1}` and `$2` -> `${cap2}` stay
         // semantically equivalent.
         let runner = PluginTestRunner::new(NginxRiftPlugin);
         runner.assert_fix_produces(
@@ -1645,8 +1702,8 @@ http {
   server {
     location / {
       rewrite ^/x/(?<cap1>(?<cap2>.*))$ /target?z=1;
-      set $outer $cap1;
-      set $inner $cap2;
+      set $outer ${cap1};
+      set $inner ${cap2};
     }
   }
 }
@@ -1716,7 +1773,7 @@ http {
         //  - named first (`(?<user>\w+)/(.*)`): a downstream `$1` in
         //    PCRE refers to the *named* `user` group, but our
         //    cap-numbering would assign `cap1` to the *unnamed* `(.*)`
-        //    (positional group 2). Renaming `$1` -> `$cap1` would
+        //    (positional group 2). Renaming `$1` -> `${cap1}` would
         //    silently point the consumer at a different capture.
         //
         //  - unnamed first (`(.*)/(?<rest>\w+)`): here `$1` does
@@ -1876,7 +1933,7 @@ http {
   server {
     location / {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $a $cap1;
+      set $a ${cap1};
       rewrite ^/u/(?<user>\w+)/(.*)$ /next/$1 last;
       set $b $1;
     }

--- a/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
+++ b/plugins/builtin/security/nginx_rift/tests/fixtures/001_basic/expected/nginx.conf
@@ -3,7 +3,7 @@ http {
     listen 80;
     location ~ ^/api/(.*)$ {
       rewrite ^/api/(?<cap1>.*)$ /internal?migrated=true;
-      set $original_endpoint $cap1;
+      set $original_endpoint ${cap1};
     }
   }
 }


### PR DESCRIPTION
## Summary

Two coupled fixes:

1. **Parser** — `$1`..`$9` are now lexed as single-digit positional
   captures, matching nginx. The lexer previously consumed all name
   characters, so `$1redirect` became one token and `$12` became `$12`.
   nginx reads exactly one digit after `$` as a capture, leaving the rest
   as literal text. The brace form `${12}` (multi-digit captures) and
   letter-first names (`$arg_1`) are unchanged.

2. **nginx-rift autofix** — because the parser now splits `$1path` into
   the args `$1` + `path`, the autofix renames captures with the braced
   `${capN}` form unconditionally. A bare `$capN` would otherwise merge
   with adjacent name text into a different, undefined variable
   (`$cap1path`).

### User-visible change

The `nginx-rift` autofix now always emits `${capN}` (e.g.
`set $x ${cap1};`) instead of the bare `$capN`. The two are equivalent
nginx variable references; the braced form is unambiguous regardless of
what follows.

### Merge note

These two changes must land together: the parser fix alone would regress
the already-merged nginx-rift autofix for `$1<name-chars>` patterns.

## Test plan
- [x] `cargo test --workspace`
- [x] Lexer: `$1redirect`, `$12`, `$12redirect`, `$9foo`, `$0redirect`, `${12}`, `$arg_1`
- [x] nginx-rift autofix: capture adjacent to name text (redirect + consumer paths)
- [x] `cargo fmt --check`, `cargo clippy`