### PR TITLE
fix(ci): pin jco to 1.24.1 to unbreak TypeScript plugin build

### DIFF
--- a/plugins/typescript/nginx-lint-plugin/package.json
+++ b/plugins/typescript/nginx-lint-plugin/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "^1",
+    "@bytecodealliance/jco": "1.24.1",
     "typescript": "^6.0.0"
   }
 }

--- a/plugins/typescript/server-tokens-enabled-ts/package.json
+++ b/plugins/typescript/server-tokens-enabled-ts/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@bytecodealliance/componentize-js": "^0.21.0",
-    "@bytecodealliance/jco": "^1",
+    "@bytecodealliance/jco": "1.24.1",
     "@types/node": "^25.5.0",
     "typescript": "^6.0.0"
   }


### PR DESCRIPTION
jco 1.24.2 introduced a regression where `jco types -n <world>` no longer disambiguates a WIT package with multiple worlds, failing with "There are multiple worlds ... one must be explicitly chosen". The plugin WIT has both `plugin` and `parser` worlds, so the "Build shared library" step (`jco types wit -n plugin`) broke.

The package-lock.json is gitignored, so CI's `npm install` always pulled the latest jco 1.x (1.24.2 at the time). Pin to 1.24.1 (last known-good) in both TypeScript plugin packages.