### PR TITLE
fix: unclosed-quote autofix redirects to the real culprit line instead of a dangling artifact

### DIFF
--- a/src/rules/syntax/unclosed_quote.rs
+++ b/src/rules/syntax/unclosed_quote.rs
@@ -55,8 +55,16 @@ impl UnclosedQuote {
         let (root, _syntax_errors) = parse_string_rowan(source);
         let line_index = LineIndex::new(source);
         let mut errors = Vec::new();
+        let mut last_double: Option<(String, usize)> = None;
+        let mut last_single: Option<(String, usize)> = None;
 
-        Self::walk_node(&root, &line_index, &mut errors);
+        Self::walk_node(
+            &root,
+            &line_index,
+            &mut errors,
+            &mut last_double,
+            &mut last_single,
+        );
 
         errors
     }
@@ -65,7 +73,20 @@ impl UnclosedQuote {
     ///
     /// BLOCK nodes belonging to raw block directives (lua etc.) are skipped
     /// entirely, avoiding per-token ancestor checks.
-    fn walk_node(node: &SyntaxNode, line_index: &LineIndex, errors: &mut Vec<LintError>) {
+    ///
+    /// `last_double`/`last_single` track the most recently seen
+    /// DOUBLE_QUOTED_STRING/SINGLE_QUOTED_STRING token's own text and start
+    /// offset, in document order across the whole file — used by
+    /// [`redirect_to_prior_open_quote`](Self::redirect_to_prior_open_quote)
+    /// to find the real culprit when an unrelated later quote happens to
+    /// make the lexer's naive pairing land on the wrong token.
+    fn walk_node(
+        node: &SyntaxNode,
+        line_index: &LineIndex,
+        errors: &mut Vec<LintError>,
+        last_double: &mut Option<(String, usize)>,
+        last_single: &mut Option<(String, usize)>,
+    ) {
         for child in node.children_with_tokens() {
             match child {
                 SyntaxElement::Node(child_node) => {
@@ -75,7 +96,7 @@ impl UnclosedQuote {
                     {
                         continue;
                     }
-                    Self::walk_node(&child_node, line_index, errors);
+                    Self::walk_node(&child_node, line_index, errors, last_double, last_single);
                 }
                 SyntaxElement::Token(token) => {
                     let (quote_char, quote_name) = match token.kind() {
@@ -85,19 +106,34 @@ impl UnclosedQuote {
                     };
 
                     let text = token.text();
+                    let offset: usize = token.text_range().start().into();
+                    let prior = if quote_char == '"' {
+                        &mut *last_double
+                    } else {
+                        &mut *last_single
+                    };
 
                     // A properly closed string starts and ends with the same quote
                     if text.len() >= 2 && text.ends_with(quote_char) {
+                        // Remember it in case a later token turns out to be a
+                        // dangling artifact caused by this one swallowing more
+                        // than one line (see redirect_to_prior_open_quote).
+                        *prior = Some((text.to_string(), offset));
                         continue;
                     }
 
-                    // Unclosed quote detected
-                    let offset: usize = token.text_range().start().into();
-                    let pos = line_index.position(offset);
+                    // Unclosed quote detected (per the lexer's naive pairing).
+                    // If this looks like a dangling artifact rather than a
+                    // genuine unclosed string, redirect to the real culprit.
+                    let (report_offset, fix) =
+                        match Self::redirect_to_prior_open_quote(quote_char, text, prior) {
+                            Some((prior_offset, fix)) => (prior_offset, Some(fix)),
+                            None => (offset, Self::create_fix(quote_char, text, offset)),
+                        };
+
+                    let pos = line_index.position(report_offset);
                     let message =
                         format!("Unclosed {} - missing closing {}", quote_name, quote_char);
-
-                    let fix = Self::create_fix(quote_char, text, offset);
 
                     let mut error =
                         LintError::new("unclosed-quote", "syntax", &message, Severity::Error)
@@ -154,6 +190,52 @@ impl UnclosedQuote {
             insert_offset,
             &quote.to_string(),
         ))
+    }
+
+    /// If `text` looks like a dangling artifact rather than a genuinely
+    /// unclosed string, and `prior` (the preceding same-kind quoted-string
+    /// token) looks like the real culprit, return a redirected `(offset,
+    /// fix)` pointing at `prior` instead.
+    ///
+    /// A single unclosed `"`/`'` followed later by an unrelated line that
+    /// happens to contain the same quote character makes the lexer pair
+    /// them up: e.g. `add_header X-Custom "value;\nreturn 200 "ok";` lexes
+    /// as one (nominally "closed") string spanning both lines, followed by
+    /// a second string starting right after `ok`'s closing quote and
+    /// running to EOF (or the next quote) — genuinely unclosed, but not the
+    /// real problem. That dangling token has essentially no content of its
+    /// own before its line's semicolon (it starts right where a real
+    /// quote's closing character was); `prior` spanning multiple lines with
+    /// a semicolon on its own first line is the actual missing-quote line.
+    fn redirect_to_prior_open_quote(
+        quote: char,
+        text: &str,
+        prior: &Option<(String, usize)>,
+    ) -> Option<(usize, Fix)> {
+        let first_line = text.lines().next().unwrap_or(text);
+        let semicolon_pos = first_line.rfind(';')?;
+        let before_semicolon = &first_line[..semicolon_pos];
+
+        // The token always starts with a quote character, so before_semicolon
+        // is at least 1 byte. Guard defensively anyway.
+        if before_semicolon.is_empty() {
+            return None;
+        }
+        if !before_semicolon[1..].trim().is_empty() {
+            return None; // has real content of its own; not a dangling artifact
+        }
+
+        let (prior_text, prior_offset) = prior.as_ref()?;
+        if !prior_text.contains('\n') {
+            return None; // prior didn't span multiple lines, nothing to redirect
+        }
+        let prior_first_line = prior_text.lines().next().unwrap_or(prior_text);
+        if !prior_first_line.contains(';') {
+            return None;
+        }
+
+        let fix = Self::create_fix(quote, prior_text, *prior_offset)?;
+        Some((*prior_offset, fix))
     }
 }
 
@@ -404,6 +486,75 @@ mod tests {
         let errors = check_quotes(content);
         assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
         assert!(errors[0].message.contains("double quote"));
+    }
+
+    /// Regression test for https://github.com/walf443/nginx-lint/issues/295.
+    ///
+    /// `add_header`'s string is genuinely unclosed; `return`'s string on the
+    /// next line is already fine. The lexer's naive pairing makes
+    /// `add_header`'s opening quote look "closed" by `return`'s opening
+    /// quote (spanning both lines), leaving `return`'s own closing quote as
+    /// a dangling, genuinely-unclosed token to EOF — the wrong place to
+    /// report and fix. The fix must redirect to the real culprit
+    /// (`add_header`'s line) instead of adding a spurious `"` next to
+    /// `return`'s already-correct string.
+    #[test]
+    fn test_fix_redirects_to_real_unclosed_line_not_dangling_artifact() {
+        let content = r#"location / {
+    add_header X-Custom "value;
+    return 200 "ok";
+}
+"#;
+        let errors = check_quotes(content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+        assert_eq!(
+            errors[0].line,
+            Some(2),
+            "Error should be reported on add_header's line, not return's"
+        );
+
+        let fix = errors[0].fixes.first().expect("Expected a fix");
+        let result = apply_fix(content, fix);
+        assert_eq!(
+            result,
+            r#"location / {
+    add_header X-Custom "value";
+    return 200 "ok";
+}
+"#,
+            "Fix should close add_header's quote, not add a spurious quote to return's line"
+        );
+    }
+
+    /// Same redirect as `test_fix_redirects_to_real_unclosed_line_not_dangling_artifact`,
+    /// but for single-quoted strings — `last_double`/`last_single` are
+    /// tracked independently, so this exercises that path separately.
+    #[test]
+    fn test_fix_redirects_to_real_unclosed_line_not_dangling_artifact_single_quote() {
+        let content = r#"location / {
+    add_header X-Custom 'value;
+    return 200 'ok';
+}
+"#;
+        let errors = check_quotes(content);
+        assert_eq!(errors.len(), 1, "Expected 1 error, got: {:?}", errors);
+        assert_eq!(
+            errors[0].line,
+            Some(2),
+            "Error should be reported on add_header's line, not return's"
+        );
+
+        let fix = errors[0].fixes.first().expect("Expected a fix");
+        let result = apply_fix(content, fix);
+        assert_eq!(
+            result,
+            r#"location / {
+    add_header X-Custom 'value';
+    return 200 'ok';
+}
+"#,
+            "Fix should close add_header's quote, not add a spurious quote to return's line"
+        );
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -577,12 +577,7 @@ fn dir_name_to_rule_name(dir_name: &str) -> String {
 /// used to run only when `parse_config` (which fails on any syntax error)
 /// succeeded on the error fixture, which it never does for these rules' own
 /// fixtures (they deliberately contain syntax errors).
-///
-/// - unclosed_quote/005_no_semicolon: see
-///   https://github.com/walf443/nginx-lint/issues/295 — the fix leaves the
-///   actual unclosed quote untouched and instead adds a spurious closing
-///   quote to a different, already-correctly-quoted line.
-const FIXTURES_WITH_KNOWN_FIX_BUGS: &[(&str, &str)] = &[("unclosed_quote", "005_no_semicolon")];
+const FIXTURES_WITH_KNOWN_FIX_BUGS: &[(&str, &str)] = &[];
 
 /// Test case information for parallel execution
 struct RuleTestCase {


### PR DESCRIPTION
## Summary

Fixes #295.

`UnclosedQuote`'s autofix (`--fix`) could leave the actual unclosed quote untouched and instead add a spurious closing quote to a *different*, already-correctly-quoted line.

## Root cause

Given:
```
add_header X-Custom "value;
return 200 "ok";
```
`add_header`'s string is genuinely missing its closing quote; `return`'s string is already fine. The lexer's naive greedy pairing doesn't know that, though — it just pairs quote characters in document order. So it lexes `"value;\n    return 200 "` (from `add_header`'s opening quote to `return`'s opening quote) as ONE token that nominally "ends with `"`", i.e. looks closed. That leaves a second, genuinely dangling token starting right after `ok`'s closing quote and running to EOF (no more `"` characters left to close it) — this is what actually gets flagged as "unclosed", at the wrong line, with essentially no real content of its own. The old fix logic inserted `"` right next to it, producing `ok"";` while leaving `add_header`'s real problem untouched.

This is the same class of ambiguity already documented by `test_multiple_unclosed_quotes_same_type_even`/`_odd` (odd/even quote counts pairing up in ways that can misattribute which token is "the" unclosed one) — just triggered here by a semicolon+newline shape instead of adjacent same-line quotes.

## Fix

`walk_node` now tracks the most recently seen `DOUBLE_QUOTED_STRING`/`SINGLE_QUOTED_STRING` token (its text and start offset) in document order. When a flagged (unclosed) token has essentially no content of its own before its line's semicolon — the signature of a dangling artifact — and the prior same-kind token spans multiple lines with a semicolon on its own first line, the error's reported position and fix are redirected there instead, reusing the existing `create_fix` logic unchanged.

**Detection is intentionally untouched** — which token gets flagged (and therefore error counts for the existing multi-quote scenarios) is unchanged; only the reported position and fix target are corrected for this specific dangling-artifact shape. This keeps the change minimal and preserves all existing test expectations.

`test_all_rule_fixtures`'s `FIXTURES_WITH_KNOWN_FIX_BUGS` list is now empty — this was the last entry.

## Known remaining gap (filed separately as #299)

The redirect only looks at the single most recently seen same-kind quoted-string token. A `"`/`'` character inside a trailing (end-of-line) `#` comment can create a longer chain (the lexer doesn't treat `#` specially once inside a string, so it can swallow a comment's quote as its own closing character) that this one-hop redirect doesn't follow — reproducing the same wrong-line-fix symptom via a different trigger. This is a deeper problem than the reported #295 shape (the culprit token here is single-line, breaking the "single-line-closed = unrelated to any chain" assumption this fix relies on), so it's tracked separately rather than expanding this PR's scope.

## Test plan

- [x] `cargo test` (default features), `cargo test --features plugins`, `cargo test --no-default-features --features cli,wasm-builtin-plugins` — all green
- [x] `cargo clippy --workspace --features plugins -- -D clippy::all` clean, `cargo fmt --check` clean
- [x] All 17 pre-existing `unclosed_quote` unit tests still pass unchanged, including the odd/even multi-quote pairing tests
- [x] New regression tests for both double- and single-quote variants of the redirect; verified both fail without the fix (temporarily reverted and confirmed failure)
- [x] Verified in isolation via `nginx-lint --rule-only unclosed-quote --fix` that `unclosed_quote/005_no_semicolon`'s fix now produces byte-identical output to its `expected/nginx.conf`
- [x] `test_all_rule_fixtures` now passes with an empty `FIXTURES_WITH_KNOWN_FIX_BUGS` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
