### PR TITLE
fix: rewrite if-let-else-return-None blocks as ? to satisfy clippy 1.97

### DIFF
--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -106,10 +106,9 @@ pub fn is_ipv4_address(s: &str) -> bool {
 /// ```
 pub fn extract_host_from_url(url: &str) -> Option<&str> {
     // Remove protocol
-    let after_protocol = if let Some(pos) = url.find("://") {
+    let after_protocol = {
+        let pos = url.find("://")?;
         &url[pos + 3..]
-    } else {
-        return None;
     };
 
     // Handle unix socket URLs (e.g., "unix:/var/run/app.sock")

--- a/plugins/builtin/best_practices/proxy_pass_with_uri/src/lib.rs
+++ b/plugins/builtin/best_practices/proxy_pass_with_uri/src/lib.rs
@@ -40,12 +40,11 @@ impl ProxyPassWithUriPlugin {
             return None;
         }
 
-        // Find the scheme (http:// or https://)
-        let after_scheme = if let Some(pos) = url.find("://") {
+        // Find the scheme (http:// or https://); no scheme means it's a
+        // variable or unix socket, so bail out via `?`.
+        let after_scheme = {
+            let pos = url.find("://")?;
             &url[pos + 3..]
-        } else {
-            // No scheme, might be a variable or unix socket
-            return None;
         };
 
         // Find the first / after the host:port


### PR DESCRIPTION
## Summary

CI's Clippy job started failing after a Rust toolchain update: https://github.com/walf443/nginx-lint/actions/runs/29064284439/job/86272457696

`ci.yml`'s Clippy job uses `dtolnay/rust-toolchain@stable`, which floats to whatever's current. Rust 1.97.0 shipped an expanded `clippy::question_mark` lint (part of `-D clippy::all`) that now also catches:

```rust
let x = if let Some(y) = expr {
    y
} else {
    return None;
};
```

The previous stable didn't flag this shape. Two occurrences in the codebase matched it exactly (both parsing a URL's `://` scheme separator):

- `crates/nginx-lint-plugin/src/helpers.rs` — `extract_host_from_url`
- `plugins/builtin/best_practices/proxy_pass_with_uri/src/lib.rs` — `extract_uri_path`

Rewrote both with `?` per clippy's own suggested fix. No behavior change.

## Testing

Reproduced locally by `rustup update stable` (1.96.1 → 1.97.0) and running the exact CI command (`cargo clippy --workspace --features plugins -- -D clippy::all`); confirmed clean after both fixes. Also verified `cargo clippy` (default features) and `cargo clippy --no-default-features --features cli,wasm-builtin-plugins` are clean, `cargo fmt --check` passes, and the full test suite (`cargo test --features plugins`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)