### PR TITLE
perf: stop computing missing-semicolon/unmatched-braces/unclosed-quote twice per file

### DIFF
--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -282,6 +282,30 @@ pub trait LintRule: Send + Sync {
         self.check(config, path)
     }
 
+    /// Whether this rule wants the raw file content directly.
+    ///
+    /// Rules that need to re-derive diagnostics from the source text itself
+    /// (rather than the parsed `Config`) should return `true` so the linter
+    /// hands them the content it already has in memory, instead of each rule
+    /// independently re-reading the file from disk and re-parsing it.
+    ///
+    /// Note: this does not compose with [`wants_shared_config`](Self::wants_shared_config) —
+    /// the default [`check_with_content`](Self::check_with_content) delegates to
+    /// [`check`](Self::check), not [`check_shared`](Self::check_shared). No current
+    /// rule needs both; a future one that does would need a custom override.
+    fn wants_content(&self) -> bool {
+        false
+    }
+
+    /// Run the rule with the raw file content already available.
+    ///
+    /// The linter calls this instead of [`check`](Self::check)/[`check_shared`](Self::check_shared)
+    /// when [`wants_content`](Self::wants_content) returns `true` and content is available.
+    /// Default implementation ignores `content` and calls `check()`.
+    fn check_with_content(&self, config: &Config, path: &Path, _content: &str) -> Vec<LintError> {
+        self.check(config, path)
+    }
+
     /// Get detailed explanation of why this rule exists
     fn why(&self) -> Option<&str> {
         None
@@ -389,6 +413,25 @@ pub fn run_rule(
         rule.check_shared(shared, path)
     } else {
         rule.check(config, path)
+    }
+}
+
+/// Like [`run_rule`], but additionally dispatches to
+/// [`LintRule::check_with_content`] for rules that
+/// [want raw content](LintRule::wants_content), so those rules don't have to
+/// re-read the file from disk when the caller already has it in memory.
+/// Falls back to [`run_rule`]'s dispatch policy otherwise.
+pub fn run_rule_with_content(
+    rule: &dyn LintRule,
+    config: &Config,
+    path: &Path,
+    content: &str,
+    shared_config: &std::sync::OnceLock<std::sync::Arc<Config>>,
+) -> Vec<LintError> {
+    if rule.wants_content() {
+        rule.check_with_content(config, path, content)
+    } else {
+        run_rule(rule, config, path, shared_config)
     }
 }
 

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -5,7 +5,7 @@ use nginx_lint::{
     ColorMode, IncludedFile, LintConfig, LintError, Linter, Reporter, RuleProfile, Severity,
     apply_fixes, apply_fixes_to_content_detailed, collect_included_files,
     collect_included_files_with_context, parse_config, parse_string_with_errors,
-    pre_parse_checks_from_content, syntax_errors_to_lint_errors,
+    syntax_errors_to_lint_errors,
 };
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -28,8 +28,9 @@ fn warn_skipped_fixes(skipped: usize, path: &Path) {
 
 /// Extend `errors` with `additional`, dropping exact duplicates.
 ///
-/// Pre-parse checks and the registered syntax rules (missing-semicolon,
-/// unmatched-braces, unclosed-quote) detect the same problems; keeping both
+/// Used to merge in rowan's own generic syntax errors alongside the
+/// registered syntax rules' (missing-semicolon, unmatched-braces,
+/// unclosed-quote) more specific diagnostics, which can overlap; keeping both
 /// copies would report each problem twice and, under `--fix`, apply the same
 /// fix twice (e.g. inserting `;;` for one missing semicolon).
 fn extend_errors_dedup(errors: &mut Vec<LintError>, additional: Vec<LintError>) {
@@ -199,18 +200,10 @@ fn run_lint_on_config(
 }
 
 /// Lint a single included file and return the result
-fn lint_file(
-    included: &IncludedFile,
-    linter: &Linter,
-    lint_config: Option<&LintConfig>,
-    profile: bool,
-) -> FileResult {
+fn lint_file(included: &IncludedFile, linter: &Linter, profile: bool) -> FileResult {
     let path = &included.path;
 
     let content = std::fs::read_to_string(path).unwrap_or_default();
-
-    // Run pre-parse checks on already-read content to avoid reading the file twice
-    let pre_parse_errors = pre_parse_checks_from_content(&content, lint_config);
 
     // Always parse with error recovery — rowan produces a usable AST even with errors
     let (config, syntax_errors) = if let Some(ref config) = included.config {
@@ -222,12 +215,10 @@ fn lint_file(
 
     let mut result = run_lint_on_config(&config, path, &content, linter, profile);
 
-    // Merge pre-parse errors and syntax errors into lint errors, dropping
-    // exact duplicates (the linter's syntax rules and pre_parse_checks
-    // overlap; rowan syntax-error may also repeat).
-    let FileResult::LintErrors { ref mut errors, .. } = result;
-    extend_errors_dedup(errors, pre_parse_errors);
+    // Merge in rowan's own generic syntax errors, dropping exact duplicates
+    // (they may repeat what a registered syntax rule already reported).
     if !syntax_errors.is_empty() {
+        let FileResult::LintErrors { ref mut errors, .. } = result;
         extend_errors_dedup(
             errors,
             syntax_errors_to_lint_errors(&syntax_errors, &content),
@@ -244,18 +235,13 @@ fn lint_file(
 /// in the written file: positions are computed against the rewritten
 /// content, and problems left behind by fixes that failed to apply or were
 /// skipped stay visible.
-fn fix_file(
-    inc: &IncludedFile,
-    linter: &Linter,
-    lint_config: Option<&LintConfig>,
-    profile: bool,
-) -> FileResult {
+fn fix_file(inc: &IncludedFile, linter: &Linter, profile: bool) -> FileResult {
     let FileResult::LintErrors {
         path,
         errors,
         ignored_count,
         profiles,
-    } = lint_file(inc, linter, lint_config, profile);
+    } = lint_file(inc, linter, profile);
 
     if errors.iter().all(|e| e.fixes.is_empty()) {
         return FileResult::LintErrors {
@@ -287,7 +273,6 @@ fn fix_file(
                 &result.content,
                 &path,
                 linter,
-                lint_config,
                 false,
                 inc.include_context.clone(),
             );
@@ -317,7 +302,6 @@ fn fix_stdin(
     result: FileResult,
     content: &str,
     linter: &Linter,
-    lint_config: Option<&LintConfig>,
     initial_context: Vec<String>,
 ) -> FileResult {
     let FileResult::LintErrors {
@@ -347,14 +331,7 @@ fn fix_stdin(
         errors: remaining,
         ignored_count: remaining_ignored,
         ..
-    } = lint_content(
-        &apply_result.content,
-        &path,
-        linter,
-        lint_config,
-        false,
-        initial_context,
-    );
+    } = lint_content(&apply_result.content, &path, linter, false, initial_context);
     FileResult::LintErrors {
         path,
         errors: remaining,
@@ -441,13 +418,9 @@ fn lint_content(
     content: &str,
     path: &Path,
     linter: &Linter,
-    lint_config: Option<&LintConfig>,
     profile: bool,
     initial_context: Vec<String>,
 ) -> FileResult {
-    // Run pre-parse checks on the content
-    let pre_parse_errors = pre_parse_checks_from_content(content, lint_config);
-
     // Parse the content (always produces AST, even with syntax errors)
     let (mut parse_result, syntax_errors) = parse_string_with_errors(content);
 
@@ -458,11 +431,10 @@ fn lint_content(
 
     let mut result = run_lint_on_config(&parse_result, path, content, linter, profile);
 
-    // Merge pre-parse errors and syntax errors into lint errors, dropping
-    // exact duplicates (see lint_file)
-    let FileResult::LintErrors { ref mut errors, .. } = result;
-    extend_errors_dedup(errors, pre_parse_errors);
+    // Merge in rowan's own generic syntax errors, dropping exact duplicates
+    // (see lint_file)
     if !syntax_errors.is_empty() {
+        let FileResult::LintErrors { ref mut errors, .. } = result;
         extend_errors_dedup(
             errors,
             syntax_errors_to_lint_errors(&syntax_errors, content),
@@ -799,18 +771,11 @@ pub fn run_lint(cli: Cli) -> ExitCode {
             content,
             Path::new("<stdin>"),
             &linter,
-            lint_config.as_ref(),
             cli.profile,
             initial_context.clone(),
         );
         if cli.fix {
-            vec![fix_stdin(
-                result,
-                content,
-                &linter,
-                lint_config.as_ref(),
-                initial_context,
-            )]
+            vec![fix_stdin(result, content, &linter, initial_context)]
         } else {
             vec![result]
         }
@@ -862,17 +827,17 @@ pub fn run_lint(cli: Cli) -> ExitCode {
         if cli.fix {
             included_files
                 .iter()
-                .map(|inc| fix_file(inc, &linter, lint_config.as_ref(), cli.profile))
+                .map(|inc| fix_file(inc, &linter, cli.profile))
                 .collect()
         } else if cli.profile {
             included_files
                 .iter()
-                .map(|inc| lint_file(inc, &linter, lint_config.as_ref(), true))
+                .map(|inc| lint_file(inc, &linter, true))
                 .collect()
         } else {
             included_files
                 .par_iter()
-                .map(|inc| lint_file(inc, &linter, lint_config.as_ref(), false))
+                .map(|inc| lint_file(inc, &linter, false))
                 .collect()
         }
     };

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -28,11 +28,14 @@ fn warn_skipped_fixes(skipped: usize, path: &Path) {
 
 /// Extend `errors` with `additional`, dropping exact duplicates.
 ///
-/// Used to merge in rowan's own generic syntax errors alongside the
-/// registered syntax rules' (missing-semicolon, unmatched-braces,
-/// unclosed-quote) more specific diagnostics, which can overlap; keeping both
-/// copies would report each problem twice and, under `--fix`, apply the same
-/// fix twice (e.g. inserting `;;` for one missing semicolon).
+/// Used to merge in rowan's own generic syntax errors (always tagged
+/// `rule: "syntax-error"`, see `syntax_errors_to_lint_errors`) on top of the
+/// errors already collected from the registered rules. The duplicate check
+/// compares `rule` too, so this can only dedupe rowan's syntax errors against
+/// each other — e.g. if error recovery reports the same position twice —
+/// never against a registered syntax rule's diagnostic
+/// (missing-semicolon/unmatched-braces/unclosed-quote), since those are
+/// always tagged with a different rule name.
 fn extend_errors_dedup(errors: &mut Vec<LintError>, additional: Vec<LintError>) {
     for err in additional {
         let is_duplicate = errors.iter().any(|existing| {
@@ -216,7 +219,7 @@ fn lint_file(included: &IncludedFile, linter: &Linter, profile: bool) -> FileRes
     let mut result = run_lint_on_config(&config, path, &content, linter, profile);
 
     // Merge in rowan's own generic syntax errors, dropping exact duplicates
-    // (they may repeat what a registered syntax rule already reported).
+    // among themselves (see extend_errors_dedup's doc comment).
     if !syntax_errors.is_empty() {
         let FileResult::LintErrors { ref mut errors, .. } = result;
         extend_errors_dedup(

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -420,7 +420,7 @@ mod example_tests {
         // Test unmatched-braces
         {
             let doc = get_rule_doc("unmatched-braces").unwrap();
-            let rule = UnmatchedBraces;
+            let rule = UnmatchedBraces::default();
             let errors = rule.check_content(doc.bad_example);
             assert!(
                 !errors.is_empty(),
@@ -465,7 +465,7 @@ mod example_tests {
         // Test unmatched-braces
         {
             let doc = get_rule_doc("unmatched-braces").unwrap();
-            let rule = UnmatchedBraces;
+            let rule = UnmatchedBraces::default();
             let errors = rule.check_content(doc.good_example);
             assert!(
                 errors.is_empty(),
@@ -539,7 +539,7 @@ mod example_tests {
         // Test unmatched-braces fix
         {
             let doc = get_rule_doc("unmatched-braces").unwrap();
-            let rule = UnmatchedBraces;
+            let rule = UnmatchedBraces::default();
             let errors = rule.check_content(doc.bad_example);
             if !errors.is_empty() && errors.iter().all(|e| !e.fixes.is_empty()) {
                 let fixed = apply_fixes(doc.bad_example, &errors);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub fn pre_parse_checks_from_content(
     let mut errors = Vec::new();
 
     // Check for unmatched braces
-    let brace_rule = UnmatchedBraces;
+    let brace_rule = UnmatchedBraces::default();
     errors.extend(brace_rule.check_content_with_extras(content, &additional_block_directives));
 
     // Check for unclosed quotes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,68 +76,6 @@ pub fn syntax_errors_to_lint_errors(
         .collect()
 }
 
-/// Run pre-parse checks that can detect errors before parsing
-/// These checks work on the raw file content and don't require a valid AST
-#[cfg(feature = "cli")]
-pub fn pre_parse_checks(path: &Path) -> Vec<LintError> {
-    pre_parse_checks_with_config(path, None)
-}
-
-/// Run pre-parse checks with optional LintConfig
-#[cfg(feature = "cli")]
-pub fn pre_parse_checks_with_config(
-    path: &Path,
-    lint_config: Option<&LintConfig>,
-) -> Vec<LintError> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
-    };
-
-    pre_parse_checks_from_content(&content, lint_config)
-}
-
-/// Run pre-parse checks on string content with optional LintConfig
-#[cfg(feature = "cli")]
-pub fn pre_parse_checks_from_content(
-    content: &str,
-    lint_config: Option<&LintConfig>,
-) -> Vec<LintError> {
-    use nginx_lint_common::ignore::{IgnoreTracker, filter_errors};
-    use rules::{MissingSemicolon, UnclosedQuote, UnmatchedBraces};
-
-    // Build ignore tracker from content without rule name validation
-    // (rule name validation is done later in lint_with_content when all plugins are loaded)
-    let (mut tracker, _warnings) = IgnoreTracker::from_content(content);
-
-    let additional_block_directives: Vec<String> = lint_config
-        .map(|c| c.additional_block_directives().to_vec())
-        .unwrap_or_default();
-
-    let mut errors = Vec::new();
-
-    // Check for unmatched braces
-    let brace_rule = UnmatchedBraces::default();
-    errors.extend(brace_rule.check_content_with_extras(content, &additional_block_directives));
-
-    // Check for unclosed quotes
-    let quote_rule = UnclosedQuote;
-    errors.extend(quote_rule.check_content(content));
-
-    // Check for missing semicolons
-    let semicolon_rule = MissingSemicolon;
-    errors.extend(semicolon_rule.check_content_with_extras(content, &additional_block_directives));
-
-    // Filter ignored errors using the local tracker.
-    // Note: we intentionally do NOT emit parse warnings or unused-directive
-    // warnings here — those are emitted by `lint_with_content`, whose tracker
-    // sees errors from ALL rules (not just pre-parse ones). Emitting unused
-    // warnings here would falsely flag ignore directives that target later
-    // rules like `include-path-exists`.
-    let result = filter_errors(errors, &mut tracker);
-    result.errors
-}
-
 /// Apply fixes to a file
 /// Returns the application result, including applied and skipped fix counts
 #[cfg(feature = "cli")]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -1,8 +1,8 @@
 // Re-export core types from nginx-lint-common
 use nginx_lint_common::config::LintConfig;
 use nginx_lint_common::ignore::IgnoreTracker;
-use nginx_lint_common::linter::run_rule;
 pub use nginx_lint_common::linter::{Fix, LintError, LintRule, Severity};
+use nginx_lint_common::linter::{run_rule, run_rule_with_content};
 use nginx_lint_common::nginx_version::{NginxVersion, format_range, is_in_range};
 use nginx_lint_common::parser::ast::Config;
 #[cfg(feature = "cli")]
@@ -185,7 +185,12 @@ impl Linter {
 
         // Syntax rules
         if is_enabled("unmatched-braces") {
-            linter.add_rule(Box::new(UnmatchedBraces));
+            let additional_block_directives = config
+                .map(|c| c.additional_block_directives().to_vec())
+                .unwrap_or_default();
+            linter.add_rule(Box::new(UnmatchedBraces::with_additional_block_directives(
+                additional_block_directives,
+            )));
         }
         if is_enabled("unclosed-quote") {
             linter.add_rule(Box::new(UnclosedQuote));
@@ -488,25 +493,49 @@ impl Linter {
     /// Uses parallel iteration when the cli feature is enabled (via rayon)
     #[cfg(feature = "cli")]
     pub fn lint(&self, config: &Config, path: &Path) -> Vec<LintError> {
+        self.lint_internal(config, path, None)
+    }
+
+    /// Run all lint rules and collect errors (sequential version for WASM)
+    #[cfg(not(feature = "cli"))]
+    pub fn lint(&self, config: &Config, path: &Path) -> Vec<LintError> {
+        self.lint_internal(config, path, None)
+    }
+
+    /// Shared implementation behind [`lint`](Self::lint)/[`lint_with_content`](Self::lint_with_content).
+    ///
+    /// `content` is `Some` only when the caller already has the file content in
+    /// memory (see [`lint_with_content`](Self::lint_with_content)), in which
+    /// case rules that [want it](nginx_lint_common::linter::LintRule::wants_content)
+    /// receive it directly instead of re-reading the file from disk.
+    #[cfg(feature = "cli")]
+    fn lint_internal(&self, config: &Config, path: &Path, content: Option<&str>) -> Vec<LintError> {
         let shared_config = std::sync::OnceLock::new();
 
         self.rules
             .par_iter()
-            .map(|rule| run_rule(rule.as_ref(), config, path, &shared_config))
+            .map(|rule| match content {
+                Some(c) => run_rule_with_content(rule.as_ref(), config, path, c, &shared_config),
+                None => run_rule(rule.as_ref(), config, path, &shared_config),
+            })
             .collect::<Vec<_>>()
             .into_iter()
             .flatten()
             .collect()
     }
 
-    /// Run all lint rules and collect errors (sequential version for WASM)
+    /// Shared implementation behind [`lint`](Self::lint)/[`lint_with_content`](Self::lint_with_content)
+    /// (sequential version for WASM). See the `cli`-feature variant for details.
     #[cfg(not(feature = "cli"))]
-    pub fn lint(&self, config: &Config, path: &Path) -> Vec<LintError> {
+    fn lint_internal(&self, config: &Config, path: &Path, content: Option<&str>) -> Vec<LintError> {
         let shared_config = std::sync::OnceLock::new();
 
         self.rules
             .iter()
-            .flat_map(|rule| run_rule(rule.as_ref(), config, path, &shared_config))
+            .flat_map(|rule| match content {
+                Some(c) => run_rule_with_content(rule.as_ref(), config, path, c, &shared_config),
+                None => run_rule(rule.as_ref(), config, path, &shared_config),
+            })
             .collect()
     }
 
@@ -524,7 +553,7 @@ impl Linter {
         use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
         let (mut tracker, warnings) = self.make_ignore_tracker(content);
-        let errors = self.lint(config, path);
+        let errors = self.lint_internal(config, path, Some(content));
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
         errors.extend(warnings_to_errors(warnings));
@@ -543,7 +572,7 @@ impl Linter {
         use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
         let (mut tracker, warnings) = self.make_ignore_tracker(content);
-        let errors = self.lint(config, path);
+        let errors = self.lint_internal(config, path, Some(content));
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
         errors.extend(warnings_to_errors(warnings));
@@ -561,6 +590,19 @@ impl Linter {
         config: &Config,
         path: &Path,
     ) -> (Vec<LintError>, Vec<RuleProfile>) {
+        self.lint_with_profile_internal(config, path, None)
+    }
+
+    /// Shared implementation behind [`lint_with_profile`](Self::lint_with_profile)/
+    /// [`lint_with_content_and_profile`](Self::lint_with_content_and_profile). See
+    /// [`lint_internal`](Self::lint_internal) for the meaning of `content`.
+    #[cfg(feature = "cli")]
+    fn lint_with_profile_internal(
+        &self,
+        config: &Config,
+        path: &Path,
+        content: Option<&str>,
+    ) -> (Vec<LintError>, Vec<RuleProfile>) {
         use std::time::Instant;
 
         let shared_config = std::sync::OnceLock::new();
@@ -570,7 +612,12 @@ impl Linter {
             .iter()
             .map(|rule| {
                 let start = Instant::now();
-                let errors = run_rule(rule.as_ref(), config, path, &shared_config);
+                let errors = match content {
+                    Some(c) => {
+                        run_rule_with_content(rule.as_ref(), config, path, c, &shared_config)
+                    }
+                    None => run_rule(rule.as_ref(), config, path, &shared_config),
+                };
                 let duration = start.elapsed();
                 let profile = RuleProfile {
                     name: rule.name().to_string(),
@@ -599,7 +646,7 @@ impl Linter {
         use nginx_lint_common::ignore::{filter_errors, warnings_to_errors};
 
         let (mut tracker, warnings) = self.make_ignore_tracker(content);
-        let (errors, profiles) = self.lint_with_profile(config, path);
+        let (errors, profiles) = self.lint_with_profile_internal(config, path, Some(content));
         let result = filter_errors(errors, &mut tracker);
         let mut errors = result.errors;
         errors.extend(warnings_to_errors(warnings));

--- a/src/rules/syntax/missing_semicolon.rs
+++ b/src/rules/syntax/missing_semicolon.rs
@@ -248,6 +248,14 @@ impl LintRule for MissingSemicolon {
 
         self.check_cst(&content)
     }
+
+    fn wants_content(&self) -> bool {
+        true
+    }
+
+    fn check_with_content(&self, _config: &Config, _path: &Path, content: &str) -> Vec<LintError> {
+        self.check_cst(content)
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/syntax/unclosed_quote.rs
+++ b/src/rules/syntax/unclosed_quote.rs
@@ -178,6 +178,14 @@ impl LintRule for UnclosedQuote {
 
         self.check_cst(&content)
     }
+
+    fn wants_content(&self) -> bool {
+        true
+    }
+
+    fn check_with_content(&self, _config: &Config, _path: &Path, content: &str) -> Vec<LintError> {
+        self.check_cst(content)
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/syntax/unmatched_braces.rs
+++ b/src/rules/syntax/unmatched_braces.rs
@@ -25,7 +25,23 @@ are balanced, and that block directives have their opening brace."#,
 };
 
 /// Check for unmatched braces
-pub struct UnmatchedBraces;
+#[derive(Default)]
+pub struct UnmatchedBraces {
+    /// Directive names treated as block directives beyond nginx's built-ins
+    /// (for extension modules), used when checking via the registered
+    /// `LintRule` path (see [`check_with_content`](LintRule::check_with_content)).
+    additional_block_directives: Vec<String>,
+}
+
+impl UnmatchedBraces {
+    /// Construct a rule instance that also treats `additional_block_directives`
+    /// as block directives, per the user's `.nginx-lint.toml` configuration.
+    pub fn with_additional_block_directives(additional_block_directives: Vec<String>) -> Self {
+        Self {
+            additional_block_directives,
+        }
+    }
+}
 
 /// Information about an opening brace on the stack.
 #[derive(Debug, Clone)]
@@ -437,7 +453,15 @@ impl LintRule for UnmatchedBraces {
             Err(_) => return Vec::new(),
         };
 
-        self.check_cst(&content, &[])
+        self.check_cst(&content, &self.additional_block_directives)
+    }
+
+    fn wants_content(&self) -> bool {
+        true
+    }
+
+    fn check_with_content(&self, _config: &Config, _path: &Path, content: &str) -> Vec<LintError> {
+        self.check_cst(content, &self.additional_block_directives)
     }
 }
 
@@ -453,7 +477,7 @@ mod tests {
         write!(file, "{}", content).unwrap();
         let path = file.path().to_path_buf();
 
-        let rule = UnmatchedBraces;
+        let rule = UnmatchedBraces::default();
         let config = Config::new();
         rule.check(&config, &path)
     }
@@ -945,7 +969,7 @@ http {
     // =========================================================================
 
     fn check_braces_with_extras(content: &str, extras: &[String]) -> Vec<LintError> {
-        let rule = UnmatchedBraces;
+        let rule = UnmatchedBraces::default();
         rule.check_content_with_extras(content, extras)
     }
 
@@ -993,26 +1017,62 @@ http {
         assert_eq!(errors.len(), 2, "Expected 2 errors, got: {:?}", errors);
     }
 
+    /// `additional_block_directives` must also be respected via the
+    /// registered `LintRule` dispatch (`check`/`check_with_content`), not
+    /// just the standalone `check_content_with_extras` helper — this is the
+    /// path the CLI actually uses once a rule is registered with
+    /// [`with_additional_block_directives`](UnmatchedBraces::with_additional_block_directives).
+    #[test]
+    fn test_registered_rule_respects_additional_block_directives() {
+        let content = r#"http {
+    my_custom_block
+        some_directive value;
+    }
+}
+"#;
+        let config = Config::new();
+        let path = Path::new("test.conf");
+
+        // Without configuring the extra block directive, the registered
+        // rule must not know about it.
+        let plain_rule = UnmatchedBraces::default();
+        assert!(
+            plain_rule
+                .check_with_content(&config, path, content)
+                .iter()
+                .all(|e| !e.message.contains("my_custom_block")),
+            "should not detect custom directive without config"
+        );
+
+        // Once configured, both check() (disk-reading fallback) and
+        // check_with_content() (the CLI's actual dispatch path) must detect it.
+        let configured_rule =
+            UnmatchedBraces::with_additional_block_directives(vec!["my_custom_block".to_string()]);
+        let errors = configured_rule.check_with_content(&config, path, content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors[0].message.contains("my_custom_block"));
+    }
+
     // =========================================================================
     // Edge cases
     // =========================================================================
 
     #[test]
     fn test_empty_input() {
-        let errors = UnmatchedBraces.check_content("");
+        let errors = UnmatchedBraces::default().check_content("");
         assert!(errors.is_empty(), "Expected no errors for empty input");
     }
 
     #[test]
     fn test_only_braces() {
-        let errors = UnmatchedBraces.check_content("{}");
+        let errors = UnmatchedBraces::default().check_content("{}");
         assert!(errors.is_empty(), "Expected no errors for matched braces");
 
-        let errors = UnmatchedBraces.check_content("{");
+        let errors = UnmatchedBraces::default().check_content("{");
         assert_eq!(errors.len(), 1);
         assert!(errors[0].message.contains("Unclosed brace"));
 
-        let errors = UnmatchedBraces.check_content("}");
+        let errors = UnmatchedBraces::default().check_content("}");
         assert_eq!(errors.len(), 1);
         assert!(errors[0].message.contains("Unexpected closing brace"));
     }
@@ -1132,7 +1192,7 @@ events {
         // R_BRACE-only lines (`}`) are skipped, so the fix falls back to EOF
         // rather than inserting before the existing `}`.
         let content = "http {\n  server_tokens on;\n  autoindex on;\n\n  upstream backend {\n    server api.example.com:8080;\n  \n\n  server {\n    listen 80;\n    server_name example.com;\n  }\n}\n";
-        let rule = UnmatchedBraces;
+        let rule = UnmatchedBraces::default();
         let errors = rule.check_content(content);
         assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
         assert!(errors[0].message.contains("Unclosed brace"));

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -170,7 +170,7 @@ pub fn lint_with_config(content: &str, config_toml: &str) -> Result<WasmLintResu
     let mut pre_parse_errors = Vec::new();
 
     if is_enabled("unmatched-braces") {
-        let rule = UnmatchedBraces;
+        let rule = UnmatchedBraces::default();
         pre_parse_errors
             .extend(rule.check_content_with_extras(content, &additional_block_directives));
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use nginx_lint::{
     LintConfig, Linter, Severity, apply_fixes, parse_config, parse_string,
-    parse_string_with_errors, pre_parse_checks, syntax_errors_to_lint_errors,
+    parse_string_with_errors, syntax_errors_to_lint_errors,
 };
 use rayon::prelude::*;
 use std::fs;
@@ -567,6 +567,36 @@ fn dir_name_to_rule_name(dir_name: &str) -> String {
     dir_name.replace('_', "-")
 }
 
+/// Fixtures whose fix-application check is known to fail for reasons
+/// unrelated to fix correctness of the general mechanism — tracked
+/// separately rather than silently ignored.
+///
+/// `(rule_dir_name, case)`. None of these were ever actually exercised by
+/// `test_all_rule_fixtures`'s fix-check before it started using
+/// error-recovery parsing (parse_string_with_errors) uniformly: the check
+/// used to run only when `parse_config` (which fails on any syntax error)
+/// succeeded on the error fixture, which it never does for these rules' own
+/// fixtures (they deliberately contain syntax errors).
+///
+/// - unmatched_braces/001_basic, 002_without_comment, 004_nested_missing,
+///   005_multiple_blocks: see
+///   https://github.com/walf443/nginx-lint/issues/294 — `find_close_brace_offset`
+///   treats comment-only lines as trivia rather than valid insertion anchors,
+///   so when everything after an unclosed block is comment-only, all of that
+///   block's missing closing braces fall back to end-of-file instead of their
+///   intended positions.
+/// - unclosed_quote/005_no_semicolon: see
+///   https://github.com/walf443/nginx-lint/issues/295 — the fix leaves the
+///   actual unclosed quote untouched and instead adds a spurious closing
+///   quote to a different, already-correctly-quoted line.
+const FIXTURES_WITH_KNOWN_FIX_BUGS: &[(&str, &str)] = &[
+    ("unmatched_braces", "001_basic"),
+    ("unmatched_braces", "002_without_comment"),
+    ("unmatched_braces", "004_nested_missing"),
+    ("unmatched_braces", "005_multiple_blocks"),
+    ("unclosed_quote", "005_no_semicolon"),
+];
+
 /// Test case information for parallel execution
 struct RuleTestCase {
     category: String,
@@ -639,30 +669,15 @@ fn test_all_rule_fixtures() {
         .flat_map(|tc| {
             let mut case_failures = Vec::new();
 
-            // Parse error fixture once
-            let error_config = if tc.error_path.exists() {
-                parse_config(&tc.error_path).ok()
-            } else {
-                None
-            };
-
-            // Parse expected fixture once
-            let expected_config = if tc.expected_path.exists() {
-                parse_config(&tc.expected_path).ok()
-            } else {
-                None
-            };
-
-            // Test error fixture: should detect errors
+            // Test error fixture: should detect errors. Uses the same
+            // error-recovery parsing (parse_string_with_errors) the real CLI
+            // uses, so a fixture containing a genuine syntax error (as the
+            // syntax rules' own fixtures do) is still linted rather than
+            // silently skipped.
             if tc.error_path.exists() {
-                let mut errors = pre_parse_checks(&tc.error_path);
-
-                if let Some(ref config) = error_config {
-                    let content = fs::read_to_string(&tc.error_path).unwrap_or_default();
-                    let (lint_errors, _) =
-                        linter.lint_with_content(config, &tc.error_path, &content);
-                    errors.extend(lint_errors);
-                }
+                let content = fs::read_to_string(&tc.error_path).unwrap_or_default();
+                let (config, _) = parse_string_with_errors(&content);
+                let (errors, _) = linter.lint_with_content(&config, &tc.error_path, &content);
 
                 let rule_errors: Vec<_> = errors
                     .iter()
@@ -679,14 +694,9 @@ fn test_all_rule_fixtures() {
 
             // Test expected fixture: should have no errors for this rule
             if tc.expected_path.exists() {
-                let mut errors = pre_parse_checks(&tc.expected_path);
-
-                if let Some(ref config) = expected_config {
-                    let content = fs::read_to_string(&tc.expected_path).unwrap_or_default();
-                    let (lint_errors, _) =
-                        linter.lint_with_content(config, &tc.expected_path, &content);
-                    errors.extend(lint_errors);
-                }
+                let content = fs::read_to_string(&tc.expected_path).unwrap_or_default();
+                let (config, _) = parse_string_with_errors(&content);
+                let (errors, _) = linter.lint_with_content(&config, &tc.expected_path, &content);
 
                 let rule_errors: Vec<_> = errors
                     .iter()
@@ -702,19 +712,17 @@ fn test_all_rule_fixtures() {
             }
 
             // Test fix: if both error and expected exist, verify fix produces expected
-            if tc.error_path.exists() && tc.expected_path.exists() && error_config.is_some() {
+            let skip_fix_check = FIXTURES_WITH_KNOWN_FIX_BUGS
+                .contains(&(tc.rule_dir_name.as_str(), tc.case.as_str()));
+            if tc.error_path.exists() && tc.expected_path.exists() && !skip_fix_check {
                 if let Ok(error_content) = fs::read_to_string(&tc.error_path) {
                     if let Ok(mut temp_file) = NamedTempFile::new() {
                         if write!(temp_file, "{}", error_content).is_ok() {
                             let temp_path = temp_file.path();
 
-                            let mut all_errors = pre_parse_checks(temp_path);
-                            if let Ok(config) = parse_config(temp_path) {
-                                let content = fs::read_to_string(temp_path).unwrap_or_default();
-                                let (lint_errors, _) =
-                                    linter.lint_with_content(&config, temp_path, &content);
-                                all_errors.extend(lint_errors);
-                            }
+                            let (config, _) = parse_string_with_errors(&error_content);
+                            let (all_errors, _) =
+                                linter.lint_with_content(&config, temp_path, &error_content);
 
                             let rule_errors_with_fixes: Vec<_> = all_errors
                                 .iter()
@@ -1272,15 +1280,11 @@ http {
     );
 }
 
-// Regression: pre_parse_checks_from_content must not emit "unused" warnings
-// for ignore directives whose target rule only runs later in lint_with_content
-// (e.g. include-path-exists). Previously, pre-parse built its own tracker,
-// filtered only the pre-parse rules, and prematurely flagged such directives
-// as unused.
+// Regression: ignore directives whose target rule runs later within
+// lint_with_content's rule pass (e.g. include-path-exists) must not be
+// flagged as unused just because earlier rules haven't matched them yet.
 #[test]
 fn test_ignore_include_path_exists_not_flagged_as_unused() {
-    use nginx_lint::pre_parse_checks_from_content;
-
     let content =
         "http {\n    include mime.types; # nginx-lint:ignore include-path-exists versioning\n}\n";
 
@@ -1288,11 +1292,9 @@ fn test_ignore_include_path_exists_not_flagged_as_unused() {
     let conf_path = tmp_dir.path().join("nginx.conf");
     fs::write(&conf_path, content).expect("write conf");
 
-    let pre_parse_errors = pre_parse_checks_from_content(content, None);
     let config = parse_string(content).expect("parse");
     let linter = get_default_linter();
-    let (mut errors, ignored_count) = linter.lint_with_content(&config, &conf_path, content);
-    errors.extend(pre_parse_errors);
+    let (errors, ignored_count) = linter.lint_with_content(&config, &conf_path, content);
 
     assert_eq!(ignored_count, 1, "include-path-exists should be ignored");
     let unused: Vec<_> = errors
@@ -1306,13 +1308,11 @@ fn test_ignore_include_path_exists_not_flagged_as_unused() {
     );
 }
 
-// Pre-parse rules (missing-semicolon, unmatched-braces, unclosed-quote) are
-// also registered as LintRule and re-run inside lint_with_content. Verify
-// that a genuinely unused ignore for such a rule is still reported.
+// Regression: an unused ignore comment targeting a registered syntax rule
+// (missing-semicolon, unmatched-braces, unclosed-quote) must still be
+// reported as unused when the rule finds nothing to suppress.
 #[test]
-fn test_unused_ignore_for_pre_parse_rule_is_still_reported() {
-    use nginx_lint::pre_parse_checks_from_content;
-
+fn test_unused_ignore_for_syntax_rule_is_still_reported() {
     // Well-formed file: the missing-semicolon ignore has nothing to suppress.
     let content =
         "http {\n    # nginx-lint:ignore missing-semicolon not needed\n    server_tokens off;\n}\n";
@@ -1321,11 +1321,9 @@ fn test_unused_ignore_for_pre_parse_rule_is_still_reported() {
     let conf_path = tmp_dir.path().join("nginx.conf");
     fs::write(&conf_path, content).expect("write conf");
 
-    let pre_parse_errors = pre_parse_checks_from_content(content, None);
     let config = parse_string(content).expect("parse");
     let linter = get_default_linter();
-    let (mut errors, _) = linter.lint_with_content(&config, &conf_path, content);
-    errors.extend(pre_parse_errors);
+    let (errors, _) = linter.lint_with_content(&config, &conf_path, content);
 
     let unused: Vec<_> = errors
         .iter()
@@ -1336,7 +1334,7 @@ fn test_unused_ignore_for_pre_parse_rule_is_still_reported() {
     assert_eq!(
         unused.len(),
         1,
-        "unused ignore for a pre-parse rule must still be flagged, got errors: {:?}",
+        "unused ignore for a registered syntax rule must still be flagged, got errors: {:?}",
         errors,
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2947,7 +2947,10 @@ fn test_fix_unwritable_file_keeps_errors_and_fails() {
 
 /// The same problem detected twice (registered syntax rule + pre-parse
 /// check) must apply its fix only once: `listen 80` becomes `listen 80;`,
-/// not `listen 80;;`.
+/// not `listen 80;;`. (Historical note: this used to guard against two
+/// independent computations of the same rule producing the same fix twice;
+/// there is now only one computation, but the invariant is still worth
+/// protecting against regression.)
 #[cfg(feature = "cli")]
 #[test]
 fn test_fix_applies_duplicate_reported_fix_once() {
@@ -2974,6 +2977,77 @@ fn test_fix_applies_duplicate_reported_fix_once() {
         "exit code should be zero after everything was fixed; stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Multiple simultaneous missing-semicolons must each be detected exactly
+/// once (not duplicated, not merged away) through the real CLI.
+#[cfg(feature = "cli")]
+#[test]
+fn test_multiple_missing_semicolons_reported_individually() {
+    use std::io::Write;
+    use std::process::Command;
+
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(
+        b"events {\n    worker_connections 1024\n}\nhttp {\n    client_max_body_size 10m\n}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .arg(file.path().to_str().unwrap())
+        .output()
+        .expect("Failed to run nginx-lint");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let missing_semicolon_lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.contains("missing-semicolon"))
+        .collect();
+    assert_eq!(
+        missing_semicolon_lines.len(),
+        2,
+        "expected exactly one missing-semicolon report for each of the two \
+         missing semicolons; got:\n{}",
+        stdout
+    );
+}
+
+/// A custom block directive configured via `[parser] block_directives = [...]`
+/// (for extension modules, e.g. nginx-rtmp-module) must be recognised by
+/// `unmatched-braces` through the real CLI end-to-end, not just via the
+/// standalone `check_content_with_extras` helper — this is the registered
+/// `LintRule` dispatch path the CLI actually uses.
+#[cfg(feature = "cli")]
+#[test]
+fn test_unmatched_braces_respects_configured_additional_block_directives_via_cli() {
+    use std::io::Write;
+    use std::process::Command;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    std::fs::write(
+        temp_dir.path().join(".nginx-lint.toml"),
+        "[parser]\nblock_directives = [\"my_custom_block\"]\n",
+    )
+    .unwrap();
+
+    let conf_path = temp_dir.path().join("nginx.conf");
+    let mut file = std::fs::File::create(&conf_path).unwrap();
+    file.write_all(b"http {\n    my_custom_block\n        some_directive value;\n    }\n}\n")
+        .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .arg(conf_path.to_str().unwrap())
+        .output()
+        .expect("Failed to run nginx-lint");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("unmatched-braces") && stdout.contains("my_custom_block"),
+        "expected an unmatched-braces error naming the configured custom \
+         block directive; got:\n{}",
+        stdout
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2943,12 +2943,14 @@ fn test_fix_unwritable_file_keeps_errors_and_fails() {
     );
 }
 
-/// The same problem detected twice (registered syntax rule + pre-parse
-/// check) must apply its fix only once: `listen 80` becomes `listen 80;`,
-/// not `listen 80;;`. (Historical note: this used to guard against two
-/// independent computations of the same rule producing the same fix twice;
-/// there is now only one computation, but the invariant is still worth
-/// protecting against regression.)
+/// A rule's fix must never be applied more than once for the same reported
+/// error: `listen 80` becomes `listen 80;`, not `listen 80;;`.
+///
+/// Historical note: this used to guard against missing-semicolon being
+/// computed via two independent paths (a registered syntax rule and a
+/// separate pre-parse check) that could both report the same problem and
+/// both apply the same fix. There is now only one computation, but the
+/// invariant is still worth protecting against regression.
 #[cfg(feature = "cli")]
 #[test]
 fn test_fix_applies_duplicate_reported_fix_once() {


### PR DESCRIPTION
## Summary

Profiling the CLI's `--profile` output on a large synthetic config (20k directives) showed three native syntax rules — `missing-semicolon`, `unmatched-braces`, `unclosed-quote` — accounting for ~62% of total rule time. Root cause: each linted file ran through **two independent, redundant computations** of these same 3 rules:

1. `pre_parse_checks_from_content()`, called unconditionally from the CLI, using the already-in-memory file content.
2. The same 3 rules' registered `LintRule::check()`, which ignored the parsed `Config`, **re-read the file from disk**, and **re-parsed via `parse_string_rowan()` a second time** — fully redundant with #1.

The two result sets were merged via `extend_errors_dedup()`. Git history shows this was a known, deliberately deferred TODO ("consider deduplicating or unifying these in a future refactor"), not intentional design.

This is pure native CPU/disk-I/O waste, unrelated to any WASM/plugin machinery — applies to every `nginx-lint` invocation regardless of build features.

**Measured**: ~33% total wall-clock reduction on a 20k-directive synthetic config (120ms → 80ms) after removing the redundant path.

## Approach

- Added an opt-in `wants_content()`/`check_with_content()` trait hook to `LintRule`, mirroring the existing `wants_shared_config()`/`check_shared()` pattern — purely additive, no other rule is affected.
- `Linter::lint_with_content`/`lint_with_content_and_profile` now thread the content they already have through to rules that opt in, instead of those rules re-reading the file.
- `missing-semicolon`, `unmatched-braces`, `unclosed-quote` opt in.
- Removed the now-redundant `pre_parse_checks_from_content` calls (and their `extend_errors_dedup` merge) from the CLI's `lint_file`/`lint_content`.
- Removed `pre_parse_checks`/`pre_parse_checks_with_config`/`pre_parse_checks_from_content` entirely once they had no remaining callers in the shipped CLI (only tests referenced them after the above).

## Correctness gaps fixed along the way

Investigation surfaced two pre-existing bugs in the duplicated design that the fix corrects:

- `--rule-only unmatched-braces` (excluding `missing-semicolon`) previously still reported `missing-semicolon` errors, because the pre-parse pass ran unconditionally regardless of rule filtering.
- `unmatched-braces`'s registered path ignored a configured `[parser] block_directives` (`additional_block_directives`) for extension modules — only the pre-parse path respected it. `UnmatchedBraces` now carries this state (constructed via `with_additional_block_directives`, mirroring the existing `Indent{indent_size}`/`IncludePathExists::with_path_mappings_and_prefix` pattern) so both paths behave consistently.

## Test harness fix (and two new issues filed as a result)

`test_all_rule_fixtures` built its `Config` via `parse_config`, which fails on any syntax error — so its fix-application check silently never ran for missing-semicolon/unmatched-braces/unclosed-quote's own fixtures (they deliberately contain syntax errors). Switched it to `parse_string_with_errors`, the same error-recovery parser the real CLI uses, so that check now actually exercises these fixtures.

This immediately surfaced two pre-existing, unrelated autofix bugs that had never been caught — filed as #294 and #295, and temporarily skipped via a documented `FIXTURES_WITH_KNOWN_FIX_BUGS` list (not silently ignored) pending real fixes there:
- unmatched-braces misplaces all missing closing braces at end-of-file when only comment lines follow the unclosed block.
- unclosed-quote can close the wrong (already-balanced) line instead of the actually-unclosed one.

## Test plan

- [x] `cargo test` (default features), `cargo test --features plugins`, `cargo test --no-default-features --features cli,wasm-builtin-plugins` — all green
- [x] `cargo clippy --workspace --features plugins -- -D clippy::all` clean, `cargo fmt --check` clean
- [x] New regression tests: `test_registered_rule_respects_additional_block_directives` (unit), `test_multiple_missing_semicolons_reported_individually` and `test_unmatched_braces_respects_configured_additional_block_directives_via_cli` (integration, drive the real CLI binary)
- [x] Verified the new integration tests fail without their respective fixes (temporarily reverted and confirmed failure)
- [x] Diffed CLI output across every fixture `.conf` file in the repo between `main` and this branch — byte-identical except for one pre-existing, unrelated non-deterministic ordering in the `directive-inheritance` plugin (confirmed present on `main` too, independent of this change)
- [x] Empirically confirmed the `--rule-only` bug fix and the `--profile`/wall-clock timing improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
