### PR TITLE
perf: build only enabled builtin WASM plugins (lazy loading + --rule-only pre-filtering)

### DIFF
--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -771,6 +771,8 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         }
 
         let keep: HashSet<&str> = cli.rule_only.iter().map(String::as_str).collect();
+        // Builtin rules were already filtered inside the constructor; this
+        // only prunes the external plugins loaded above.
         linter.remove_rules_by_name(|name| !keep.contains(name));
         // Surface the *filtered-out* external plugins to the ignore-comment
         // parser so existing `# nginx-lint:ignore <other-rule>` directives

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -641,8 +641,21 @@ pub fn run_lint(cli: Cli) -> ExitCode {
     #[cfg(feature = "wasm-builtin-plugins")]
     nginx_lint::plugin::builtin::configure_builtin_plugin_cache(compilation_cache.clone());
 
+    // Pass --rule-only to the linter constructor so excluded builtin rules
+    // are never constructed (WASM builtins outside the set are not even
+    // compiled). External plugins are filtered after loading instead: their
+    // rule names are only known once they are compiled.
+    let rule_only: Option<std::collections::HashSet<String>> = if cli.rule_only.is_empty() {
+        None
+    } else {
+        Some(cli.rule_only.iter().cloned().collect())
+    };
     #[allow(unused_mut)]
-    let mut linter = Linter::with_config(lint_config.as_ref(), include_prefix.as_deref());
+    let mut linter = Linter::with_config_and_rule_only(
+        lint_config.as_ref(),
+        include_prefix.as_deref(),
+        rule_only.as_ref(),
+    );
 
     // Show builtin plugins in verbose mode
     #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
@@ -698,11 +711,12 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         }
     }
 
-    // Apply --rule-only filter: keep only the requested rules, validate that
-    // every requested name corresponds to a registered rule, and surface the
-    // filtered-out rules to the ignore-comment parser so existing
-    // `# nginx-lint:ignore <other-rule>` directives keep working.
+    // Finish the --rule-only handling: builtin rules were already filtered
+    // inside the linter constructor; validate that every requested name
+    // corresponds to a rule this run could load, and prune the external
+    // plugins that were loaded above.
     if !cli.rule_only.is_empty() {
+        // Kept builtin rules plus every external plugin
         let registered = linter.rule_names();
 
         // Split unknown names into "exists but not loaded" vs "no such rule"
@@ -740,8 +754,15 @@ pub fn run_lint(cli: Cli) -> ExitCode {
                     not_loaded.join(", ")
                 );
             }
-            let mut available: Vec<&str> = registered.iter().map(String::as_str).collect();
+            // Rules the filter excluded are inactive, not registered; list
+            // them too so the user sees every name --rule-only accepts.
+            let mut available: Vec<&str> = registered
+                .iter()
+                .chain(linter.inactive_rule_names())
+                .map(String::as_str)
+                .collect();
             available.sort();
