### PR TITLE
feat(nginx-lint-plugin): add custom-runtime testing entry for workerd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,12 @@ jobs:
         run: npm install
         working-directory: plugins/typescript/nginx-lint-plugin
       - name: Transpile parser WASM to JS
-        run: npx jco transpile ../../../target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm -o wasm/parser --name parser
+        run: npx jco transpile ../../../target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm -o wasm/parser --name parser --instantiation async
+        working-directory: plugins/typescript/nginx-lint-plugin
+      # jco's --instantiation mode emits a stray `export type Result` inside the
+      # Root interface (invalid TS); the type is unused, so strip it.
+      - name: Fix jco instantiation d.ts
+        run: sed -i '/export type Result<T, E>/d' wasm/parser/parser.d.ts
         working-directory: plugins/typescript/nginx-lint-plugin
       - name: Build package
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
         working-directory: plugins/typescript/nginx-lint-plugin
       # jco's --instantiation mode emits a stray `export type Result` inside the
       # Root interface (invalid TS); the type is unused, so strip it.
+      # Upstream bug: https://github.com/bytecodealliance/jco/issues/1708
       - name: Fix jco instantiation d.ts
         run: sed -i '/export type Result<T, E>/d' wasm/parser/parser.d.ts
         working-directory: plugins/typescript/nginx-lint-plugin

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,9 @@ build-parser-wasm:
 	cd plugins/typescript/nginx-lint-plugin && \
 		npx jco transpile \
 			../../../target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm \
-			-o wasm/parser --name parser
+			-o wasm/parser --name parser --instantiation async && \
+		sed -i.bak '/export type Result<T, E>/d' wasm/parser/parser.d.ts && \
+		rm -f wasm/parser/parser.d.ts.bak
 	@echo "Parser component built and transpiled."
 
 # Run tests

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ build-with-wasm-plugins: collect-plugins
 	@echo "Done."
 
 # Build nginx-lint-parser as WASM Component for TypeScript plugin testing
