### PR TITLE
fix: skip fixes with offsets not on UTF-8 char boundaries

### DIFF
--- a/crates/nginx-lint-common/src/lib.rs
+++ b/crates/nginx-lint-common/src/lib.rs
@@ -45,8 +45,9 @@ pub use ignore::{
     FilterResult, IgnoreTracker, IgnoreWarning, filter_errors, parse_context_comment,
 };
 pub use linter::{
-    Fix, LintError, LintRule, Linter, RULE_CATEGORIES, Severity, apply_fixes_to_content,
-    compute_line_starts, normalize_line_fix,
+    Fix, FixApplyResult, LintError, LintRule, Linter, RULE_CATEGORIES, Severity,
+    apply_fixes_to_content, apply_fixes_to_content_detailed, compute_line_starts,
+    normalize_line_fix,
 };
 pub use nginx_lint_parser::{parse_config, parse_string, parse_string_with_errors};
 pub use nginx_version::{NginxVersion, NginxVersionParseError, format_range, is_in_range};

--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -504,7 +504,13 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
             continue;
         }
 
-        if start <= result.len() && end <= result.len() && start <= end {
+        // Offsets must lie on UTF-8 char boundaries: replace_range panics
+        // otherwise, and plugin-provided fixes are untrusted input.
+        if start <= end
+            && end <= result.len()
+            && result.is_char_boundary(start)
+            && result.is_char_boundary(end)
+        {
             result.replace_range(start..end, &fix.new_text);
             applied_ranges.push((start, start + fix.new_text.len()));
             fix_count += 1;
@@ -625,6 +631,40 @@ mod fix_tests {
         let fixes: Vec<&Fix> = vec![&fix1, &fix2];
         let (_, count) = apply_fixes_to_content(content, &fixes);
         // Only one fix should apply (the other is skipped due to overlap)
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_apply_fix_non_char_boundary_skipped() {
+        // "あ" is 3 bytes (0..3); offsets 1 and 2 are not char boundaries.
+        // Such fixes (e.g. from a malicious plugin) must be skipped, not panic.
+        let content = "あいう;\n";
+        let fix = Fix::replace_range(1, 2, "x");
+        let fixes: Vec<&Fix> = vec![&fix];
+        let (result, count) = apply_fixes_to_content(content, &fixes);
+        assert_eq!(result, content);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_apply_fix_non_char_boundary_end_skipped() {
+        // start is on a boundary but end is mid-character
+        let content = "あいう;\n";
+        let fix = Fix::replace_range(0, 4, "x");
+        let fixes: Vec<&Fix> = vec![&fix];
+        let (result, count) = apply_fixes_to_content(content, &fixes);
+        assert_eq!(result, content);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_apply_fix_multibyte_on_boundary_applies() {
+        // Offsets on char boundaries within multibyte content still work
+        let content = "あいう;\n";
+        let fix = Fix::replace_range(3, 6, "x");
+        let fixes: Vec<&Fix> = vec![&fix];
+        let (result, count) = apply_fixes_to_content(content, &fixes);
+        assert_eq!(result, "あxう;\n");
         assert_eq!(count, 1);
     }
 

--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -447,13 +447,37 @@ pub fn normalize_line_fix(fix: &Fix, content: &str, line_starts: &[usize]) -> Op
     Some(Fix::replace_range(line_start, line_end, &fix.new_text))
 }
 
+/// Result of applying fixes to content, with detailed counts.
+#[derive(Debug)]
+pub struct FixApplyResult {
+    /// Content after applying the fixes
+    pub content: String,
+    /// Number of fixes applied
+    pub applied: usize,
+    /// Number of fixes skipped because their offsets were out of range or
+    /// not on UTF-8 character boundaries (e.g. produced by a buggy plugin).
+    /// Does not include fixes skipped due to overlap with an applied fix.
+    pub skipped_invalid: usize,
+}
+
 /// Apply fixes to content string.
 ///
-/// All fixes (both line-based and offset-based) are normalized to offset-based,
-/// then applied in reverse order to avoid index shifts. Overlapping fixes are skipped.
+/// Convenience wrapper around [`apply_fixes_to_content_detailed`] for callers
+/// that do not need the skipped-fix count.
 ///
 /// Returns `(modified_content, number_of_fixes_applied)`.
 pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) {
+    let result = apply_fixes_to_content_detailed(content, fixes);
+    (result.content, result.applied)
+}
+
+/// Apply fixes to content string, reporting skipped fixes.
+///
+/// All fixes (both line-based and offset-based) are normalized to offset-based,
+/// then applied in reverse order to avoid index shifts. Overlapping fixes are skipped.
+/// Fixes with invalid offsets (out of range or not on UTF-8 char boundaries) are
+/// skipped and counted in [`FixApplyResult::skipped_invalid`].
+pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixApplyResult {
     let line_starts = compute_line_starts(content);
 
     // Normalize all fixes to range-based
@@ -491,6 +515,7 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
     });
 
     let mut fix_count = 0;
+    let mut skipped_invalid = 0;
     let mut result = content.to_string();
     let mut applied_ranges: Vec<(usize, usize)> = Vec::new();
 
@@ -514,6 +539,8 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
             result.replace_range(start..end, &fix.new_text);
             applied_ranges.push((start, start + fix.new_text.len()));
             fix_count += 1;
+        } else {
+            skipped_invalid += 1;
         }
     }
 
