### PR TITLE
ci: run independent steps in parallel using new Actions parallel syntax

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -54,8 +54,13 @@ jobs:
         with:
           shared-key: "container-tests"
 
-      - name: Pull image
-        run: docker pull ${{ matrix.nginx-image }}
+      - parallel:
+          - name: Pull image
+            run: docker pull ${{ matrix.nginx-image }}
+          - name: Pull CoreDNS image
+            run: docker pull coredns/coredns:latest
+          - name: Pull PHP-FPM image
+            run: docker pull php:8.3-fpm
 
       - name: Show nginx version
         run: |
@@ -63,12 +68,6 @@ jobs:
             "nginx -v 2>&1 || openresty -v 2>&1 \
              || /usr/local/nginx/sbin/nginx -v 2>&1 \
              || /usr/local/openresty/bin/openresty -v 2>&1"
-
-      - name: Pull CoreDNS image
-        run: docker pull coredns/coredns:latest
-
-      - name: Pull PHP-FPM image
-        run: docker pull php:8.3-fpm
 
       - name: Run container tests
         env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -220,15 +220,16 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "build-parser-wasm"
-      - name: Install wasm-tools
-        run: |
-          WASM_TOOLS_VERSION=1.245.1
-          curl -sSfL "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" \
-            | tar xz --strip-components=1 --wildcards "*/wasm-tools"
-          mv wasm-tools /usr/local/bin/
-      - name: Install shared library dependencies
-        working-directory: plugins/typescript/nginx-lint-plugin
-        run: npm install
+      - parallel:
+          - name: Install wasm-tools
+            run: |
+              WASM_TOOLS_VERSION=1.245.1
+              curl -sSfL "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" \
+                | tar xz --strip-components=1 --wildcards "*/wasm-tools"
+              mv wasm-tools /usr/local/bin/
+          - name: Install shared library dependencies
+            working-directory: plugins/typescript/nginx-lint-plugin
+            run: npm install
       - name: Build parser WASM component
         run: make build-parser-wasm
       - name: Build shared library


### PR DESCRIPTION
GitHub Actions now supports running steps concurrently within a job (https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/).

- container-tests.yml: pull the nginx, CoreDNS, and PHP-FPM images concurrently instead of sequentially; none depend on each other.
- plugins.yml (typescript-plugin): install wasm-tools and the npm dependencies concurrently; both are prerequisites for the parser WASM build but are independent of each other.