+# The sed step below strips a stray, unused `export type Result` that jco's
+# --instantiation mode emits (invalid TS). Upstream bug:
+# https://github.com/bytecodealliance/jco/issues/1708
 build-parser-wasm:
 	@command -v wasm-tools >/dev/null 2>&1 || { echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"; exit 1; }
 	cargo build --manifest-path crates/nginx-lint-parser/Cargo.toml \

--- a/plugins/typescript/nginx-lint-plugin/README.md
+++ b/plugins/typescript/nginx-lint-plugin/README.md
@@ -107,6 +107,32 @@ it("handles included files", () => {
 | `assertErrorOnLine(content, line)` | Assert error on a specific line |
 | `testExamples(badConf, goodConf)` | Validate bad config produces errors, good config does not |
 
+### Custom runtimes (Cloudflare Workers / workerd)
+
+`nginx-lint-plugin/testing` loads the parser WASM with `node:fs`/`fetch`, which
+are unavailable in some runtimes — most notably Cloudflare Workers (workerd).
+For those, import `nginx-lint-plugin/testing/custom` and supply the core module
+yourself. The bundler (e.g. wrangler/esbuild) precompiles a `.wasm` import into
+a `WebAssembly.Module`, and since the parser core has no imports it can be
+instantiated synchronously:
+
+```ts
+import { createTesting } from "nginx-lint-plugin/testing/custom";
+import coreModule from "nginx-lint-plugin/wasm/parser/parser.core.wasm";
+
+const { parseConfig, PluginTestRunner } = await createTesting({
+  getCoreModule: () => coreModule,
+  instantiateCore: (module) => new WebAssembly.Instance(module),
+});
+
+// Same API as nginx-lint-plugin/testing from here on:
+const runner = new PluginTestRunner(spec, check);
+runner.assertErrors("http { server_tokens on; }", 1);
+```
+
+`createTesting` returns the same `parseConfig` and `PluginTestRunner` as the
+default entry. In Node/browser you don't need this — use `.../testing`.
+
 ## Building a Plugin
 
 ### package.json

--- a/plugins/typescript/nginx-lint-plugin/package.json
+++ b/plugins/typescript/nginx-lint-plugin/package.json
@@ -12,7 +12,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./testing": "./dist/plugin-test-runner.js"
+    "./testing": "./dist/plugin-test-runner.js",
+    "./testing/custom": "./dist/plugin-test-runner-custom.js",
+    "./wasm/parser/parser.core.wasm": "./wasm/parser/parser.core.wasm"
   },
   "files": [
     "dist",

--- a/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
@@ -1,0 +1,72 @@
+/**
+ * Custom-runtime testing entry: `nginx-lint-plugin/testing/custom`.
+ *
+ * Same API as `nginx-lint-plugin/testing`, but the caller supplies how to load
+ * the parser core WASM module. Use this where the built-in fetch/node:fs loader
+ * does not work — most notably Cloudflare Workers / workerd, where the core
+ * module is imported (and precompiled by the bundler) instead of fetched.
+ *
+ * Example (Cloudflare Workers):
+ * ```ts
+ * import { createTesting } from "nginx-lint-plugin/testing/custom";
+ * // wrangler/esbuild compiles a .wasm import to a WebAssembly.Module:
+ * import coreModule from "nginx-lint-plugin/wasm/parser/parser.core.wasm";
+ *
+ * const { parseConfig, PluginTestRunner } = await createTesting({
+ *   getCoreModule: () => coreModule,
+ *   // The core module has no imports, so it can be instantiated synchronously.
+ *   instantiateCore: (module) => new WebAssembly.Instance(module),
+ * });
+ * ```
+ */
+
+import { instantiate } from "../wasm/parser/parser.js";
+import {
+  makeParseConfig,
+  makePluginTestRunner,
+  type ParseConfigFn,
+  type PluginTestRunnerClass,
+} from "./testing-core.js";
+
+export interface CreateTestingOptions {
+  /**
+   * Compile a parser core WASM module by file name (e.g. "parser.core.wasm").
+   * Return a `WebAssembly.Module`, or a promise of one.
+   */
+  getCoreModule: (
+    path: string,
+  ) => WebAssembly.Module | Promise<WebAssembly.Module>;
+  /**
+   * Optionally override how the core module is instantiated. Defaults to
+   * `WebAssembly.instantiate`. The core module has no imports, so a synchronous
+   * `(m) => new WebAssembly.Instance(m)` is valid and keeps `parseConfig` sync.
+   */
+  instantiateCore?: (
+    module: WebAssembly.Module,
+    imports: Record<string, unknown>,
+  ) => WebAssembly.Instance | Promise<WebAssembly.Instance>;
+}
+
+export interface Testing {
+  parseConfig: ParseConfigFn;
+  PluginTestRunner: PluginTestRunnerClass;
+}
+
+/**
+ * Instantiate the parser with a caller-provided core-module loader and return
+ * the `parseConfig` + `PluginTestRunner` API.
+ */
+export async function createTesting(
+  options: CreateTestingOptions,
+): Promise<Testing> {
+  // The component declares only type-only imports (data-types/parser-types)
+  // that are never invoked at runtime, so `{}` is a safe import object.
+  const root = await instantiate(
+    options.getCoreModule,
+    {} as never,
+    options.instantiateCore,
+  );
+  const parseConfig = makeParseConfig(root.parseConfig);
+  const PluginTestRunner = makePluginTestRunner(parseConfig);
+  return { parseConfig, PluginTestRunner };
+}

--- a/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner.ts
@@ -7,12 +7,25 @@
  *
  * Usage:
  *   import { parseConfig, PluginTestRunner } from "nginx-lint-plugin/testing";
+ *
+ * This entry instantiates the parser WASM with a built-in loader (node:fs in
+ * Node, fetch in the browser). In runtimes without either — e.g. Cloudflare
+ * Workers / workerd — import `nginx-lint-plugin/testing/custom` and supply the
+ * core module yourself.
  */
 
-import { parseConfig as parseConfigWasm } from "../wasm/parser/parser.js";
-import { buildConfigFromParseOutput } from "./config-builder.js";
-import type { Config } from "./generated/interfaces/nginx-lint-plugin-config-api.js";
-import type { LintError, PluginSpec } from "./generated/interfaces/nginx-lint-plugin-types.js";
+import { instantiate } from "../wasm/parser/parser.js";
+import { makeParseConfig, makePluginTestRunner } from "./testing-core.js";
+
+// When `getCoreModule` is omitted, jco's generated glue falls back to its
+// built-in loader (node:fs in Node, fetch in the browser) — the original
+// behavior. Top-level await keeps the exported `parseConfig` synchronous for
+// callers. The component declares only type-only imports (data-types/
+// parser-types) that are never invoked, so `{}` is a safe import object.
+const { parseConfig: parseConfigWasm } = await instantiate(
+  undefined as never,
+  {} as never,
+);
 
 /**
  * Parse an nginx configuration string into a WIT-compatible Config object.
@@ -21,16 +34,7 @@ import type { LintError, PluginSpec } from "./generated/interfaces/nginx-lint-pl
  * to the production Rust parser. The DFS traversal (allDirectivesWithContext)
  * is computed on the Rust side.
  */
-export function parseConfig(
-  source: string,
-  opts?: { includeContext?: string[] },
-): Config {
-  const output = parseConfigWasm(source, opts?.includeContext ?? []);
-  return buildConfigFromParseOutput(output);
-}
-
-type SpecFn = () => PluginSpec;
-type CheckFn = (cfg: Config, path: string) => LintError[];
+export const parseConfig = makeParseConfig(parseConfigWasm);
 
 /**
  * Test runner for TypeScript nginx-lint plugins.
@@ -47,72 +51,5 @@ type CheckFn = (cfg: Config, path: string) => LintError[];
  * runner.assertErrors("http { server_tokens off; }", 0);
  * ```
  */
-export class PluginTestRunner {
-  private specFn: SpecFn;
-  private checkFn: CheckFn;
-
-  constructor(spec: SpecFn, check: CheckFn) {
-    this.specFn = spec;
-    this.checkFn = check;
-  }
-
-  /**
-   * Parse and check a config string, returning only errors from this plugin's rule.
-   */
-  checkString(content: string, opts?: { includeContext?: string[] }): LintError[] {
-    const cfg = parseConfig(content, opts);
-    const errors = this.checkFn(cfg, "test.conf");
-    const ruleName = this.specFn().name;
-    return errors.filter((e) => e.rule === ruleName);
-  }
-
-  /**
-   * Assert that parsing and checking a config produces exactly `count` errors
-   * from this plugin's rule.
-   */
-  assertErrors(content: string, count: number): void {
-    const errors = this.checkString(content);
-    if (errors.length !== count) {
-      throw new Error(
-        `Expected ${count} error(s) from "${this.specFn().name}", got ${errors.length}: ${JSON.stringify(errors, null, 2)}`,
-      );
-    }
-  }
-
-  /**
-   * Assert that a config produces at least one error on the given line.
-   */
-  assertErrorOnLine(content: string, line: number): void {
-    const errors = this.checkString(content);
-    const hasLine = errors.some((e) => e.line === line);
-    if (!hasLine) {
-      const lines = errors.map((e) => e.line);
-      throw new Error(
-        `Expected error on line ${line} from "${this.specFn().name}", got errors on lines: ${JSON.stringify(lines)}`,
-      );
-    }
-  }
-
-  /**
-   * Test bad/good config content.
-   * - `badConf` must produce at least one error.
-   * - `goodConf` must produce zero errors.
-   */
-  testExamples(badConf: string, goodConf: string): void {
-    const ruleName = this.specFn().name;
-
-    const badErrors = this.checkString(badConf);
-    if (badErrors.length === 0) {
-      throw new Error(
-        `bad.conf should produce at least one "${ruleName}" error, got none`,
-      );
-    }
-
-    const goodErrors = this.checkString(goodConf);
-    if (goodErrors.length > 0) {
-      throw new Error(
-        `good.conf should produce no "${ruleName}" errors, got: ${JSON.stringify(goodErrors, null, 2)}`,
-      );
-    }
-  }
-}
+export const PluginTestRunner = makePluginTestRunner(parseConfig);
+export type PluginTestRunner = InstanceType<typeof PluginTestRunner>;

--- a/plugins/typescript/nginx-lint-plugin/src/testing-core.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/testing-core.ts
@@ -1,0 +1,140 @@
+/**
+ * Loader-agnostic testing internals.
+ *
+ * Given the raw component `parse-config` export, this builds the high-level
+ * `parseConfig` (returns a method-based Config) and the `PluginTestRunner`
+ * class. It performs NO WASM instantiation itself, so it is shared by:
+ *   - `./plugin-test-runner.ts` (the default `nginx-lint-plugin/testing` entry,
+ *     which instantiates with the built-in fetch/fs loader), and
+ *   - `./plugin-test-runner-custom.ts` (the `nginx-lint-plugin/testing/custom`
+ *     entry, which takes a caller-supplied core module — e.g. on Cloudflare
+ *     Workers / workerd, where fetch()/node:fs are unavailable).
+ */
+
+import { buildConfigFromParseOutput } from "./config-builder.js";
+import type { Config } from "./generated/interfaces/nginx-lint-plugin-config-api.js";
+import type {
+  LintError,
+  PluginSpec,
+} from "./generated/interfaces/nginx-lint-plugin-types.js";
+import type { ParseOutput } from "../wasm/parser/interfaces/nginx-lint-plugin-parser-types.js";
+
+/** The raw component export: parse a config string into the flat ParseOutput. */
+export type WasmParseConfig = (
+  source: string,
+  includeContext: string[],
+) => ParseOutput;
+
+/** High-level parse: returns the method-based Config used by plugins. */
+export type ParseConfigFn = (
+  source: string,
+  opts?: { includeContext?: string[] },
+) => Config;
+
+type SpecFn = () => PluginSpec;
+type CheckFn = (cfg: Config, path: string) => LintError[];
+
+/** Wrap the raw component `parse-config` into the high-level `parseConfig`. */
+export function makeParseConfig(parseConfigWasm: WasmParseConfig): ParseConfigFn {
+  return function parseConfig(source, opts) {
+    const output = parseConfigWasm(source, opts?.includeContext ?? []);
+    return buildConfigFromParseOutput(output);
+  };
+}
+
+/** Instance shape of the runner produced by {@link makePluginTestRunner}. */
+export interface PluginTestRunner {
+  /** Parse and check a config string, returning only this rule's errors. */
+  checkString(content: string, opts?: { includeContext?: string[] }): LintError[];
+  /** Assert the config produces exactly `count` errors from this rule. */
+  assertErrors(content: string, count: number): void;
+  /** Assert the config produces at least one error on `line`. */
+  assertErrorOnLine(content: string, line: number): void;
+  /** Assert `badConf` produces errors and `goodConf` produces none. */
+  testExamples(badConf: string, goodConf: string): void;
+}
+
+/** Constructor of {@link PluginTestRunner}. */
+export interface PluginTestRunnerClass {
+  new (spec: SpecFn, check: CheckFn): PluginTestRunner;
+}
+
+/** Build the PluginTestRunner class bound to a given `parseConfig`. */
+export function makePluginTestRunner(
+  parseConfig: ParseConfigFn,
+): PluginTestRunnerClass {
+  // The explicit PluginTestRunnerClass return type keeps the anonymous class's
+  // private members out of re-exporters' declaration files (TS4094).
+  return class PluginTestRunner {
+    private specFn: SpecFn;
+    private checkFn: CheckFn;
+
+    constructor(spec: SpecFn, check: CheckFn) {
+      this.specFn = spec;
+      this.checkFn = check;
+    }
+
+    /**
+     * Parse and check a config string, returning only errors from this plugin's rule.
+     */
+    checkString(
+      content: string,
+      opts?: { includeContext?: string[] },
+    ): LintError[] {
+      const cfg = parseConfig(content, opts);
+      const errors = this.checkFn(cfg, "test.conf");
+      const ruleName = this.specFn().name;
+      return errors.filter((e) => e.rule === ruleName);
+    }
+
+    /**
+     * Assert that parsing and checking a config produces exactly `count` errors
+     * from this plugin's rule.
+     */
+    assertErrors(content: string, count: number): void {
+      const errors = this.checkString(content);
+      if (errors.length !== count) {
+        throw new Error(
+          `Expected ${count} error(s) from "${this.specFn().name}", got ${errors.length}: ${JSON.stringify(errors, null, 2)}`,
+        );
+      }
+    }
+
+    /**
+     * Assert that a config produces at least one error on the given line.
+     */
+    assertErrorOnLine(content: string, line: number): void {
+      const errors = this.checkString(content);
+      const hasLine = errors.some((e) => e.line === line);
+      if (!hasLine) {
+        const lines = errors.map((e) => e.line);
+        throw new Error(
+          `Expected error on line ${line} from "${this.specFn().name}", got errors on lines: ${JSON.stringify(lines)}`,
+        );
+      }
+    }
+
+    /**
+     * Test bad/good config content.
+     * - `badConf` must produce at least one error.
+     * - `goodConf` must produce zero errors.
+     */
+    testExamples(badConf: string, goodConf: string): void {
+      const ruleName = this.specFn().name;
+
+      const badErrors = this.checkString(badConf);
+      if (badErrors.length === 0) {
+        throw new Error(
+          `bad.conf should produce at least one "${ruleName}" error, got none`,
+        );
+      }
+
+      const goodErrors = this.checkString(goodConf);
+      if (goodErrors.length > 0) {
+        throw new Error(
+          `good.conf should produce no "${ruleName}" errors, got: ${JSON.stringify(goodErrors, null, 2)}`,
+        );
+      }
+    }
+  };
+}


### PR DESCRIPTION
The default `nginx-lint-plugin/testing` entry loads the parser WASM via node:fs/fetch, which don't exist in some runtimes (notably Cloudflare Workers / workerd). Add `nginx-lint-plugin/testing/custom` exposing `createTesting({ getCoreModule, instantiateCore })`, letting the caller supply the precompiled core module. The parser core has no imports, so it can be instantiated synchronously, keeping `parseConfig` sync.

- Transpile the parser with jco `--instantiation async` so the glue takes a caller-provided core module instead of self-loading it.
- Extract loader-agnostic internals into testing-core.ts (no WASM instantiation), shared by both entries, so importing the custom entry never triggers the default fetch/fs loader.
- The default `./testing` entry keeps the same public API and behavior (instantiates with jco's built-in loader); this is purely additive.
- Export the core wasm and the new entry from package.json.
- Strip a stray `export type Result` jco emits inside the Root interface in --instantiation mode (invalid TS; the type is unused).

Verified: default entry parses in Node as before; custom entry parses via a caller-supplied module with synchronous instantiation (the workerd path).

refs https://github.com/bytecodealliance/jco/issues/1708