@@ -522,7 +549,11 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
         result.push('\n');
     }
 
-    (result, fix_count)
+    FixApplyResult {
+        content: result,
+        applied: fix_count,
+        skipped_invalid,
+    }
 }
 
 #[cfg(test)]
@@ -666,6 +697,31 @@ mod fix_tests {
         let (result, count) = apply_fixes_to_content(content, &fixes);
         assert_eq!(result, "あxう;\n");
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_detailed_counts_invalid_fixes() {
+        // One valid fix, one non-boundary fix, one out-of-range fix
+        let content = "あいう;\n";
+        let valid = Fix::replace_range(3, 6, "x");
+        let non_boundary = Fix::replace_range(1, 2, "y");
+        let out_of_range = Fix::replace_range(100, 200, "z");
+        let fixes: Vec<&Fix> = vec![&valid, &non_boundary, &out_of_range];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(result.content, "あxう;\n");
+        assert_eq!(result.applied, 1);
+        assert_eq!(result.skipped_invalid, 2);
+    }
+
+    #[test]
+    fn test_detailed_overlap_not_counted_as_invalid() {
+        let content = "abcdef\n";
+        let fix1 = Fix::replace_range(0, 3, "XYZ");
+        let fix2 = Fix::replace_range(2, 5, "QQQ"); // overlaps with fix1
+        let fixes: Vec<&Fix> = vec![&fix1, &fix2];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(result.applied, 1);
+        assert_eq!(result.skipped_invalid, 0);
     }
 
     #[test]

--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -448,15 +448,17 @@ pub fn normalize_line_fix(fix: &Fix, content: &str, line_starts: &[usize]) -> Op
 }
 
 /// Result of applying fixes to content, with detailed counts.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FixApplyResult {
     /// Content after applying the fixes
     pub content: String,
     /// Number of fixes applied
     pub applied: usize,
-    /// Number of fixes skipped because their offsets were out of range or
-    /// not on UTF-8 character boundaries (e.g. produced by a buggy plugin).
-    /// Does not include fixes skipped due to overlap with an applied fix.
+    /// Number of fixes skipped because they could not be applied: offsets out
+    /// of range or not on UTF-8 character boundaries, or a line-based fix
+    /// referencing a missing line or `old_text` (e.g. produced by a buggy
+    /// plugin). Does not include fixes skipped due to overlap with an applied
+    /// fix.
     pub skipped_invalid: usize,
 }
 
@@ -475,10 +477,11 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
 ///
 /// All fixes (both line-based and offset-based) are normalized to offset-based,
 /// then applied in reverse order to avoid index shifts. Overlapping fixes are skipped.
-/// Fixes with invalid offsets (out of range or not on UTF-8 char boundaries) are
-/// skipped and counted in [`FixApplyResult::skipped_invalid`].
+/// Fixes that cannot be applied (invalid offsets, or line-based fixes that fail
+/// normalization) are skipped and counted in [`FixApplyResult::skipped_invalid`].
 pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixApplyResult {
     let line_starts = compute_line_starts(content);
+    let mut skipped_invalid = 0;
 
     // Normalize all fixes to range-based
     let mut range_fixes: Vec<Fix> = Vec::with_capacity(fixes.len());
@@ -487,6 +490,8 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
             range_fixes.push((*fix).clone());
         } else if let Some(normalized) = normalize_line_fix(fix, content, &line_starts) {
             range_fixes.push(normalized);
+        } else {
+            skipped_invalid += 1;
         }
     }
 
@@ -515,7 +520,6 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
     });
 
     let mut fix_count = 0;
-    let mut skipped_invalid = 0;
     let mut result = content.to_string();
     let mut applied_ranges: Vec<(usize, usize)> = Vec::new();
 