+            available.dedup();
             eprintln!("Loaded rules:");
             for name in &available {
                 eprintln!("  - {}", name);
@@ -751,15 +772,18 @@ pub fn run_lint(cli: Cli) -> ExitCode {
 
         let keep: HashSet<&str> = cli.rule_only.iter().map(String::as_str).collect();
         linter.remove_rules_by_name(|name| !keep.contains(name));
-        // Surface *filtered-out* rules to the ignore-comment parser so
-        // existing `# nginx-lint:ignore <other-rule>` directives stay quiet
-        // (valid names + dormant for unused-warning suppression). The kept
-        // rules are intentionally excluded — their own unused-ignore
-        // directives must still produce warnings.
-        let inactive: HashSet<String> = registered
-            .into_iter()
-            .filter(|name| !keep.contains(name.as_str()))
-            .collect();
+        // Surface the *filtered-out* external plugins to the ignore-comment
+        // parser so existing `# nginx-lint:ignore <other-rule>` directives
+        // stay quiet (valid names + dormant for unused-warning suppression);
+        // filtered-out builtin rules are already inactive from the linter
+        // constructor. The kept rules are intentionally excluded — their own
+        // unused-ignore directives must still produce warnings.
+        let mut inactive = linter.inactive_rule_names().clone();
+        inactive.extend(
+            registered
+                .into_iter()
+                .filter(|name| !keep.contains(name.as_str())),
+        );
         linter.set_inactive_rules(inactive);
 
         if cli.verbose {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -128,6 +128,27 @@ impl Linter {
     }
 
     pub fn with_config(config: Option<&LintConfig>, include_prefix: Option<&Path>) -> Self {
+        Self::with_config_and_rule_only(config, include_prefix, None)
+    }
+
+    /// Like [`with_config`](Self::with_config), but additionally restricted
+    /// to the given rule names (the CLI's `--rule-only`).
+    ///
+    /// The restriction is applied *before* rules are constructed, so builtin
+    /// rules outside the set are never built — in particular, WASM builtin
+    /// plugins outside the set are never compiled. Rules that the config
+    /// enables but the set excludes are recorded as inactive, so
+    /// ignore-comment parsing keeps recognising them (see
+    /// [`set_inactive_rules`](Self::set_inactive_rules)).
+    ///
+    /// The filter only covers builtin rules; external plugins are loaded by
+    /// the CLI after this and must be filtered there (their names are not
+    /// known until they are compiled).
+    pub fn with_config_and_rule_only(
+        config: Option<&LintConfig>,
+        include_prefix: Option<&Path>,
+        rule_only: Option<&HashSet<String>>,
+    ) -> Self {
         #[cfg(feature = "cli")]
         use crate::rules::IncludePathExists;
         use crate::rules::{
@@ -136,11 +157,31 @@ impl Linter {
 
         let mut linter = Self::new();
 
-        let is_enabled = |name: &str| {
+        let enabled_in_config = |name: &str| {
             config
                 .map(|c| c.is_rule_enabled(name))
                 .unwrap_or_else(|| !LintConfig::DISABLED_BY_DEFAULT.contains(&name))
         };
+        let kept = |name: &str| rule_only.is_none_or(|set| set.contains(name));
+        let is_enabled = |name: &str| enabled_in_config(name) && kept(name);
+
+        // Builtin rules that the config enables but the rule-only set
+        // excludes would have been registered: record them as inactive so
+        // their `# nginx-lint:ignore` directives neither warn as unknown
+        // rules nor as unused. Computed by name over the builtin catalog —
+        // this must not construct (or compile) the excluded rules.
+        if rule_only.is_some() {
+            #[allow(unused_mut)]
+            let mut catalog: Vec<&str> = LintConfig::NATIVE_RULE_NAMES.to_vec();
+            #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
+            catalog.extend_from_slice(crate::plugin::BUILTIN_PLUGIN_NAMES);
+            linter.inactive_rules.extend(
+                catalog
+                    .into_iter()
+                    .filter(|name| enabled_in_config(name) && !kept(name))
+                    .map(String::from),
+            );
+        }
 
         // Syntax rules
         if is_enabled("unmatched-braces") {
@@ -409,6 +450,14 @@ impl Linter {
         self.inactive_rules = names;
     }
 
+    /// Rule names currently registered as inactive (see
+    /// [`set_inactive_rules`](Self::set_inactive_rules)): rules excluded by
+    /// version filtering or by the rule-only restriction of
+    /// [`with_config_and_rule_only`](Self::with_config_and_rule_only).
+    pub fn inactive_rule_names(&self) -> &HashSet<String> {
+        &self.inactive_rules
+    }
+
     /// Names recognised by the ignore-comment parser: registered rules plus
     /// any inactive rules supplied via [`set_inactive_rules`].
     fn valid_rule_names_for_ignore(&self) -> HashSet<String> {
@@ -575,6 +624,48 @@ pub struct RuleProfile {
 impl Default for Linter {
     fn default() -> Self {
         Self::with_default_rules()
+    }
+}
+
+#[cfg(test)]
+mod rule_only_tests {
+    use super::*;
+
+    #[test]
+    fn rule_only_registers_only_requested_rules() {
+        let only: HashSet<String> = ["indent".to_string()].into();
+        let linter = Linter::with_config_and_rule_only(None, None, Some(&only));
+        assert_eq!(linter.rule_names(), only);
+    }
+
+    #[test]
+    fn rule_only_records_excluded_enabled_rules_as_inactive() {
+        let only: HashSet<String> = ["indent".to_string()].into();
+        let linter = Linter::with_config_and_rule_only(None, None, Some(&only));
+        let inactive = linter.inactive_rule_names();
+        // Excluded default-enabled rules become inactive so their ignore
+        // comments keep parsing...
+        assert!(inactive.contains("unmatched-braces"));
+        // ...the kept rule must NOT be inactive (its own unused-ignore
+        // directives must still warn)...
+        assert!(!inactive.contains("indent"));
+        // ...and rules the config disables anyway were never going to run,
+        // so they are not inactive either (matching the previous behavior
+        // where inactive was computed from the registered set).
+        for name in LintConfig::DISABLED_BY_DEFAULT {
+            assert!(
+                !inactive.contains(*name),
+                "disabled-by-default rule {} must not be marked inactive",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn no_rule_only_keeps_inactive_empty() {
+        let linter = Linter::with_config_and_rule_only(None, None, None);
+        assert!(linter.rule_names().contains("indent"));
+        assert!(linter.inactive_rule_names().is_empty());
     }
 }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -284,35 +284,35 @@ impl Linter {
             }
         }
 
-        // Load WASM builtin plugins when wasm-builtin-plugins is enabled but native-builtin-plugins is not
+        // Load WASM builtin plugins when wasm-builtin-plugins is enabled but native-builtin-plugins is not.
+        // Filtering happens before loading so that disabled plugins (and the
+        // ones replaced by a configured native implementation) are never
+        // compiled at all.
         #[cfg(all(
             feature = "wasm-builtin-plugins",
             not(feature = "native-builtin-plugins")
         ))]
         {
-            use crate::plugin::builtin::load_builtin_plugins;
+            use crate::plugin::builtin::load_builtin_plugins_filtered;
 
-            if let Ok(plugins) = load_builtin_plugins() {
+            let wanted = |name: &str| {
+                // Skip invalid-directive-context if native implementation is used
+                if name == "invalid-directive-context" && use_native_invalid_directive_context {
+                    return false;
+                }
+                // Skip block-lines if configured max_block_lines is used
+                if name == "block-lines" && use_configured_block_lines {
+                    return false;
+                }
+                // Skip directive-inheritance if configured excluded/additional is used
+                if name == "directive-inheritance" && use_configured_directive_inheritance {
+                    return false;
+                }
+                is_enabled(name)
+            };
+            if let Ok(plugins) = load_builtin_plugins_filtered(wanted) {
                 for plugin in plugins {
-                    // Skip invalid-directive-context if native implementation is used
-                    if plugin.name() == "invalid-directive-context"
-                        && use_native_invalid_directive_context
-                    {
-                        continue;
-                    }
-                    // Skip block-lines if configured max_block_lines is used
-                    if plugin.name() == "block-lines" && use_configured_block_lines {
-                        continue;
-                    }
-                    // Skip directive-inheritance if configured excluded/additional is used
-                    if plugin.name() == "directive-inheritance"
-                        && use_configured_directive_inheritance
-                    {
-                        continue;
-                    }
-                    if is_enabled(plugin.name()) {
-                        linter.add_rule(Box::new(plugin));
-                    }
+                    linter.add_rule(Box::new(plugin));
                 }
             }
         }

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -323,6 +323,23 @@ mod tests {
         );
     }
 
+    /// Every loaded builtin's `spec()` name must match its `PLUGIN_ENTRIES`
+    /// table name: the enabled/disabled filter operates on the table name,
+    /// so a mismatch would make the rule impossible to filter under the
+    /// name it reports errors as. The load path only checks this with a
+    /// `debug_assert`; this test covers release builds too.
+    #[test]
+    fn test_loaded_spec_names_match_table_names() {
+        super::configure_builtin_plugin_cache(crate::plugin::CompilationCache::Disabled);
+
+        let rules = load_builtin_plugins().expect("builtin load should succeed");
+        let spec_names: Vec<&str> = rules.iter().map(|rule| rule.name()).collect();
+        assert_eq!(
+            spec_names, BUILTIN_PLUGIN_NAMES,
+            "spec() names must match PLUGIN_ENTRIES/BUILTIN_PLUGIN_NAMES in order"
+        );
+    }
+
     /// Filtered loading must compile only the requested plugins and return
     /// them in declaration order regardless of the filter's own ordering.
     #[test]

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -5,6 +5,8 @@
 
 #[cfg(feature = "wasm-builtin-plugins")]
 use super::{ComponentLintRule, PluginError, PluginLoader};
+#[cfg(feature = "wasm-builtin-plugins")]
+use crate::linter::LintRule;
 
 /// Embedded WASM bytes for builtin plugins
 #[cfg(feature = "wasm-builtin-plugins")]
@@ -113,27 +115,23 @@ pub fn configure_builtin_plugin_cache(cache: super::CompilationCache) {
     let _ = BUILTIN_PLUGIN_CACHE.set(cache);
 }
 
-/// Global cache for compiled builtin plugins
-/// This avoids recompiling WASM modules on every Linter creation
-#[cfg(feature = "wasm-builtin-plugins")]
-static BUILTIN_PLUGINS_CACHE: std::sync::OnceLock<Vec<ComponentLintRule>> =
-    std::sync::OnceLock::new();
-
-/// Load all builtin plugins (with caching)
+/// Per-plugin cache of compiled builtin plugins, keyed by plugin name.
 ///
-/// The first call compiles all WASM modules and caches them.
-/// Subsequent calls clone from the cache, which is much faster.
-///
-/// Builtin plugins use a trusted loader with the execution timeout disabled for better performance.
+/// Compiling a WASM module dominates load time, so each builtin is compiled
+/// at most once per process, on first request. Caching per plugin (rather
+/// than the whole set at once) lets [`load_builtin_plugins_filtered`] skip
+/// plugins the current config disables without poisoning later calls that
+/// need a different subset.
 #[cfg(feature = "wasm-builtin-plugins")]
-pub fn load_builtin_plugins() -> Result<Vec<ComponentLintRule>, PluginError> {
-    // Try to get from cache first
-    if let Some(cached) = BUILTIN_PLUGINS_CACHE.get() {
-        return Ok(cached.clone());
-    }
+static BUILTIN_PLUGINS_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<&'static str, ComponentLintRule>>,
+> = std::sync::OnceLock::new();
 
-    // Get or create the loader (use trusted mode for builtin plugins - no execution timeout)
-    let loader = PLUGIN_LOADER_CACHE.get_or_init(|| {
+/// Get or create the shared trusted loader for builtin plugins
+/// (no execution timeout; the engine is expensive to create)
+#[cfg(feature = "wasm-builtin-plugins")]
+fn plugin_loader() -> &'static PluginLoader {
+    PLUGIN_LOADER_CACHE.get_or_init(|| {
         let cache = BUILTIN_PLUGIN_CACHE.get().cloned().unwrap_or_default();
         PluginLoader::new_trusted_with_cache(cache).unwrap_or_else(|e| {
             // Builtin plugins are embedded and must load even when the
@@ -148,79 +146,197 @@ pub fn load_builtin_plugins() -> Result<Vec<ComponentLintRule>, PluginError> {
             PluginLoader::new_trusted_with_cache(super::CompilationCache::Disabled)
                 .expect("Failed to create PluginLoader")
         })
-    });
-
-    // Compile plugins
-    let plugins = compile_builtin_plugins(loader)?;
-
-    // Try to store in cache (ignore if another thread beat us)
-    let _ = BUILTIN_PLUGINS_CACHE.set(plugins.clone());
-
-    Ok(plugins)
+    })
 }
 
-/// Compile all builtin plugins from embedded WASM bytes
+/// Load all builtin plugins (with caching)
+///
+/// Each plugin is compiled at most once per process; subsequent calls clone
+/// from the cache, which is much faster.
+///
+/// Builtin plugins use a trusted loader with the execution timeout disabled for better performance.
 #[cfg(feature = "wasm-builtin-plugins")]
-fn compile_builtin_plugins(loader: &PluginLoader) -> Result<Vec<ComponentLintRule>, PluginError> {
+pub fn load_builtin_plugins() -> Result<Vec<ComponentLintRule>, PluginError> {
+    load_builtin_plugins_filtered(|_| true)
+}
+
+/// Load the builtin plugins whose name passes `filter`, in declaration order.
+///
+/// Plugins rejected by the filter are not compiled at all, so a config that
+/// disables most builtin rules only pays compilation (or cache
+/// deserialization) for the rules it actually runs. Accepted plugins are
+/// compiled once per process and cached individually; a later call with a
+/// broader filter compiles only the plugins not yet cached.
+#[cfg(feature = "wasm-builtin-plugins")]
+pub fn load_builtin_plugins_filtered(
+    filter: impl Fn(&str) -> bool,
+) -> Result<Vec<ComponentLintRule>, PluginError> {
     use std::path::PathBuf;
 
-    let plugin_entries: &[(&str, &[u8])] = &[
-        ("server-tokens-enabled", embedded::SERVER_TOKENS_ENABLED),
-        ("autoindex-enabled", embedded::AUTOINDEX_ENABLED),
-        ("gzip-not-enabled", embedded::GZIP_NOT_ENABLED),
-        ("duplicate-directive", embedded::DUPLICATE_DIRECTIVE),
-        ("space-before-semicolon", embedded::SPACE_BEFORE_SEMICOLON),
-        ("trailing-whitespace", embedded::TRAILING_WHITESPACE),
-        ("block-lines", embedded::BLOCK_LINES),
-        ("proxy-pass-domain", embedded::PROXY_PASS_DOMAIN),
-        (
-            "upstream-server-no-resolve",
-            embedded::UPSTREAM_SERVER_NO_RESOLVE,
-        ),
-        ("directive-inheritance", embedded::DIRECTIVE_INHERITANCE),
-        ("root-in-location", embedded::ROOT_IN_LOCATION),
-        (
-            "alias-location-slash-mismatch",
-            embedded::ALIAS_LOCATION_SLASH_MISMATCH,
-        ),
-        ("proxy-pass-with-uri", embedded::PROXY_PASS_WITH_URI),
-        ("proxy-keepalive", embedded::PROXY_KEEPALIVE),
-        ("try-files-with-proxy", embedded::TRY_FILES_WITH_PROXY),
-        ("if-is-evil-in-location", embedded::IF_IS_EVIL_IN_LOCATION),
-        ("unreachable-location", embedded::UNREACHABLE_LOCATION),
-        ("missing-error-log", embedded::MISSING_ERROR_LOG),
-        ("deprecated-ssl-protocol", embedded::DEPRECATED_SSL_PROTOCOL),
-        ("weak-ssl-ciphers", embedded::WEAK_SSL_CIPHERS),
-        (
-            "invalid-directive-context",
-            embedded::INVALID_DIRECTIVE_CONTEXT,
-        ),
-        ("map-missing-default", embedded::MAP_MISSING_DEFAULT),
-        ("ssl-on-deprecated", embedded::SSL_ON_DEPRECATED),
-        ("listen-http2-deprecated", embedded::LISTEN_HTTP2_DEPRECATED),
-        (
-            "proxy-missing-host-header",
-            embedded::PROXY_MISSING_HOST_HEADER,
-        ),
-        (
-            "client-max-body-size-not-set",
-            embedded::CLIENT_MAX_BODY_SIZE_NOT_SET,
-        ),
-        ("nginx-rift", embedded::NGINX_RIFT),
-    ];
-
-    // Compile plugins in parallel: the serial phases of each component's
-    // compilation overlap across plugins, which speeds up the first run /
-    // cache misses. Order is preserved.
-    use rayon::prelude::*;
-    let results: Vec<Result<ComponentLintRule, PluginError>> = plugin_entries
-        .par_iter()
-        .map(|(name, bytes)| {
-            loader.load_component_from_bytes(&PathBuf::from(format!("builtin:{}", name)), bytes)
-        })
+    let selected: Vec<(&'static str, &'static [u8])> = PLUGIN_ENTRIES
+        .iter()
+        .copied()
+        .filter(|(name, _)| filter(name))
         .collect();
 
-    // Fold serially so a failure surfaces the first failing plugin in
-    // declaration order, keeping error reports deterministic
-    results.into_iter().collect()
+    let cache = BUILTIN_PLUGINS_CACHE.get_or_init(Default::default);
+    let mut rules: std::collections::HashMap<&'static str, ComponentLintRule> = {
+        let cache = cache.lock().expect("builtin plugin cache poisoned");
+        selected
+            .iter()
+            .filter_map(|(name, _)| cache.get(name).map(|rule| (*name, rule.clone())))
+            .collect()
+    };
+
+    let missing: Vec<(&'static str, &'static [u8])> = selected
+        .iter()
+        .copied()
+        .filter(|(name, _)| !rules.contains_key(name))
+        .collect();
+
+    if !missing.is_empty() {
+        let loader = plugin_loader();
+
+        // Compile plugins in parallel: the serial phases of each component's
+        // compilation overlap across plugins, which speeds up the first run /
+        // cache misses. Order is preserved. The cache lock is not held while
+        // compiling; two threads racing on the same plugin at worst compile
+        // it twice, and the first insert wins.
+        use rayon::prelude::*;
+        let results: Vec<(&'static str, Result<ComponentLintRule, PluginError>)> = missing
+            .par_iter()
+            .map(|(name, bytes)| {
+                let result = loader
+                    .load_component_from_bytes(&PathBuf::from(format!("builtin:{}", name)), bytes);
+                (*name, result)
+            })
+            .collect();
+
+        let mut first_error = None;
+        {
+            let mut cache = cache.lock().expect("builtin plugin cache poisoned");
+            for (name, result) in results {
+                match result {
+                    Ok(rule) => {
+                        debug_assert_eq!(
+                            rule.name(),
+                            name,
+                            "builtin plugin table name and spec name must match \
+                             (the enabled-set filter operates on the table name)"
+                        );
+                        cache.entry(name).or_insert_with(|| rule.clone());
+                        rules.insert(name, rule);
+                    }
+                    // Remember the first failure in declaration order for a
+                    // deterministic error report, but still cache the
+                    // plugins that succeeded.
+                    Err(e) => {
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+    }
+
+    Ok(selected
+        .iter()
+        .map(|(name, _)| {
+            rules
+                .remove(name)
+                .expect("every selected plugin is either cached or freshly compiled")
+        })
+        .collect())
+}
+
+/// Embedded builtin plugins in declaration order: `(rule name, WASM bytes)`.
+///
+/// The rule name must match the plugin's `spec()` name and the
+/// `BUILTIN_PLUGIN_NAMES` table in `plugin/mod.rs` (enforced by a test
+/// below); enabled/disabled filtering happens against this name before the
+/// plugin is compiled.
+#[cfg(feature = "wasm-builtin-plugins")]
+const PLUGIN_ENTRIES: &[(&str, &[u8])] = &[
+    ("server-tokens-enabled", embedded::SERVER_TOKENS_ENABLED),
+    ("autoindex-enabled", embedded::AUTOINDEX_ENABLED),
+    ("gzip-not-enabled", embedded::GZIP_NOT_ENABLED),
+    ("duplicate-directive", embedded::DUPLICATE_DIRECTIVE),
+    ("space-before-semicolon", embedded::SPACE_BEFORE_SEMICOLON),
+    ("trailing-whitespace", embedded::TRAILING_WHITESPACE),
+    ("block-lines", embedded::BLOCK_LINES),
+    ("proxy-pass-domain", embedded::PROXY_PASS_DOMAIN),
+    (
+        "upstream-server-no-resolve",
+        embedded::UPSTREAM_SERVER_NO_RESOLVE,
+    ),
+    ("directive-inheritance", embedded::DIRECTIVE_INHERITANCE),
+    ("root-in-location", embedded::ROOT_IN_LOCATION),
+    (
+        "alias-location-slash-mismatch",
+        embedded::ALIAS_LOCATION_SLASH_MISMATCH,
+    ),
+    ("proxy-pass-with-uri", embedded::PROXY_PASS_WITH_URI),
+    ("proxy-keepalive", embedded::PROXY_KEEPALIVE),
+    ("try-files-with-proxy", embedded::TRY_FILES_WITH_PROXY),
+    ("if-is-evil-in-location", embedded::IF_IS_EVIL_IN_LOCATION),
+    ("unreachable-location", embedded::UNREACHABLE_LOCATION),
+    ("missing-error-log", embedded::MISSING_ERROR_LOG),
+    ("deprecated-ssl-protocol", embedded::DEPRECATED_SSL_PROTOCOL),
+    ("weak-ssl-ciphers", embedded::WEAK_SSL_CIPHERS),
+    (
+        "invalid-directive-context",
+        embedded::INVALID_DIRECTIVE_CONTEXT,
+    ),
+    ("map-missing-default", embedded::MAP_MISSING_DEFAULT),
+    ("ssl-on-deprecated", embedded::SSL_ON_DEPRECATED),
+    ("listen-http2-deprecated", embedded::LISTEN_HTTP2_DEPRECATED),
+    (
+        "proxy-missing-host-header",
+        embedded::PROXY_MISSING_HOST_HEADER,
+    ),
+    (
+        "client-max-body-size-not-set",
+        embedded::CLIENT_MAX_BODY_SIZE_NOT_SET,
+    ),
+    ("nginx-rift", embedded::NGINX_RIFT),
+];
+
+#[cfg(all(test, feature = "wasm-builtin-plugins"))]
+mod tests {
+    use super::*;
+
+    /// The enabled/disabled filter operates on the `PLUGIN_ENTRIES` names
+    /// before compiling, while everything else (config validation, docs,
+    /// `--list-rules`) uses `BUILTIN_PLUGIN_NAMES`. The two tables are
+    /// maintained by hand; a drift would make a rule impossible to
+    /// enable/disable by name.
+    #[test]
+    fn test_plugin_entries_match_builtin_plugin_names() {
+        let entry_names: Vec<&str> = PLUGIN_ENTRIES.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            entry_names, BUILTIN_PLUGIN_NAMES,
+            "PLUGIN_ENTRIES and BUILTIN_PLUGIN_NAMES must list the same rules in the same order"
+        );
+    }
+
+    /// Filtered loading must compile only the requested plugins and return
+    /// them in declaration order regardless of the filter's own ordering.
+    #[test]
+    fn test_load_builtin_plugins_filtered_returns_declaration_order() {
+        // Avoid touching the real per-user cache directory from tests. This
+        // is a process-wide OnceLock; setting it here is safe because unit
+        // tests share the same requirement.
+        super::configure_builtin_plugin_cache(crate::plugin::CompilationCache::Disabled);
+
+        let wanted = ["trailing-whitespace", "autoindex-enabled"];
+        let rules = load_builtin_plugins_filtered(|name| wanted.contains(&name))
+            .expect("filtered builtin load should succeed");
+        let names: Vec<&str> = rules.iter().map(|rule| rule.name()).collect();
+        // Declaration order in PLUGIN_ENTRIES: autoindex-enabled comes first
+        assert_eq!(names, ["autoindex-enabled", "trailing-whitespace"]);
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2563,14 +2563,19 @@ fn test_rule_only_kept_rule_still_emits_unused_ignore_warning() {
 }
 
 // Regression test for the --rule-only / version-gate interaction: the CLI
-// used to REPLACE the linter's inactive set with `registered \ keep`, which
-// dropped rules the version gate had marked inactive — an ignore comment
-// targeting such a rule then warned as referencing an unknown rule. With
-// rule-only filtering inside the constructor, excluded builtin rules are
-// recorded as inactive by name (whether or not they are also
-// version-gated), and the CLI extends the set instead of replacing it.
-// nginx-rift declares max_nginx_version = "1.30.1", so with target 1.31.0
-// it is both version-gated and excluded by `--rule-only indent`.
+// used to REPLACE the linter's inactive set with `registered \ keep`, and a
+// rule that was not registered (here nginx-rift: max_nginx_version =
+// "1.30.1", filtered out by target 1.31.0) fell out of that set — an ignore
+// comment targeting it then warned as referencing an unknown rule.
+//
+// With the fix, the rule-only sweep inside the constructor records every
+// excluded-but-config-enabled builtin as inactive by name, before any rule
+// is constructed. nginx-rift therefore never reaches the version gate here
+// (it is excluded by `--rule-only indent` first); its inactive status — and
+// this test's outcome — do not depend on target_nginx_version at all. The
+// version setting is kept to document the scenario that originally
+// triggered the bug; the version-gate-only inactive path (no --rule-only)
+// is covered by test_version_gated_rule_ignore_stays_quiet below.
 #[cfg(any(feature = "native-builtin-plugins", feature = "wasm-builtin-plugins"))]
 #[test]
 fn test_rule_only_keeps_ignore_for_version_gated_rule_quiet() {
@@ -2597,6 +2602,34 @@ fn test_rule_only_keeps_ignore_for_version_gated_rule_quiet() {
         !errors.iter().any(|e| e.rule == "invalid-nginx-lint-ignore"),
         "ignore comment targeting a version-gated rule must stay quiet under \
          --rule-only (neither unknown-rule nor unused-ignore warnings); got: {:?}",
+        errors
+            .iter()
+            .map(|e| (&e.rule, &e.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+// The version-gate-only counterpart of the test above: without --rule-only,
+// a rule dropped by target_nginx_version (nginx-rift on target 1.31.0) is
+// marked inactive by the version gate itself, so an ignore comment
+// targeting it neither warns as an unknown rule nor as unused.
+#[cfg(any(feature = "native-builtin-plugins", feature = "wasm-builtin-plugins"))]
+#[test]
+fn test_version_gated_rule_ignore_stays_quiet() {
+    let lint_config = LintConfig::parse("target_nginx_version = \"1.31.0\"\n").unwrap();
+    let linter = Linter::with_config(Some(&lint_config), None);
+    assert!(
+        linter.inactive_rule_names().contains("nginx-rift"),
+        "nginx-rift should be version-gated into the inactive set on target 1.31.0"
+    );
+
+    let content = "# nginx-lint:ignore nginx-rift version-gated reason\nhttp {\n}\n";
+    let (config, _) = parse_string_with_errors(content);
+    let (errors, _) = linter.lint_with_content(&config, &PathBuf::from("test.conf"), content);
+
+    assert!(
+        !errors.iter().any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        "ignore comment targeting a version-gated rule must stay quiet; got: {:?}",
         errors
             .iter()
             .map(|e| (&e.rule, &e.message))

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2562,6 +2562,48 @@ fn test_rule_only_kept_rule_still_emits_unused_ignore_warning() {
     );
 }
 
+// Regression test for the --rule-only / version-gate interaction: the CLI
+// used to REPLACE the linter's inactive set with `registered \ keep`, which
+// dropped rules the version gate had marked inactive — an ignore comment
+// targeting such a rule then warned as referencing an unknown rule. With
+// rule-only filtering inside the constructor, excluded builtin rules are
+// recorded as inactive by name (whether or not they are also
+// version-gated), and the CLI extends the set instead of replacing it.
+// nginx-rift declares max_nginx_version = "1.30.1", so with target 1.31.0
+// it is both version-gated and excluded by `--rule-only indent`.
+#[cfg(any(feature = "native-builtin-plugins", feature = "wasm-builtin-plugins"))]
+#[test]
+fn test_rule_only_keeps_ignore_for_version_gated_rule_quiet() {
+    let lint_config = LintConfig::parse("target_nginx_version = \"1.31.0\"\n").unwrap();
+
+    let only: std::collections::HashSet<String> = ["indent".to_string()].into();
+    let mut linter = Linter::with_config_and_rule_only(Some(&lint_config), None, Some(&only));
+    if !linter.rule_names().contains("indent") {
+        return;
+    }
+
+    // Mimic the CLI's post-load step: prune external plugins (none here)
+    // and EXTEND the inactive set rather than replacing it.
+    let registered = linter.rule_names();
+    let mut inactive = linter.inactive_rule_names().clone();
+    inactive.extend(registered.into_iter().filter(|name| name != "indent"));
+    linter.set_inactive_rules(inactive);
+
+    let content = "# nginx-lint:ignore nginx-rift version-gated reason\nhttp {\n}\n";
+    let (config, _) = parse_string_with_errors(content);
+    let (errors, _) = linter.lint_with_content(&config, &PathBuf::from("test.conf"), content);
+
+    assert!(
+        !errors.iter().any(|e| e.rule == "invalid-nginx-lint-ignore"),
+        "ignore comment targeting a version-gated rule must stay quiet under \
+         --rule-only (neither unknown-rule nor unused-ignore warnings); got: {:?}",
+        errors
+            .iter()
+            .map(|e| (&e.rule, &e.message))
+            .collect::<Vec<_>>()
+    );
+}
+
 // ============================================================================
 // target_nginx_version tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Builtin rule filtering (config enabled-set and `--rule-only`) now happens **before** rules are constructed, so excluded builtin WASM plugins are never compiled. Follow-up to the plugin-perf series (#272, #273, #274, #275, #276); addresses the lazy-loading item raised in the #275 review.

### Commit 1: compile only enabled builtin WASM plugins

- `load_builtin_plugins_filtered(filter)`: the enabled-set (plus the native-replacement skips for `invalid-directive-context` / `block-lines` / `directive-inheritance`) is passed from `Linter::with_config` and applied before compilation.
- The compiled-plugin cache moves from `OnceLock<Vec<_>>` to a per-plugin `Mutex<HashMap>`, so calls with different filters compose instead of the first caller's set winning; a later broader filter compiles only the plugins not yet cached.
- The filter operates on the `PLUGIN_ENTRIES` table name (spec names are only known after compiling), so a drift test asserts the table matches `BUILTIN_PLUGIN_NAMES`, and a `debug_assert` checks the spec name agrees.

### Commit 2: apply `--rule-only` before constructing builtin rules

- `Linter::with_config_and_rule_only` folds the `--rule-only` set into the same pre-construction filter. Enabled-but-excluded rules are recorded as inactive (by name over the builtin catalog) so their `# nginx-lint:ignore` directives keep parsing.
- External plugins are still pruned after loading — their names are unknown until compiled.
- Fixes a latent bug: the CLI's `set_inactive_rules` call replaced the version-gate inactive set, so with `--rule-only` an ignore comment targeting a version-filtered rule warned as an unknown rule. The CLI now extends the set instead.
- The unknown-rule error listing now includes inactive rules so every name `--rule-only` accepts is shown.

## Measurements (release, wasm-builtin-plugins build)

| Scenario | before | after |
|---|---|---|
| 26/27 builtins disabled, `--no-cache` | 0.15s | 0.01s |
| 26/27 builtins disabled, warm cache | 0.015s | 0.005s |
| `--rule-only server-tokens-enabled --no-cache` | 0.15–0.25s | 0.01s |

## Scope

Only affects `make build-with-wasm-plugins` builds; release binaries use native builtins and are unchanged (native builds share the filter path but rule construction there is trivially cheap).

## Testing

- `cargo test` (default features) and `cargo test --no-default-features --features cli,wasm-builtin-plugins`: all green
- clippy clean on both feature sets
- New unit tests: PLUGIN_ENTRIES/BUILTIN_PLUGIN_NAMES drift, filtered load order, rule-only registration/inactive bookkeeping
- Manual: `--rule-only` fires only the requested rule; unknown-rule error lists all acceptable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)