### PR TITLE
ci: show nginx version before running container tests

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -57,6 +57,13 @@ jobs:
       - name: Pull image
         run: docker pull ${{ matrix.nginx-image }}
 
+      - name: Show nginx version
+        run: |
+          docker run --rm --entrypoint /bin/sh ${{ matrix.nginx-image }} -c \
+            "nginx -v 2>&1 || openresty -v 2>&1 \
+             || /usr/local/nginx/sbin/nginx -v 2>&1 \
+             || /usr/local/openresty/bin/openresty -v 2>&1"
+
       - name: Pull CoreDNS image
         run: docker pull coredns/coredns:latest
 


### PR DESCRIPTION
Add a step to container-tests.yml that runs `nginx -v` for each matrix image before the tests, so the actual nginx core version used is visible in the CI logs. Uses the same binary fallback as detected_image_version() to support nginx, openresty, and freenginx images.