### PR TITLE
fix: unmatched-braces autofix misplaces closing braces after comment-only lines

### DIFF
--- a/src/rules/syntax/unmatched_braces.rs
+++ b/src/rules/syntax/unmatched_braces.rs
@@ -1180,14 +1180,22 @@ events {
     /// comment-only lines were skipped entirely rather than considered.
     #[test]
     fn test_fix_unclosed_inserts_before_marker_comment() {
-        let content = "http {\n    server_tokens on;\n# closing brace goes here\n";
+        let content = r#"http {
+    server_tokens on;
+# closing brace goes here
+"#;
         let errors = check_braces(content);
         assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
 
         let fix = errors[0].fixes.first().expect("Expected fix");
         let result = apply_fix(content, fix);
         assert_eq!(
-            result, "http {\n    server_tokens on;\n}\n# closing brace goes here\n",
+            result,
+            r#"http {
+    server_tokens on;
+}
+# closing brace goes here
+"#,
             "Fix should insert }} right before the marker comment"
         );
     }
@@ -1197,7 +1205,12 @@ events {
     /// marker — it must be skipped like a blank line, not used as an anchor.
     #[test]
     fn test_fix_unclosed_skips_deeper_indented_comment() {
-        let content = "http {\n    server {\n        listen 80;\n        # inline comment about listen\n    }\n";
+        let content = r#"http {
+    server {
+        listen 80;
+        # inline comment about listen
+    }
+"#;
         let errors = check_braces(content);
         assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
         assert!(errors[0].message.contains("Unclosed brace"));
@@ -1219,8 +1232,12 @@ events {
     /// at the right position — the original repro shape for issue #294.
     #[test]
     fn test_fix_unclosed_nested_multiple_marker_comments() {
-        let content =
-            "http {\n  server {\n    listen 80;\n  # missing server brace\n# missing http brace\n";
+        let content = r#"http {
+  server {
+    listen 80;
+  # missing server brace
+# missing http brace
+"#;
         let errors = check_braces(content);
         assert_eq!(errors.len(), 2, "Expected 2 errors, got: {:?}", errors);
 
@@ -1229,7 +1246,14 @@ events {
         assert_eq!(applied, 2, "Both fixes should apply without conflict");
         assert_eq!(
             result,
-            "http {\n  server {\n    listen 80;\n  }\n  # missing server brace\n}\n# missing http brace\n",
+            r#"http {
+  server {
+    listen 80;
+  }
+  # missing server brace
+}
+# missing http brace
+"#,
         );
     }
 

--- a/src/rules/syntax/unmatched_braces.rs
+++ b/src/rules/syntax/unmatched_braces.rs
@@ -340,7 +340,14 @@ impl UnmatchedBraces {
     /// Scans lines after `brace_line` (1-based) looking for the first line
     /// whose first non-trivia token starts at indentation ≤ `brace_indent`.
     /// Returns the byte offset of that line's start (so `}` is inserted
-    /// before it). Falls back to `source.len()` (EOF) if no such line exists.
+    /// before it). A comment-only line at or before `brace_indent` is also
+    /// treated as a valid anchor (e.g. a `# missing closing brace here`
+    /// marker) — a comment can't be block content that needs to stay inside,
+    /// so there's no ambiguity to guard against the way there is for real
+    /// directives at the same indent (see the `is_block_boundary` check
+    /// below). A comment indented deeper than `brace_indent` is just part of
+    /// the block's content and is skipped, same as blank lines. Falls back
+    /// to `source.len()` (EOF) if no such line exists.
     fn find_close_brace_offset(
         source: &str,
         line_tokens: &[Vec<&FlatToken>],
@@ -353,7 +360,19 @@ impl UnmatchedBraces {
             let mut meaningful = line_toks.iter().filter(|t| !t.kind.is_trivia());
             let first_meaningful = match meaningful.next() {
                 Some(tok) => tok,
-                None => continue, // blank or comment-only line
+                None => {
+                    // Blank or comment-only line.
+                    if let Some(comment) = line_toks.iter().find(|t| t.kind == SyntaxKind::COMMENT)
+                    {
+                        let indent = Self::line_indent(source, comment.offset);
+                        if indent <= brace_indent {
+                            let line_start =
+                                source[..comment.offset].rfind('\n').map_or(0, |i| i + 1);
+                            return Self::skip_blank_lines_backward(source, line_start);
+                        }
+                    }
+                    continue;
+                }
             };
 
             // Skip lines that only contain `}` — those closing braces were
@@ -1151,6 +1170,66 @@ events {
             result.ends_with("}\n"),
             "Fix should append at EOF, got:\n{}",
             result
+        );
+    }
+
+    /// A comment at or below the unclosed block's own indentation is a valid
+    /// anchor for the missing `}` — regression test for
+    /// https://github.com/walf443/nginx-lint/issues/294, where three such
+    /// braces all fell back to EOF instead of their marked positions because
+    /// comment-only lines were skipped entirely rather than considered.
+    #[test]
+    fn test_fix_unclosed_inserts_before_marker_comment() {
+        let content = "http {\n    server_tokens on;\n# closing brace goes here\n";
+        let errors = check_braces(content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+
+        let fix = errors[0].fixes.first().expect("Expected fix");
+        let result = apply_fix(content, fix);
+        assert_eq!(
+            result, "http {\n    server_tokens on;\n}\n# closing brace goes here\n",
+            "Fix should insert }} right before the marker comment"
+        );
+    }
+
+    /// A comment indented deeper than the unclosed block is just part of the
+    /// block's content (e.g. an inline explanatory comment), not a boundary
+    /// marker — it must be skipped like a blank line, not used as an anchor.
+    #[test]
+    fn test_fix_unclosed_skips_deeper_indented_comment() {
+        let content = "http {\n    server {\n        listen 80;\n        # inline comment about listen\n    }\n";
+        let errors = check_braces(content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+        assert!(errors[0].message.contains("Unclosed brace"));
+
+        let fix = errors[0].fixes.first().expect("Expected fix");
+        let result = apply_fix(content, fix);
+        // `http {` (indent 0) is unclosed; the deeper-indented comment inside
+        // `server {}` must not be mistaken for the boundary, so the fix falls
+        // through to EOF (there's no line at indent <= 0 after it).
+        assert!(
+            result.ends_with("}\n"),
+            "Fix should append at EOF, not before the deeper-indented comment, got:\n{}",
+            result
+        );
+    }
+
+    /// Multiple nested unclosed blocks, each marked only by a trailing
+    /// comment at its own indentation, must each get their own `}` inserted
+    /// at the right position — the original repro shape for issue #294.
+    #[test]
+    fn test_fix_unclosed_nested_multiple_marker_comments() {
+        let content =
+            "http {\n  server {\n    listen 80;\n  # missing server brace\n# missing http brace\n";
+        let errors = check_braces(content);
+        assert_eq!(errors.len(), 2, "Expected 2 errors, got: {:?}", errors);
+
+        let fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
+        let (result, applied) = crate::apply_fixes_to_content(content, &fixes);
+        assert_eq!(applied, 2, "Both fixes should apply without conflict");
+        assert_eq!(
+            result,
+            "http {\n  server {\n    listen 80;\n  }\n  # missing server brace\n}\n# missing http brace\n",
         );
     }
 

--- a/src/rules/syntax/unmatched_braces.rs
+++ b/src/rules/syntax/unmatched_braces.rs
@@ -342,12 +342,14 @@ impl UnmatchedBraces {
     /// Returns the byte offset of that line's start (so `}` is inserted
     /// before it). A comment-only line at or before `brace_indent` is also
     /// treated as a valid anchor (e.g. a `# missing closing brace here`
-    /// marker) — a comment can't be block content that needs to stay inside,
-    /// so there's no ambiguity to guard against the way there is for real
-    /// directives at the same indent (see the `is_block_boundary` check
-    /// below). A comment indented deeper than `brace_indent` is just part of
-    /// the block's content and is skipped, same as blank lines. Falls back
-    /// to `source.len()` (EOF) if no such line exists.
+    /// marker), but only if no real content indented deeper than
+    /// `brace_indent` follows it later — such content must stay inside the
+    /// block, so a same-indent comment preceding it is just a stray note,
+    /// not the block's actual end (see [`nested_content_follows`]
+    /// (Self::nested_content_follows)). A comment indented deeper than
+    /// `brace_indent` is just part of the block's content and is skipped,
+    /// same as blank lines. Falls back to `source.len()` (EOF) if no
+    /// qualifying line exists.
     fn find_close_brace_offset(
         source: &str,
         line_tokens: &[Vec<&FlatToken>],
@@ -356,7 +358,7 @@ impl UnmatchedBraces {
     ) -> usize {
         // line_tokens is 0-indexed; brace_line is 1-based.
         // Start scanning from the line after the brace.
-        for line_toks in line_tokens.iter().skip(brace_line) {
+        for (line_idx, line_toks) in line_tokens.iter().enumerate().skip(brace_line) {
             let mut meaningful = line_toks.iter().filter(|t| !t.kind.is_trivia());
             let first_meaningful = match meaningful.next() {
                 Some(tok) => tok,
@@ -365,7 +367,21 @@ impl UnmatchedBraces {
                     if let Some(comment) = line_toks.iter().find(|t| t.kind == SyntaxKind::COMMENT)
                     {
                         let indent = Self::line_indent(source, comment.offset);
-                        if indent <= brace_indent {
+                        // Reject a same-indent comment if real content still
+                        // to come needs to stay inside this block (e.g. a
+                        // stray unindented note followed by more nested
+                        // directives) — same ambiguity the `is_block_boundary`
+                        // check below guards against for real directives, but
+                        // a comment has no `{` to signal "definitely a new
+                        // sibling", so we look ahead instead.
+                        if indent <= brace_indent
+                            && !Self::nested_content_follows(
+                                source,
+                                line_tokens,
+                                line_idx + 1,
+                                brace_indent,
+                            )
+                        {
                             let line_start =
                                 source[..comment.offset].rfind('\n').map_or(0, |i| i + 1);
                             return Self::skip_blank_lines_backward(source, line_start);
@@ -399,6 +415,31 @@ impl UnmatchedBraces {
 
         // No line with lower indentation found — insert at EOF
         source.len()
+    }
+
+    /// Whether real (non-comment) content indented deeper than `brace_indent`
+    /// appears at or after `from_line`, before any line that would itself
+    /// qualify as a boundary.
+    ///
+    /// Used to decide whether a same-indent comment genuinely marks the end
+    /// of a block, or is just a stray note with more nested content still to
+    /// come after it (which must stay inside the block, so the comment must
+    /// not be used as the closing brace's anchor).
+    fn nested_content_follows(
+        source: &str,
+        line_tokens: &[Vec<&FlatToken>],
+        from_line: usize,
+        brace_indent: usize,
+    ) -> bool {
+        for line_toks in line_tokens.iter().skip(from_line) {
+            // Comments and blank lines don't tell us anything either way —
+            // keep looking past them for the next real content.
+            let Some(real) = line_toks.iter().find(|t| !t.kind.is_trivia()) else {
+                continue;
+            };
+            return Self::line_indent(source, real.offset) > brace_indent;
+        }
+        false
     }
 
     /// Given a byte offset at a line start, skip backward past any preceding
@@ -1254,6 +1295,36 @@ events {
 }
 # missing http brace
 "#,
+        );
+    }
+
+    /// A comment at the unclosed block's own indentation is NOT a valid
+    /// anchor if real content still to come is indented deeper — that
+    /// content must stay inside the block, so the comment is just a stray
+    /// note, not the block's actual end. Without this guard the fix would
+    /// insert `}` right after the comment and orphan `server_name` outside
+    /// the block it belongs to.
+    #[test]
+    fn test_fix_unclosed_ignores_marker_comment_followed_by_more_nested_content() {
+        let content = r#"server {
+    listen 80;
+# note: added later
+    server_name example.com;
+"#;
+        let errors = check_braces(content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+
+        let fix = errors[0].fixes.first().expect("Expected fix");
+        let result = apply_fix(content, fix);
+        assert_eq!(
+            result,
+            r#"server {
+    listen 80;
+# note: added later
+    server_name example.com;
+}
+"#,
+            "Fix should fall back to EOF rather than split the block before server_name"
         );
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -578,24 +578,11 @@ fn dir_name_to_rule_name(dir_name: &str) -> String {
 /// succeeded on the error fixture, which it never does for these rules' own
 /// fixtures (they deliberately contain syntax errors).
 ///
-/// - unmatched_braces/001_basic, 002_without_comment, 004_nested_missing,
-///   005_multiple_blocks: see
-///   https://github.com/walf443/nginx-lint/issues/294 — `find_close_brace_offset`
-///   treats comment-only lines as trivia rather than valid insertion anchors,
-///   so when everything after an unclosed block is comment-only, all of that
-///   block's missing closing braces fall back to end-of-file instead of their
-///   intended positions.
 /// - unclosed_quote/005_no_semicolon: see
 ///   https://github.com/walf443/nginx-lint/issues/295 — the fix leaves the
 ///   actual unclosed quote untouched and instead adds a spurious closing
 ///   quote to a different, already-correctly-quoted line.
-const FIXTURES_WITH_KNOWN_FIX_BUGS: &[(&str, &str)] = &[
-    ("unmatched_braces", "001_basic"),
-    ("unmatched_braces", "002_without_comment"),
-    ("unmatched_braces", "004_nested_missing"),
-    ("unmatched_braces", "005_multiple_blocks"),
-    ("unclosed_quote", "005_no_semicolon"),
-];
+const FIXTURES_WITH_KNOWN_FIX_BUGS: &[(&str, &str)] = &[("unclosed_quote", "005_no_semicolon")];
 
 /// Test case information for parallel execution
 struct RuleTestCase {


### PR DESCRIPTION
## Summary

Fixes #294.

`UnmatchedBraces`'s autofix (`--fix`) could insert all missing closing braces at end-of-file instead of at their correct positions, whenever the lines following an unclosed block were comment-only.

## Root cause

`find_close_brace_offset` scans forward from an unclosed `{` looking for the first line whose first non-trivia token is at indentation ≤ the brace's own indentation, and inserts `}` right before that line. Comment tokens are trivia and were skipped entirely — so a comment-only line was never considered a valid "insert here" anchor. `tests/fixtures/rules/syntax/unmatched_braces/001_basic` is built around exactly this: three unclosed blocks, each followed by an explanatory `# Missing closing brace for ...` marker comment at the matching indentation. Since everything after the unclosed blocks was comment-only, the scan found no qualifying line for any of them and fell back to end-of-file for all three.

## Fix

A comment-only line at or before the unclosed block's own indentation is now treated as a valid anchor too (insert `}` right before it), *unless* real (non-comment) content indented deeper than the block still follows later in the file — in that case the comment is just a stray note in the middle of the block, not its actual end, and using it as the anchor would orphan that later content outside the block. A comment indented *deeper* than the block is still skipped, same as a blank line, since it's just part of the block's content.

(This lookahead guard was added in a follow-up commit after review caught that the first version used an unconditional `indent <= brace_indent` check, unlike the existing `is_block_boundary` heuristic for real directives at the same indent, which requires strict `indent < brace_indent` or an `L_BRACE` specifically to avoid this same ambiguity.)

This lets `test_all_rule_fixtures`'s fix-verification pass for `unmatched_braces/001_basic`, `002_without_comment`, `004_nested_missing`, and `005_multiple_blocks` — all four removed from `FIXTURES_WITH_KNOWN_FIX_BUGS`.

## New issue found along the way

While manually verifying the fix against the full default rule set (not just `--rule-only unmatched-braces`), I found that `unmatched-braces`'s fix can conflict with `indent`'s fix when both are applied together in the same `--fix` run, producing malformed output. This is unrelated to comment handling — a general fix-application-ordering gap between any two rules whose fixes touch nearby regions — so it's filed separately as #296 rather than addressed here.

## Test plan

- [x] `cargo test` (default features), `cargo test --features plugins`, `cargo test --no-default-features --features cli,wasm-builtin-plugins` — all green
- [x] `cargo clippy --workspace --features plugins -- -D clippy::all` clean, `cargo fmt --check` clean
- [x] New unit tests: a comment-only marker line is used as the anchor; a comment indented deeper than the block is skipped (not used as anchor); multiple nested unclosed blocks each marked by their own comment get distinct, correct fixes
- [x] Verified the new tests fail on the pre-fix code (temporarily reverted the fix and confirmed failure)
- [x] Verified in isolation via `nginx-lint --rule-only unmatched-braces --fix` that all four previously-broken fixtures now produce byte-identical output to their `expected/nginx.conf`
- [x] New regression test for the lookahead guard: a same-indent comment followed by more deeply-nested real content is not used as the anchor (falls back to EOF instead of splitting the block); verified this test fails without the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