@@ -710,6 +714,19 @@ mod fix_tests {
         let result = apply_fixes_to_content_detailed(content, &fixes);
         assert_eq!(result.content, "あxう;\n");
         assert_eq!(result.applied, 1);
+        assert_eq!(result.skipped_invalid, 2);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_detailed_counts_failed_line_normalization() {
+        let content = "listen 80;\n";
+        let missing_old_text = Fix::replace(1, "nonexistent", "x");
+        let out_of_range_line = Fix::replace(99, "listen", "x");
+        let fixes: Vec<&Fix> = vec![&missing_old_text, &out_of_range_line];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(result.content, content);
+        assert_eq!(result.applied, 0);
         assert_eq!(result.skipped_invalid, 2);
     }
 

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -3,7 +3,7 @@ use clap::CommandFactory;
 use colored::control;
 use nginx_lint::{
     ColorMode, IncludedFile, LintConfig, LintError, Linter, Reporter, RuleProfile, Severity,
-    apply_fixes, apply_fixes_to_content, collect_included_files,
+    apply_fixes, apply_fixes_to_content_detailed, collect_included_files,
     collect_included_files_with_context, parse_config, parse_string_with_errors,
     pre_parse_checks_from_content, syntax_errors_to_lint_errors,
 };
@@ -12,6 +12,19 @@ use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+
+/// Warn about fixes that were skipped due to invalid offsets (out of range
+/// or not on UTF-8 char boundaries), which indicates a buggy or misbehaving
+/// rule/plugin.
+fn warn_skipped_fixes(skipped: usize, path: &Path) {
+    if skipped > 0 {
+        eprintln!(
+            "Warning: skipped {} fix(es) with invalid offsets in {}",
+            skipped,
+            path.display()
+        );
+    }
+}
 
 /// Result of linting a single file
 enum FileResult {
@@ -214,17 +227,23 @@ fn process_results(
                 if fix {
                     if let Some(content) = stdin_content {
                         let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
-                        let (fixed_content, count) = apply_fixes_to_content(content, &fixes);
-                        if count > 0 {
-                            print!("{}", fixed_content);
+                        let result = apply_fixes_to_content_detailed(content, &fixes);
+                        warn_skipped_fixes(result.skipped_invalid, &path);
+                        if result.applied > 0 {
+                            print!("{}", result.content);
                         } else {
                             print!("{}", content);
                         }
                     } else {
                         match apply_fixes(&path, &errors) {
-                            Ok(count) => {
-                                if count > 0 {
-                                    eprintln!("Applied {} fix(es) to {}", count, path.display());
+                            Ok(result) => {
+                                warn_skipped_fixes(result.skipped_invalid, &path);
+                                if result.applied > 0 {
+                                    eprintln!(
+                                        "Applied {} fix(es) to {}",
+                                        result.applied,
+                                        path.display()
+                                    );
                                 }
                             }
                             Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,10 @@ pub use docs::{RuleDoc, RuleDocOwned};
 pub use linter::RuleProfile;
 pub use linter::{Fix, LintError, LintRule, Linter, Severity};
 pub use nginx_lint_common::RULE_CATEGORIES;
-pub use nginx_lint_common::{apply_fixes_to_content, compute_line_starts, normalize_line_fix};
+pub use nginx_lint_common::{
+    FixApplyResult, apply_fixes_to_content, apply_fixes_to_content_detailed, compute_line_starts,
+    normalize_line_fix,
+};
 
 #[cfg(feature = "cli")]
 pub use include::{IncludedFile, collect_included_files, collect_included_files_with_context};
@@ -135,17 +138,17 @@ pub fn pre_parse_checks_from_content(
 }
 
 /// Apply fixes to a file
-/// Returns the number of fixes applied
+/// Returns the application result, including applied and skipped fix counts
 #[cfg(feature = "cli")]
-pub fn apply_fixes(path: &Path, errors: &[LintError]) -> std::io::Result<usize> {
+pub fn apply_fixes(path: &Path, errors: &[LintError]) -> std::io::Result<FixApplyResult> {
     let content = fs::read_to_string(path)?;
     let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
 
-    let (result, fix_count) = apply_fixes_to_content(&content, &fixes);
+    let result = apply_fixes_to_content_detailed(&content, &fixes);
 
-    if fix_count > 0 {
-        fs::write(path, result)?;
+    if result.applied > 0 {
+        fs::write(path, &result.content)?;
     }
 
-    Ok(fix_count)
+    Ok(result)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -723,8 +723,8 @@ fn test_all_rule_fixtures() {
                                 .collect();
 
                             if !rule_errors_with_fixes.is_empty() {
-                                if let Ok(fix_count) = apply_fixes(temp_path, &rule_errors_with_fixes) {
-                                    if fix_count > 0 {
+                                if let Ok(fix_result) = apply_fixes(temp_path, &rule_errors_with_fixes) {
+                                    if fix_result.applied > 0 {
                                         if let (Ok(fixed_content), Ok(expected_content)) = (
                                             fs::read_to_string(temp_path),
                                             fs::read_to_string(&tc.expected_path),


### PR DESCRIPTION
apply_fixes_to_content called String::replace_range with unvalidated offsets, so a fix pointing into the middle of a multibyte character (e.g. from a buggy or malicious plugin) panicked the whole CLI. Such fixes are now skipped, same as out-of-range offsets.

Additionally, skipped fixes are no longer silent: `apply_fixes_to_content_detailed` returns a `FixApplyResult` with applied/skipped counts (invalid offsets and failed line-fix normalization; overlap skips are by design and not counted), and the CLI prints a stderr warning when any fix is skipped during `--fix`.

Note: `apply_fixes` now returns `io::Result<FixApplyResult>` instead of `io::Result<usize>` (breaking change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)