### PR TITLE
fix: report unfixable errors when running with --fix

### DIFF
--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -26,6 +26,26 @@ fn warn_skipped_fixes(skipped: usize, path: &Path) {
     }
 }
 
+/// Extend `errors` with `additional`, dropping exact duplicates.
+///
+/// Pre-parse checks and the registered syntax rules (missing-semicolon,
+/// unmatched-braces, unclosed-quote) detect the same problems; keeping both
+/// copies would report each problem twice and, under `--fix`, apply the same
+/// fix twice (e.g. inserting `;;` for one missing semicolon).
+fn extend_errors_dedup(errors: &mut Vec<LintError>, additional: Vec<LintError>) {
+    for err in additional {
+        let is_duplicate = errors.iter().any(|existing| {
+            existing.rule == err.rule
+                && existing.line == err.line
+                && existing.column == err.column
+                && existing.message == err.message
+        });
+        if !is_duplicate {
+            errors.push(err);
+        }
+    }
+}
+
 /// Resolve a path value from the config file: a relative path is resolved
 /// against the directory containing the config file.
 fn resolve_against_config_dir(path: PathBuf, config_dir: Option<&Path>) -> PathBuf {
@@ -202,88 +222,199 @@ fn lint_file(
 
     let mut result = run_lint_on_config(&config, path, &content, linter, profile);
 
-    // Merge pre-parse errors and syntax errors into lint errors
-    // TODO: pre_parse_checks (unmatched-braces, etc.) and rowan syntax-error may report
-    // the same issue. Consider deduplicating or unifying these in a future refactor.
+    // Merge pre-parse errors and syntax errors into lint errors, dropping
+    // exact duplicates (the linter's syntax rules and pre_parse_checks
+    // overlap; rowan syntax-error may also repeat).
     let FileResult::LintErrors { ref mut errors, .. } = result;
-    errors.extend(pre_parse_errors);
+    extend_errors_dedup(errors, pre_parse_errors);
     if !syntax_errors.is_empty() {
-        errors.extend(syntax_errors_to_lint_errors(&syntax_errors, &content));
+        extend_errors_dedup(
+            errors,
+            syntax_errors_to_lint_errors(&syntax_errors, &content),
+        );
     }
 
     result
 }
 
-/// Process lint results: report errors, apply fixes, and determine exit code
+/// Lint a file, apply autofixes, and re-lint the fixed content.
+///
+/// Reporting the re-lint result (instead of the pre-fix errors) means the
+/// reported errors and the exit code always describe what actually remains
+/// in the written file: positions are computed against the rewritten
+/// content, and problems left behind by fixes that failed to apply or were
+/// skipped stay visible.
+fn fix_file(
+    inc: &IncludedFile,
+    linter: &Linter,
+    lint_config: Option<&LintConfig>,
+    profile: bool,
+) -> FileResult {
+    let FileResult::LintErrors {
+        path,
+        errors,
+        ignored_count,
+        profiles,
+    } = lint_file(inc, linter, lint_config, profile);
+
+    if errors.iter().all(|e| e.fixes.is_empty()) {
+        return FileResult::LintErrors {
+            path,
+            errors,
+            ignored_count,
+            profiles,
+        };
+    }
+
+    match apply_fixes(&path, &errors) {
+        Ok(result) => {
+            warn_skipped_fixes(result.skipped_invalid, &path);
+            if result.applied == 0 {
+                // Nothing was written: the original lint results still hold.
+                return FileResult::LintErrors {
+                    path,
+                    errors,
+                    ignored_count,
+                    profiles,
+                };
+            }
+            eprintln!("Applied {} fix(es) to {}", result.applied, path.display());
+            let FileResult::LintErrors {
+                errors: remaining,
+                ignored_count: remaining_ignored,
+                ..
+            } = lint_content(
+                &result.content,
+                &path,
+                linter,
+                lint_config,
+                false,
+                inc.include_context.clone(),
+            );
+            FileResult::LintErrors {
+                path,
+                errors: remaining,
+                ignored_count: remaining_ignored,
+                profiles,
+            }
+        }
+        Err(e) => {
+            eprintln!("Error applying fixes to {}: {}", path.display(), e);
+            // Nothing was written: every error still stands.
+            FileResult::LintErrors {
+                path,
+                errors,
+                ignored_count,
+                profiles,
+            }
+        }
+    }
+}
+
+/// Apply autofixes to stdin content, print the result to stdout, and
+/// re-lint the fixed content for the stderr report and the exit code.
+fn fix_stdin(
+    result: FileResult,
+    content: &str,
+    linter: &Linter,
+    lint_config: Option<&LintConfig>,
+    initial_context: Vec<String>,
+) -> FileResult {
+    let FileResult::LintErrors {
+        path,
+        errors,
+        ignored_count,
+        profiles,
+    } = result;
+
+    let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
+    let apply_result = apply_fixes_to_content_detailed(content, &fixes);
+    warn_skipped_fixes(apply_result.skipped_invalid, &path);
+
+    if apply_result.applied == 0 {
+        // Nothing was fixed: echo the input and keep the original results.
+        print!("{}", content);
+        return FileResult::LintErrors {
+            path,
+            errors,
+            ignored_count,
+            profiles,
+        };
+    }
+
+    print!("{}", apply_result.content);
+    let FileResult::LintErrors {
+        errors: remaining,
+        ignored_count: remaining_ignored,
+        ..
+    } = lint_content(
+        &apply_result.content,
+        &path,
+        linter,
+        lint_config,
+        false,
+        initial_context,
+    );
+    FileResult::LintErrors {
+        path,
+        errors: remaining,
+        ignored_count: remaining_ignored,
+        profiles,
+    }
+}
+
+/// Process lint results: report errors and determine the exit code.
+///
+/// Under `--fix` the results have already been fixed and re-linted by
+/// `fix_file`/`fix_stdin`, so they are reported like any other lint result;
+/// in stdin mode the report goes to stderr because stdout carries the fixed
+/// content.
 fn process_results(
     results: Vec<FileResult>,
     fix: bool,
     no_fail_on_warnings: bool,
     profile: bool,
     reporter: &Reporter,
-    stdin_content: Option<&str>,
+    stdin_mode: bool,
 ) -> ExitCode {
     let mut all_errors = Vec::new();
     let mut all_profiles: Vec<RuleProfile> = Vec::new();
+    // Once the output consumer closes the stream (e.g. piping into `head`),
+    // stop reporting but still compute the exit code.
+    let mut output_closed = false;
 
     for result in results {
-        match result {
-            FileResult::LintErrors {
-                path,
-                errors,
-                ignored_count,
-                profiles,
-            } => {
-                if fix {
-                    // Errors without an autofix remain after fixing; report them
-                    // so they don't silently disappear under --fix.
-                    let unfixed: Vec<LintError> = errors
-                        .iter()
-                        .filter(|e| e.fixes.is_empty())
-                        .cloned()
-                        .collect();
-                    if let Some(content) = stdin_content {
-                        let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
-                        let result = apply_fixes_to_content_detailed(content, &fixes);
-                        warn_skipped_fixes(result.skipped_invalid, &path);
-                        if result.applied > 0 {
-                            print!("{}", result.content);
-                        } else {
-                            print!("{}", content);
-                        }
-                        // stdout carries the fixed content, so report to stderr
-                        if !unfixed.is_empty() {
-                            reporter.report_to_stderr(&unfixed, &path, ignored_count);
-                        }
-                    } else {
-                        match apply_fixes(&path, &errors) {
-                            Ok(result) => {
-                                warn_skipped_fixes(result.skipped_invalid, &path);
-                                if result.applied > 0 {
-                                    eprintln!(
-                                        "Applied {} fix(es) to {}",
-                                        result.applied,
-                                        path.display()
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                eprintln!("Error applying fixes to {}: {}", path.display(), e);
-                            }
-                        }
-                        if !unfixed.is_empty() {
-                            reporter.report(&unfixed, &path, ignored_count);
-                        }
-                    }
-                    all_errors.extend(unfixed);
-                } else {
-                    reporter.report(&errors, &path, ignored_count);
-                    all_errors.extend(errors);
-                }
-                if let Some(p) = profiles {
-                    all_profiles.extend(p);
-                }
+        let FileResult::LintErrors {
+            path,
+            errors,
+            ignored_count,
+            profiles,
+        } = result;
+
+        let report_result = if output_closed {
+            Ok(())
+        } else if fix && stdin_mode {
+            // stdout carries the fixed content, so report to stderr
+            if !errors.is_empty() || ignored_count > 0 {
+                reporter.report_to_stderr(&errors, &path, ignored_count)
+            } else {
+                Ok(())
             }
+        } else {
+            reporter.report(&errors, &path, ignored_count)
+        };
+        if let Err(e) = report_result {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                output_closed = true;
+            } else {
+                eprintln!("Error writing report: {}", e);
+                return ExitCode::from(2);
+            }
+        }
+
+        all_errors.extend(errors);
+        if let Some(p) = profiles {
+            all_profiles.extend(p);
         }
     }
 
@@ -327,12 +458,15 @@ fn lint_content(
 
     let mut result = run_lint_on_config(&parse_result, path, content, linter, profile);
 
-    // Merge pre-parse errors and syntax errors into lint errors
-    // TODO: pre_parse_checks and rowan syntax-error may overlap (see lint_file TODO)
+    // Merge pre-parse errors and syntax errors into lint errors, dropping
+    // exact duplicates (see lint_file)
     let FileResult::LintErrors { ref mut errors, .. } = result;
-    errors.extend(pre_parse_errors);
+    extend_errors_dedup(errors, pre_parse_errors);
     if !syntax_errors.is_empty() {
-        errors.extend(syntax_errors_to_lint_errors(&syntax_errors, content));
+        extend_errors_dedup(
+            errors,
+            syntax_errors_to_lint_errors(&syntax_errors, content),
+        );
     }
 
     result
@@ -635,14 +769,25 @@ pub fn run_lint(cli: Cli) -> ExitCode {
 
     // 8. Build results: stdin mode vs file mode
     let results: Vec<FileResult> = if let Some(ref content) = stdin_content {
-        vec![lint_content(
+        let result = lint_content(
             content,
             Path::new("<stdin>"),
             &linter,
             lint_config.as_ref(),
             cli.profile,
-            initial_context,
-        )]
+            initial_context.clone(),
+        );
+        if cli.fix {
+            vec![fix_stdin(
+                result,
+                content,
+                &linter,
+                lint_config.as_ref(),
+                initial_context,
+            )]
+        } else {
+            vec![result]
+        }
     } else {
         // Collect all files to lint (including files referenced by include directives)
         let mut seen_paths: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
@@ -688,10 +833,15 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         }
 
         // Lint files (parallel when not fixing and not profiling, sequential otherwise)
-        if cli.fix || cli.profile {
+        if cli.fix {
             included_files
                 .iter()
-                .map(|inc| lint_file(inc, &linter, lint_config.as_ref(), cli.profile))
+                .map(|inc| fix_file(inc, &linter, lint_config.as_ref(), cli.profile))
+                .collect()
+        } else if cli.profile {
+            included_files
+                .iter()
+                .map(|inc| lint_file(inc, &linter, lint_config.as_ref(), true))
                 .collect()
         } else {
             included_files
@@ -701,13 +851,13 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         }
     };
 
-    // 9. Process results (report/fix/exit code)
+    // 9. Process results (report/exit code)
     process_results(
         results,
         cli.fix,
         cli.no_fail_on_warnings,
         cli.profile,
         &reporter,
-        stdin_content.as_deref(),
+        stdin_mode,
     )
 }

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -235,6 +235,13 @@ fn process_results(
                 profiles,
             } => {
                 if fix {
+                    // Errors without an autofix remain after fixing; report them
+                    // so they don't silently disappear under --fix.
+                    let unfixed: Vec<LintError> = errors
+                        .iter()
+                        .filter(|e| e.fixes.is_empty())
+                        .cloned()
+                        .collect();
                     if let Some(content) = stdin_content {
                         let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
                         let result = apply_fixes_to_content_detailed(content, &fixes);
@@ -243,6 +250,10 @@ fn process_results(
                             print!("{}", result.content);
                         } else {
                             print!("{}", content);
+                        }
+                        // stdout carries the fixed content, so report to stderr
+                        if !unfixed.is_empty() {
+                            reporter.report_to_stderr(&unfixed, &path, ignored_count);
                         }
                     } else {
                         match apply_fixes(&path, &errors) {
@@ -260,11 +271,15 @@ fn process_results(
                                 eprintln!("Error applying fixes to {}: {}", path.display(), e);
                             }
                         }
+                        if !unfixed.is_empty() {
+                            reporter.report(&unfixed, &path, ignored_count);
+                        }
                     }
+                    all_errors.extend(unfixed);
                 } else {
                     reporter.report(&errors, &path, ignored_count);
+                    all_errors.extend(errors);
                 }
-                all_errors.extend(errors);
                 if let Some(p) = profiles {
                     all_profiles.extend(p);
                 }

--- a/src/reporter/errorformat.rs
+++ b/src/reporter/errorformat.rs
@@ -2,9 +2,11 @@ use crate::LintError;
 use crate::Severity;
 use crate::config::{Color, ColorConfig};
 use colored::{ColoredString, Colorize};
+use std::io::Write;
 use std::path::Path;
 
 pub(crate) fn report(
+    writer: &mut dyn Write,
     errors: &[LintError],
     path: &Path,
     colors: &ColorConfig,
@@ -47,11 +49,11 @@ pub(crate) fn report(
         )
         .bold();
 
-        println!("{}: {}: {}", location, severity_str, error.message);
+        let _ = writeln!(writer, "{}: {}: {}", location, severity_str, error.message);
     }
 
     if !errors.is_empty() || ignored_count > 0 {
-        println!();
+        let _ = writeln!(writer);
         let error_count = errors
             .iter()
             .filter(|e| e.severity == Severity::Error)
@@ -73,7 +75,7 @@ pub(crate) fn report(
         }
 
         if !parts.is_empty() {
-            println!("Found {}", parts.join(", "));
+            let _ = writeln!(writer, "Found {}", parts.join(", "));
         }
     }
 }

--- a/src/reporter/errorformat.rs
+++ b/src/reporter/errorformat.rs
@@ -11,7 +11,7 @@ pub(crate) fn report(
     path: &Path,
     colors: &ColorConfig,
     ignored_count: usize,
-) {
+) -> std::io::Result<()> {
     let path_str = path.display();
 
     let mut sorted_errors: Vec<_> = errors.iter().collect();
@@ -49,11 +49,11 @@ pub(crate) fn report(
         )
         .bold();
 
-        let _ = writeln!(writer, "{}: {}: {}", location, severity_str, error.message);
+        writeln!(writer, "{}: {}: {}", location, severity_str, error.message)?;
     }
 
     if !errors.is_empty() || ignored_count > 0 {
-        let _ = writeln!(writer);
+        writeln!(writer)?;
         let error_count = errors
             .iter()
             .filter(|e| e.severity == Severity::Error)
@@ -75,9 +75,11 @@ pub(crate) fn report(
         }
 
         if !parts.is_empty() {
-            let _ = writeln!(writer, "Found {}", parts.join(", "));
+            writeln!(writer, "Found {}", parts.join(", "))?;
         }
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/reporter/github_actions.rs
+++ b/src/reporter/github_actions.rs
@@ -2,10 +2,15 @@ use crate::LintError;
 use crate::Severity;
 use std::path::Path;
 
-pub(crate) fn report(writer: &mut dyn std::io::Write, errors: &[LintError], path: &Path) {
+pub(crate) fn report(
+    writer: &mut dyn std::io::Write,
+    errors: &[LintError],
+    path: &Path,
+) -> std::io::Result<()> {
     for line in format(errors, path) {
-        let _ = writeln!(writer, "{}", line);
+        writeln!(writer, "{}", line)?;
     }
+    Ok(())
 }
 
 pub(crate) fn format(errors: &[LintError], path: &Path) -> Vec<String> {

--- a/src/reporter/github_actions.rs
+++ b/src/reporter/github_actions.rs
@@ -2,9 +2,9 @@ use crate::LintError;
 use crate::Severity;
 use std::path::Path;
 
-pub(crate) fn report(errors: &[LintError], path: &Path) {
+pub(crate) fn report(writer: &mut dyn std::io::Write, errors: &[LintError], path: &Path) {
     for line in format(errors, path) {
-        println!("{}", line);
+        let _ = writeln!(writer, "{}", line);
     }
 }
 

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -21,8 +21,8 @@ pub(crate) fn report(
     errors: &[LintError],
     path: &Path,
     ignored_count: usize,
-) {
-    let _ = writeln!(writer, "{}", format(errors, path, ignored_count));
+) -> std::io::Result<()> {
+    writeln!(writer, "{}", format(errors, path, ignored_count))
 }
 
 pub(crate) fn format(errors: &[LintError], path: &Path, ignored_count: usize) -> String {

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -16,8 +16,13 @@ struct Summary {
     ignored: usize,
 }
 
-pub(crate) fn report(errors: &[LintError], path: &Path, ignored_count: usize) {
-    println!("{}", format(errors, path, ignored_count));
+pub(crate) fn report(
+    writer: &mut dyn std::io::Write,
+    errors: &[LintError],
+    path: &Path,
+    ignored_count: usize,
+) {
+    let _ = writeln!(writer, "{}", format(errors, path, ignored_count));
 }
 
 pub(crate) fn format(errors: &[LintError], path: &Path, ignored_count: usize) -> String {

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -31,14 +31,26 @@ impl Reporter {
         Self { format, colors }
     }
 
-    pub fn report(&self, errors: &[LintError], path: &Path, ignored_count: usize) {
-        self.report_to(&mut std::io::stdout().lock(), errors, path, ignored_count);
+    /// Report to stdout. Returns any write error so the caller can react
+    /// (e.g. a broken pipe, or a full disk truncating JSON output).
+    pub fn report(
+        &self,
+        errors: &[LintError],
+        path: &Path,
+        ignored_count: usize,
+    ) -> std::io::Result<()> {
+        self.report_to(&mut std::io::stdout().lock(), errors, path, ignored_count)
     }
 
     /// Report to stderr instead of stdout. Used in `--fix` stdin mode, where
     /// stdout carries the fixed content.
-    pub fn report_to_stderr(&self, errors: &[LintError], path: &Path, ignored_count: usize) {
-        self.report_to(&mut std::io::stderr().lock(), errors, path, ignored_count);
+    pub fn report_to_stderr(
+        &self,
+        errors: &[LintError],
+        path: &Path,
+        ignored_count: usize,
+    ) -> std::io::Result<()> {
+        self.report_to(&mut std::io::stderr().lock(), errors, path, ignored_count)
     }
 
     fn report_to(
@@ -47,7 +59,7 @@ impl Reporter {
         errors: &[LintError],
         path: &Path,
         ignored_count: usize,
-    ) {
+    ) -> std::io::Result<()> {
         match self.format {
             OutputFormat::ErrorFormat => {
                 errorformat::report(writer, errors, path, &self.colors, ignored_count)

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -32,12 +32,28 @@ impl Reporter {
     }
 
     pub fn report(&self, errors: &[LintError], path: &Path, ignored_count: usize) {
+        self.report_to(&mut std::io::stdout().lock(), errors, path, ignored_count);
+    }
+
+    /// Report to stderr instead of stdout. Used in `--fix` stdin mode, where
+    /// stdout carries the fixed content.
+    pub fn report_to_stderr(&self, errors: &[LintError], path: &Path, ignored_count: usize) {
+        self.report_to(&mut std::io::stderr().lock(), errors, path, ignored_count);
+    }
+
+    fn report_to(
+        &self,
+        writer: &mut dyn std::io::Write,
+        errors: &[LintError],
+        path: &Path,
+        ignored_count: usize,
+    ) {
         match self.format {
             OutputFormat::ErrorFormat => {
-                errorformat::report(errors, path, &self.colors, ignored_count)
+                errorformat::report(writer, errors, path, &self.colors, ignored_count)
             }
-            OutputFormat::Json => json::report(errors, path, ignored_count),
-            OutputFormat::GithubActions => github_actions::report(errors, path),
+            OutputFormat::Json => json::report(writer, errors, path, ignored_count),
+            OutputFormat::GithubActions => github_actions::report(writer, errors, path),
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2739,10 +2739,12 @@ fn test_why_command_omits_applies_to_for_unversioned_rule() {
 // CLI --fix tests - unfixable errors must still be reported
 // ============================================================================
 
-/// Config with a fixable error (unmatched brace gets a closing-brace fix)
-/// and an unfixable one (the resulting rowan syntax error has no fix).
+/// Config with a fixable warning (inconsistent indent) and an unfixable
+/// error (the stray `;;` produces a rowan syntax error that has no fix and
+/// survives `--fix`).
 #[cfg(feature = "cli")]
-const UNFIXABLE_CONFIG: &str = "events {\n    worker_connections 1024;\n";
+const UNFIXABLE_CONFIG: &str =
+    "events {\n    worker_connections 1024;\n      multi_accept on;;\n}\n";
 
 #[cfg(feature = "cli")]
 #[test]
@@ -2832,5 +2834,105 @@ fn test_fix_exits_zero_when_all_errors_fixed() {
         "exit code should be zero when all errors were fixed; stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// When applying fixes fails (e.g. read-only file), nothing was fixed, so
+/// every error must still be reported and the exit code must be non-zero.
+#[cfg(all(feature = "cli", unix))]
+#[test]
+fn test_fix_unwritable_file_keeps_errors_and_fails() {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(b"events {\n    worker_connections 1024\n}\n")
+        .unwrap();
+    std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o444)).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", file.path().to_str().unwrap()])
+        .output()
+        .expect("Failed to run nginx-lint --fix");
+
+    std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("missing-semicolon"),
+        "errors must still be reported when fixes could not be written; got:\n{}",
+        stdout
+    );
+    assert!(
+        !output.status.success(),
+        "exit code must be non-zero when fixes could not be written"
+    );
+}
+
+/// The same problem detected twice (registered syntax rule + pre-parse
+/// check) must apply its fix only once: `listen 80` becomes `listen 80;`,
+/// not `listen 80;;`.
+#[cfg(feature = "cli")]
+#[test]
+fn test_fix_applies_duplicate_reported_fix_once() {
+    use std::io::Write;
+    use std::process::Command;
+
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(b"events {\n    worker_connections 1024\n}\n")
+        .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", file.path().to_str().unwrap()])
+        .output()
+        .expect("Failed to run nginx-lint --fix");
+
+    let fixed = std::fs::read_to_string(file.path()).unwrap();
+    assert!(
+        fixed.contains("worker_connections 1024;") && !fixed.contains("1024;;"),
+        "the missing-semicolon fix must be applied exactly once; got:\n{}",
+        fixed
+    );
+    assert!(
+        output.status.success(),
+        "exit code should be zero after everything was fixed; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The report printed by --fix must describe the file as written: running a
+/// plain lint on the fixed file afterwards must produce the identical
+/// report (same errors, same positions).
+#[cfg(feature = "cli")]
+#[test]
+fn test_fix_reports_positions_of_fixed_file() {
+    use std::io::Write;
+    use std::process::Command;
+
+    // Unclosed `map` block: the inserted closing brace shifts every
+    // following line, so stale (pre-fix) positions would not survive the
+    // comparison below.
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(
+        b"http {\n    map $a $b {\n        default 1;\n\n    server {\n        listen 80;\n    }\n}\n",
+    )
+    .unwrap();
+
+    let fix_output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", file.path().to_str().unwrap()])
+        .output()
+        .expect("Failed to run nginx-lint --fix");
+
+    let relint_output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .arg(file.path().to_str().unwrap())
+        .output()
+        .expect("Failed to run nginx-lint");
+
+    assert_eq!(
+        String::from_utf8_lossy(&fix_output.stdout),
+        String::from_utf8_lossy(&relint_output.stdout),
+        "--fix must report exactly what a plain lint of the fixed file reports"
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2734,3 +2734,103 @@ fn test_why_command_omits_applies_to_for_unversioned_rule() {
         stderr
     );
 }
+
+// ============================================================================
+// CLI --fix tests - unfixable errors must still be reported
+// ============================================================================
+
+/// Config with a fixable error (unmatched brace gets a closing-brace fix)
+/// and an unfixable one (the resulting rowan syntax error has no fix).
+#[cfg(feature = "cli")]
+const UNFIXABLE_CONFIG: &str = "events {\n    worker_connections 1024;\n";
+
+#[cfg(feature = "cli")]
+#[test]
+fn test_fix_reports_unfixable_errors() {
+    use std::io::Write;
+    use std::process::Command;
+
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(UNFIXABLE_CONFIG.as_bytes()).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", file.path().to_str().unwrap()])
+        .output()
+        .expect("Failed to run nginx-lint --fix");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("syntax-error"),
+        "unfixable errors should still be reported with --fix; got:\n{}",
+        stdout
+    );
+    assert!(
+        !output.status.success(),
+        "exit code should be non-zero when unfixable errors remain"
+    );
+}
+
+#[cfg(feature = "cli")]
+#[test]
+fn test_fix_stdin_reports_unfixable_errors_to_stderr() {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to run nginx-lint --fix -");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(UNFIXABLE_CONFIG.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // stdout carries only the fixed content; the report goes to stderr
+    assert!(
+        stdout.contains("worker_connections 1024;"),
+        "stdout should contain the fixed content; got:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("syntax-error"),
+        "the report must not be mixed into the fixed content on stdout; got:\n{}",
+        stdout
+    );
+    assert!(
+        stderr.contains("syntax-error"),
+        "unfixable errors should be reported to stderr in stdin mode; got:\n{}",
+        stderr
+    );
+}
+
+#[cfg(feature = "cli")]
+#[test]
+fn test_fix_exits_zero_when_all_errors_fixed() {
+    use std::io::Write;
+    use std::process::Command;
+
+    // Only an inconsistent-indent warning, which has an autofix
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(b"events {\n    worker_connections 1024;\n      multi_accept on;\n}\n")
+        .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["--fix", file.path().to_str().unwrap()])
+        .output()
+        .expect("Failed to run nginx-lint --fix");
+
+    assert!(
+        output.status.success(),
+        "exit code should be zero when all errors were fixed; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Previously, --fix applied autofixes but never reported the errors that have no autofix, so they silently disappeared compared to a plain lint run.

- Report errors without fixes after applying autofixes, matching the "report remaining problems" behavior of tools like eslint --fix
- In stdin mode, send the report to stderr so stdout stays clean for the fixed content (adds Reporter::report_to_stderr and makes the formatters writer-based)
- Exit code with --fix now reflects only the remaining unfixed errors: exit 0 when everything was fixed (previously always 1)