### PR TITLE
perf: replace fuel metering with epoch interruption for untrusted plugins

### DIFF
--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -124,7 +124,7 @@ static BUILTIN_PLUGINS_CACHE: std::sync::OnceLock<Vec<ComponentLintRule>> =
 /// The first call compiles all WASM modules and caches them.
 /// Subsequent calls clone from the cache, which is much faster.
 ///
-/// Builtin plugins use a trusted loader with fuel metering disabled for better performance.
+/// Builtin plugins use a trusted loader with the execution timeout disabled for better performance.
 #[cfg(feature = "wasm-builtin-plugins")]
 pub fn load_builtin_plugins() -> Result<Vec<ComponentLintRule>, PluginError> {
     // Try to get from cache first
@@ -132,7 +132,7 @@ pub fn load_builtin_plugins() -> Result<Vec<ComponentLintRule>, PluginError> {
         return Ok(cached.clone());
     }
 
-    // Get or create the loader (use trusted mode for builtin plugins - no fuel metering)
+    // Get or create the loader (use trusted mode for builtin plugins - no execution timeout)
     let loader = PLUGIN_LOADER_CACHE.get_or_init(|| {
         let cache = BUILTIN_PLUGIN_CACHE.get().cloned().unwrap_or_default();
         PluginLoader::new_trusted_with_cache(cache).unwrap_or_else(|e| {

--- a/src/plugin/component_rule.rs
+++ b/src/plugin/component_rule.rs
@@ -102,7 +102,7 @@ impl ComponentStoreData {
     ///
     /// Panics (trapped by wasmtime) if the resource table is full. This can
     /// happen if an untrusted plugin requests an excessive number of handles.
-    /// The fuel limit should prevent this in practice.
+    /// The execution timeout should prevent this in practice.
     fn push_directive(
         &mut self,
         config: Arc<Config>,
@@ -734,10 +734,9 @@ pub struct ComponentLintRule {
     engine: Engine,
     /// Memory limit in bytes
     memory_limit: u64,
-    /// Fuel limit for CPU metering (0 = unlimited)
-    fuel_limit: u64,
-    /// Whether fuel metering is enabled
-    fuel_enabled: bool,
+    /// Execution timeout per call in epoch ticks (None = no timeout, for
+    /// trusted plugins)
+    timeout_ticks: Option<u64>,
     /// Leaked static strings for LintRule trait
     name: &'static str,
     category: &'static str,
@@ -751,8 +750,7 @@ impl ComponentLintRule {
         path: PathBuf,
         component_bytes: &[u8],
         memory_limit: u64,
-        fuel_limit: u64,
-        fuel_enabled: bool,
+        timeout_ticks: Option<u64>,
     ) -> Result<Self, PluginError> {
         // Compile the component
         let component = wasmtime::component::Component::new(engine, component_bytes)
@@ -764,8 +762,7 @@ impl ComponentLintRule {
             &component,
             &path,
             memory_limit,
-            fuel_limit,
-            fuel_enabled,
+            timeout_ticks,
         )?;
         let spec = convert_plugin_spec(&spec_wit);
 
@@ -782,22 +779,19 @@ impl ComponentLintRule {
             component: Arc::new(component),
             engine: engine.clone(),
             memory_limit,
-            fuel_limit,
-            fuel_enabled,
+            timeout_ticks,
             name,
             category,
             description,
         })
     }
 
-    /// Create a store with limits and fuel
+    /// Create a store with limits and the execution deadline
     fn create_store(
         engine: &Engine,
         memory_limit: u64,
-        fuel_limit: u64,
-        fuel_enabled: bool,
-        path: &Path,
-    ) -> Result<Store<ComponentStoreData>, PluginError> {
+        timeout_ticks: Option<u64>,
+    ) -> Store<ComponentStoreData> {
         let limits = StoreLimitsBuilder::new()
             .memory_size(memory_limit as usize)
             .build();
@@ -809,12 +803,13 @@ impl ComponentLintRule {
             },
         );
         store.limiter(|data| &mut data.limits);
-        if fuel_enabled {
-            store.set_fuel(fuel_limit).map_err(|e| {
-                PluginError::execution_error(path, format!("Failed to set fuel: {}", e))
-            })?;
+        if let Some(ticks) = timeout_ticks {
+            // The loader's epoch ticker advances the engine epoch at a fixed
+            // interval; execution traps with Trap::Interrupt once the
+            // deadline is reached (wasmtime's default deadline behavior).
+            store.set_epoch_deadline(ticks);
         }
-        Ok(store)
+        store
     }
 
     /// Instantiate the component with config-api imports registered
@@ -842,10 +837,9 @@ impl ComponentLintRule {
         component: &wasmtime::component::Component,
         path: &Path,
         memory_limit: u64,
-        fuel_limit: u64,
-        fuel_enabled: bool,
+        timeout_ticks: Option<u64>,
     ) -> Result<bindings::nginx_lint::plugin::types::PluginSpec, PluginError> {
-        let mut store = Self::create_store(engine, memory_limit, fuel_limit, fuel_enabled, path)?;
+        let mut store = Self::create_store(engine, memory_limit, timeout_ticks);
         let plugin = Self::instantiate(engine, component, &mut store, path)?;
 
         plugin
@@ -859,13 +853,7 @@ impl ComponentLintRule {
         config: &Config,
         file_path: &Path,
     ) -> Result<Vec<LintError>, PluginError> {
-        let mut store = Self::create_store(
-            &self.engine,
-            self.memory_limit,
-            self.fuel_limit,
-            self.fuel_enabled,
-            &self.path,
-        )?;
+        let mut store = Self::create_store(&self.engine, self.memory_limit, self.timeout_ticks);
         let plugin = Self::instantiate(&self.engine, &self.component, &mut store, &self.path)?;
 
         // Create config resource handle
@@ -886,7 +874,8 @@ impl ComponentLintRule {
         let wit_errors = plugin
             .call_check(&mut store, config_resource, &path_str)
             .map_err(|e| {
-                if e.downcast_ref::<Trap>() == Some(&Trap::OutOfFuel) {
+                // Epoch deadline expiry surfaces as Trap::Interrupt
+                if e.downcast_ref::<Trap>() == Some(&Trap::Interrupt) {
                     PluginError::timeout(&self.path)
                 } else {
                     PluginError::execution_error(&self.path, format!("check() failed: {}", e))
@@ -1253,8 +1242,7 @@ mod tests {
             PathBuf::from("test.wasm"),
             b"not a wasm component",
             256 * 1024 * 1024,
-            10_000_000,
-            true,
+            Some(100),
         );
         assert!(matches!(result, Err(PluginError::CompileError { .. })));
     }

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -12,8 +12,12 @@ use wasmtime::{Cache, CacheConfig, Config, Engine};
 /// Memory limit for plugins (256 MB)
 const MEMORY_LIMIT_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Fuel limit for CPU metering (prevents infinite loops)
-const FUEL_LIMIT: u64 = 10_000_000_000;
+/// How often the background ticker advances the engine epoch
+const EPOCH_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Execution timeout for a single plugin call by an untrusted plugin,
+/// expressed in epoch ticks (100 ticks × 100 ms = 10 seconds)
+const TIMEOUT_TICKS: u64 = 100;
 
 /// Compilation cache configuration for the plugin loader.
 ///
@@ -59,22 +63,23 @@ fn is_component_model(bytes: &[u8]) -> Option<bool> {
 /// Plugin loader that discovers and loads WASM plugins from a directory
 pub struct PluginLoader {
     engine: Engine,
-    /// Whether fuel metering is enabled (for untrusted plugins)
-    fuel_enabled: bool,
+    /// Whether the execution timeout (epoch interruption) is enabled
+    /// (for untrusted plugins)
+    timeout_enabled: bool,
     /// Compilation cache handle, kept for reporting hit/miss statistics
     cache: Option<Cache>,
 }
 
 impl PluginLoader {
-    /// Create a new plugin loader with security constraints (fuel metering enabled)
+    /// Create a new plugin loader with security constraints (execution timeout enabled)
     pub fn new() -> Result<Self, PluginError> {
         Self::with_options(true, CompilationCache::Default)
     }
 
-    /// Create a new plugin loader for trusted plugins (fuel metering disabled for performance)
+    /// Create a new plugin loader for trusted plugins (execution timeout disabled for performance)
     ///
     /// WARNING: Only use this for trusted, builtin plugins. External plugins should use `new()`
-    /// to enable fuel metering and prevent infinite loops.
+    /// to enable the execution timeout and prevent infinite loops.
     pub fn new_trusted() -> Result<Self, PluginError> {
         Self::with_options(false, CompilationCache::Default)
     }
@@ -91,12 +96,16 @@ impl PluginLoader {
         Self::with_options(true, cache)
     }
 
-    fn with_options(enable_fuel: bool, cache: CompilationCache) -> Result<Self, PluginError> {
+    fn with_options(enable_timeout: bool, cache: CompilationCache) -> Result<Self, PluginError> {
         let cache = Self::build_cache(cache)?;
         let mut config = Config::new();
 
-        // Enable fuel-based metering only for untrusted plugins
-        config.consume_fuel(enable_fuel);
+        // Enable epoch interruption only for untrusted plugins: each check
+        // call gets a wall-clock deadline (see TIMEOUT_TICKS) so an infinite
+        // loop in a plugin cannot hang the linter. Epoch checks cost a few
+        // percent at runtime, unlike fuel metering which instruments every
+        // basic block.
+        config.epoch_interruption(enable_timeout);
         // Enable component model support for WIT-based plugins
         config.wasm_component_model(true);
         // Enable Wasm GC support (needed for GC-based languages like wado)
@@ -108,11 +117,41 @@ impl PluginLoader {
         let engine = Engine::new(&config)
             .map_err(|e| PluginError::compile_error("engine", e.to_string()))?;
 
+        if enable_timeout {
+            Self::spawn_epoch_ticker(&engine)?;
+        }
+
         Ok(Self {
             engine,
-            fuel_enabled: enable_fuel,
+            timeout_enabled: enable_timeout,
             cache,
         })
+    }
+
+    /// Spawn the background thread that advances the engine epoch at a fixed
+    /// interval. Deadlines are expressed in ticks of this interval. The
+    /// thread holds only a weak engine reference and exits once the engine
+    /// (and every rule cloned from it) has been dropped.
+    fn spawn_epoch_ticker(engine: &Engine) -> Result<(), PluginError> {
+        let weak_engine = engine.weak();
+        std::thread::Builder::new()
+            .name("nginx-lint-epoch-ticker".to_string())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(EPOCH_TICK_INTERVAL);
+                    let Some(engine) = weak_engine.upgrade() else {
+                        break;
+                    };
+                    engine.increment_epoch();
+                }
+            })
+            .map_err(|e| {
+                PluginError::execution_error(
+                    "engine",
+                    format!("Failed to spawn epoch ticker thread: {}", e),
+                )
+            })?;
+        Ok(())
     }
 
     fn build_cache(cache: CompilationCache) -> Result<Option<Cache>, PluginError> {
@@ -176,14 +215,15 @@ impl PluginLoader {
         MEMORY_LIMIT_BYTES
     }
 
-    /// Get the fuel limit for CPU metering
-    pub fn fuel_limit(&self) -> u64 {
-        if self.fuel_enabled { FUEL_LIMIT } else { 0 }
+    /// Get the execution timeout in epoch ticks, or `None` when the timeout
+    /// is disabled (trusted plugins)
+    pub fn timeout_ticks(&self) -> Option<u64> {
+        self.timeout_enabled.then_some(TIMEOUT_TICKS)
     }
 
-    /// Check if fuel metering is enabled
-    pub fn fuel_enabled(&self) -> bool {
-        self.fuel_enabled
+    /// Check if the execution timeout (epoch interruption) is enabled
+    pub fn timeout_enabled(&self) -> bool {
+        self.timeout_enabled
     }
 
     /// Load all WASM plugins from a directory
@@ -235,18 +275,12 @@ impl PluginLoader {
         path: &Path,
         component_bytes: &[u8],
     ) -> Result<ComponentLintRule, PluginError> {
-        let fuel_limit = if self.fuel_enabled {
-            self.fuel_limit()
-        } else {
-            0
-        };
         ComponentLintRule::new(
             &self.engine,
             path.to_path_buf(),
             component_bytes,
             self.memory_limit(),
-            fuel_limit,
-            self.fuel_enabled,
+            self.timeout_ticks(),
         )
     }
 }
@@ -266,6 +300,50 @@ mod tests {
     fn test_loader_creation() {
         let loader = PluginLoader::new_with_cache(CompilationCache::Disabled);
         assert!(loader.is_ok());
+    }
+
+    #[test]
+    fn test_timeout_enabled_for_untrusted() {
+        let loader = test_loader();
+        assert!(loader.timeout_enabled());
+        assert_eq!(loader.timeout_ticks(), Some(TIMEOUT_TICKS));
+    }
+
+    #[test]
+    fn test_timeout_disabled_for_trusted() {
+        let loader = PluginLoader::new_trusted_with_cache(CompilationCache::Disabled).unwrap();
+        assert!(!loader.timeout_enabled());
+        assert_eq!(loader.timeout_ticks(), None);
+    }
+
+    #[test]
+    fn test_epoch_deadline_interrupts_infinite_loop() {
+        // End-to-end check of the timeout machinery: epoch interruption
+        // compiled in, the ticker thread advancing the epoch, and the
+        // deadline trapping a spinning guest.
+        let loader = test_loader();
+        let wat = r#"(component
+            (core module $m
+                (func (export "spin") (loop $l br $l))
+            )
+            (core instance $i (instantiate $m))
+            (func (export "spin") (canon lift (core func $i "spin")))
+        )"#;
+        let component = wasmtime::component::Component::new(loader.engine(), wat).unwrap();
+        let mut store = wasmtime::Store::new(loader.engine(), ());
+        // Trap at the first tick (~100ms) to keep the test fast
+        store.set_epoch_deadline(1);
+        let linker = wasmtime::component::Linker::<()>::new(loader.engine());
+        let instance = linker.instantiate(&mut store, &component).unwrap();
+        let spin = instance
+            .get_typed_func::<(), ()>(&mut store, "spin")
+            .unwrap();
+
+        let err = spin.call(&mut store, ()).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<wasmtime::Trap>(),
+            Some(&wasmtime::Trap::Interrupt)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace fuel metering with epoch interruption as the runaway-plugin protection for untrusted (external) WASM plugins. Fuel instruments every basic block of the generated code; epoch interruption compiles in only cheap epoch checks and uses a wall-clock deadline instead.

## How it works

- The untrusted engine is built with `Config::epoch_interruption(true)`; trusted builtin loaders remain timeout-free as before
- A background ticker thread (holding only a weak engine reference, so it exits when the engine is dropped) advances the engine epoch every 100ms
- Each plugin call gets `store.set_epoch_deadline(100)` = a 10-second wall-clock timeout; expiry traps with `Trap::Interrupt`, mapped to the existing `PluginError::Timeout`
- `PluginLoader::fuel_limit()/fuel_enabled()` are replaced by `timeout_ticks()/timeout_enabled()`
- An end-to-end test compiles an infinite-loop component and asserts it traps with `Trap::Interrupt` through the ticker + deadline machinery

## Measured impact (8 external plugins, debug build)

| Metric | fuel (main) | epoch (this PR) |
|---|---|---|
| Cold compile (cache miss) | 0.89–0.94s | 0.76–0.78s (~15% faster) |
| Cached artifact size | 936 KB | 896 KB (~4% smaller) |
| Warm lint run (50 files) | ~2.2s | ~2.2s (no change) |

Honest note: warm execution time does not improve for typical lint plugins — their per-check cost is dominated by host-side work (instantiation, linker setup, config conversion), not guest execution, so fuel's per-instruction overhead was not the bottleneck there. The wins are faster compilation on cache misses, smaller cache artifacts, a more meaningful timeout unit (10s wall clock instead of an opaque instruction count), and protection whose overhead stays negligible even for compute-heavy plugins (where fuel can cost up to ~2x).

## Compatibility notes

- Timeout semantics change from deterministic (instruction count) to wall-clock (10s per check call); for lint plugins the practical behavior — "runaway plugins get killed" — is unchanged
- The compiler configuration changes, so cached artifacts for external plugins recompile once after upgrading (cache keys include the config); builtin plugins are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)