### PR TITLE
fix(nginx-lint-plugin): ship generated type declarations in dist

### DIFF
--- a/plugins/typescript/nginx-lint-plugin/package.json
+++ b/plugins/typescript/nginx-lint-plugin/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "copy-wit": "mkdir -p wit && cp ../../../wit/nginx-lint-plugin.wit wit/",
     "generate": "jco types wit -n plugin -o src/generated",
-    "build": "npm run copy-wit && npm run generate && tsc",
+    "copy-types": "rm -rf dist/generated && cp -R src/generated dist/generated",
+    "build": "npm run copy-wit && npm run generate && tsc && npm run copy-types",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
The published package re-exported Config/Directive/LintError/PluginSpec from ./generated/interfaces/*, but tsc never copied those hand-authored .d.ts from src/generated into dist/generated (declaration inputs aren't emitted), and files only ships dist. So consumers' `import type { Config } from "nginx-lint-plugin"` failed to resolve (TS2307) — types silently degraded to `any` under skipLibCheck, giving plugin authors no autocomplete and no type checking of the Config/Directive API.

Add a copy-types build step (src/generated -> dist/generated) so the interface declarations ship. Verified: a consumer plugin now type-checks the API (bogus method -> TS2339; valid methods resolve).