### PR TITLE
fix: apply_fixes_to_content_detailed no longer merges a whitespace fix into a structural insert

### DIFF
--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -562,11 +562,18 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
     (result.content, result.applied)
 }
 
-/// Whether `s` is non-empty and consists entirely of whitespace — used to
-/// tell a pure reformatting insert (e.g. `indent`'s fixes) apart from one
-/// that inserts real content (e.g. a missing closing brace).
+/// Whether `s` is non-empty and consists entirely of whitespace — i.e. an
+/// insert of `s` is pure reformatting (e.g. `indent`'s fixes), not content.
 fn is_whitespace_only(s: &str) -> bool {
     !s.is_empty() && s.chars().all(char::is_whitespace)
+}
+
+/// Whether `s` contains at least one non-whitespace character — i.e. an
+/// insert of `s` adds real content (e.g. a missing closing brace), not just
+/// whitespace. The complement of [`is_whitespace_only`] over non-empty
+/// strings; both are `false` for the empty string (a no-op insert).
+fn has_non_whitespace(s: &str) -> bool {
+    s.chars().any(|c| !c.is_whitespace())
 }
 
 /// Apply fixes to content string, reporting skipped fixes.
@@ -615,10 +622,23 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
         }
     });
 
+    // Offsets that have at least one structural (content-inserting) zero-width
+    // insert, e.g. `unmatched-braces` inserting a missing `}`. Computed over
+    // the whole fix set up front so the decision below doesn't depend on the
+    // order fixes happen to be processed in — the ascending-indent sort tiebreak
+    // means a structural insert with more leading whitespace than a competing
+    // reformatting insert would otherwise be processed second and let both apply.
+    let structural_insert_offsets: std::collections::HashSet<usize> = range_fixes
+        .iter()
+        .filter(|f| {
+            f.start_offset.unwrap() == f.end_offset.unwrap() && has_non_whitespace(&f.new_text)
+        })
+        .map(|f| f.start_offset.unwrap())
+        .collect();
+
     let mut fix_count = 0;
     let mut result = content.to_string();
-    // (start, end, was this insert's new_text whitespace-only)
-    let mut applied_ranges: Vec<(usize, usize, bool)> = Vec::new();
+    let mut applied_ranges: Vec<(usize, usize)> = Vec::new();
 
     for fix in &range_fixes {
         let start = fix.start_offset.unwrap();
@@ -626,9 +646,7 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
         let is_insert = start == end;
 
         // Check if this range overlaps with any already applied range
-        let overlaps = applied_ranges
-            .iter()
-            .any(|(s, e, _)| start < *e && end > *s);
+        let overlaps = applied_ranges.iter().any(|(s, e)| start < *e && end > *s);
 
         // Two zero-width inserts at the identical point don't trip the
         // check above (touching, not overlapping) — which is intentional
@@ -638,10 +656,10 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
         // inserts real content (e.g. `unmatched-braces` inserting a missing
         // `}`) produces nonsensical interleaved output — the whitespace fix
         // was computed against a structure this other fix is about to
-        // change anyway, so drop it.
+        // change anyway, so drop it (regardless of which is processed first).
         let conflicts_with_structural_insert = is_insert
             && is_whitespace_only(&fix.new_text)
-            && applied_ranges.iter().any(|(s, _, ws)| *s == start && !*ws);
+            && structural_insert_offsets.contains(&start);
 
         if overlaps || conflicts_with_structural_insert {
             continue;
@@ -655,11 +673,7 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
             && result.is_char_boundary(end)
         {
             result.replace_range(start..end, &fix.new_text);
-            applied_ranges.push((
-                start,
-                start + fix.new_text.len(),
-                is_insert && is_whitespace_only(&fix.new_text),
-            ));
+            applied_ranges.push((start, start + fix.new_text.len()));
             fix_count += 1;
         } else {
             skipped_invalid += 1;
@@ -900,6 +914,30 @@ mod fix_tests {
         assert_eq!(
             result.content, "}\n# Missing closing brace for http\n",
             "the whitespace-only fix must be dropped, not interleaved with the brace"
+        );
+        assert_eq!(result.applied, 1);
+    }
+
+    /// The whitespace-vs-structural conflict must be resolved independently
+    /// of processing order. A structural insert's own `new_text` can carry
+    /// MORE leading whitespace than the competing whitespace-only fix — e.g.
+    /// `unmatched-braces` closing a deeply-nested block emits
+    /// `"      }\n"` (its brace at the block's own indent), while `indent`
+    /// proposes a smaller reindent for the same line (plausible on
+    /// unclosed-brace input, cf. #300). The ascending-indent sort tiebreak
+    /// then processes the whitespace-only fix FIRST, so a check that only
+    /// looked at already-applied fixes would miss the conflict and let both
+    /// apply. The structural fix must still win.
+    #[test]
+    fn test_whitespace_only_insert_skipped_even_when_structural_insert_is_more_indented() {
+        let content = "# note\n";
+        let close_brace = Fix::replace_range(0, 0, "      }\n"); // 6 leading spaces
+        let reindent = Fix::replace_range(0, 0, "  "); // 2 leading spaces
+        let fixes: Vec<&Fix> = vec![&close_brace, &reindent];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(
+            result.content, "      }\n# note\n",
+            "structural fix must win regardless of relative leading-whitespace ordering"
         );
         assert_eq!(result.applied, 1);
     }

--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -562,6 +562,13 @@ pub fn apply_fixes_to_content(content: &str, fixes: &[&Fix]) -> (String, usize) 
     (result.content, result.applied)
 }
 
+/// Whether `s` is non-empty and consists entirely of whitespace — used to
+/// tell a pure reformatting insert (e.g. `indent`'s fixes) apart from one
+/// that inserts real content (e.g. a missing closing brace).
+fn is_whitespace_only(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(char::is_whitespace)
+}
+
 /// Apply fixes to content string, reporting skipped fixes.
 ///
 /// All fixes (both line-based and offset-based) are normalized to offset-based,
@@ -610,15 +617,33 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
 
     let mut fix_count = 0;
     let mut result = content.to_string();
-    let mut applied_ranges: Vec<(usize, usize)> = Vec::new();
+    // (start, end, was this insert's new_text whitespace-only)
+    let mut applied_ranges: Vec<(usize, usize, bool)> = Vec::new();
 
     for fix in &range_fixes {
         let start = fix.start_offset.unwrap();
         let end = fix.end_offset.unwrap();
+        let is_insert = start == end;
 
         // Check if this range overlaps with any already applied range
-        let overlaps = applied_ranges.iter().any(|(s, e)| start < *e && end > *s);
-        if overlaps {
+        let overlaps = applied_ranges
+            .iter()
+            .any(|(s, e, _)| start < *e && end > *s);
+
+        // Two zero-width inserts at the identical point don't trip the
+        // check above (touching, not overlapping) — which is intentional
+        // when both are pure whitespace (e.g. two `indent` fixes for the
+        // same line combine into the right total indentation). But
+        // stacking a whitespace-only reformatting insert next to one that
+        // inserts real content (e.g. `unmatched-braces` inserting a missing
+        // `}`) produces nonsensical interleaved output — the whitespace fix
+        // was computed against a structure this other fix is about to
+        // change anyway, so drop it.
+        let conflicts_with_structural_insert = is_insert
+            && is_whitespace_only(&fix.new_text)
+            && applied_ranges.iter().any(|(s, _, ws)| *s == start && !*ws);
+
+        if overlaps || conflicts_with_structural_insert {
             continue;
         }
 
@@ -630,7 +655,11 @@ pub fn apply_fixes_to_content_detailed(content: &str, fixes: &[&Fix]) -> FixAppl
             && result.is_char_boundary(end)
         {
             result.replace_range(start..end, &fix.new_text);
-            applied_ranges.push((start, start + fix.new_text.len()));
+            applied_ranges.push((
+                start,
+                start + fix.new_text.len(),
+                is_insert && is_whitespace_only(&fix.new_text),
+            ));
             fix_count += 1;
         } else {
             skipped_invalid += 1;
@@ -828,6 +857,51 @@ mod fix_tests {
         let result = apply_fixes_to_content_detailed(content, &fixes);
         assert_eq!(result.applied, 1);
         assert_eq!(result.skipped_invalid, 0);
+    }
+
+    /// Two whitespace-only inserts at the exact same point (e.g. two
+    /// `indent` errors reconciling to the same total indentation) must
+    /// still stack in ascending-indent order — this is the legitimate use
+    /// of same-point insertion the conflict check below must not break.
+    #[test]
+    fn test_same_point_whitespace_only_inserts_stack() {
+        let content = "#note\n";
+        let four_spaces = Fix::replace_range(0, 0, "    ");
+        let two_spaces = Fix::replace_range(0, 0, "  ");
+        let fixes: Vec<&Fix> = vec![&four_spaces, &two_spaces];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(result.content, "      #note\n");
+        assert_eq!(
+            result.applied, 2,
+            "both whitespace-only inserts should apply"
+        );
+    }
+
+    /// Regression test for https://github.com/walf443/nginx-lint/issues/296.
+    ///
+    /// A structural insert (e.g. `unmatched-braces` inserting a missing
+    /// `}`) and a whitespace-only reformatting insert (e.g. `indent`
+    /// reformatting the very line the brace is being inserted before) at
+    /// the exact same point don't trip the ordinary range-overlap check
+    /// (both are zero-width, touching but not overlapping) — without a
+    /// dedicated conflict check they get concatenated in whatever order the
+    /// sort happens to produce, yielding nonsensical interleaved output
+    /// (e.g. `      }` — 6 spaces of indentation matching neither fix's own
+    /// intent). The whitespace-only fix must be dropped instead, since it
+    /// was computed against content this other fix is about to change
+    /// immediately adjacent to it anyway.
+    #[test]
+    fn test_whitespace_only_insert_skipped_when_it_conflicts_with_structural_insert() {
+        let content = "# Missing closing brace for http\n";
+        let close_brace = Fix::replace_range(0, 0, "}\n");
+        let reindent = Fix::replace_range(0, 0, "      ");
+        let fixes: Vec<&Fix> = vec![&close_brace, &reindent];
+        let result = apply_fixes_to_content_detailed(content, &fixes);
+        assert_eq!(
+            result.content, "}\n# Missing closing brace for http\n",
+            "the whitespace-only fix must be dropped, not interleaved with the brace"
+        );
+        assert_eq!(result.applied, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #296.

`nginx-lint --fix` with the default rule set could produce malformed output when `unmatched-braces` and `indent` both proposed fixes touching the same position — e.g. inserting a missing `}` at 6 spaces of indentation matching neither rule's own intent, immediately followed by trailing whitespace stuck onto the adjacent comment line.

## Root cause

Traced the exact `Fix` objects both rules produce for `unmatched_braces/001_basic` (the fixture originally reported in #296):

- `unmatched-braces`: insert `"}\n"` at offset 246 (zero-width).
- `indent`: insert `"      "` (6 spaces) at the same offset 246 (zero-width) — reformatting the very comment line the brace is about to be inserted before.

`apply_fixes_to_content_detailed`'s overlap check (`start < e && end > s`) never flags two *zero-width* ranges at the *identical* point as overlapping (they're touching, not overlapping, under strict inequality). This is intentional for the legitimate case of multiple whitespace-only inserts at the same point (e.g. two `indent` errors for the same line combining into the right total indentation via the existing ascending-indent tiebreak) — but when one insert carries real content (`}`) and the other is pure whitespace, letting them both apply and concatenate produces nonsensical output: `"      }\n"` instead of the clean `"}\n"` either rule alone would produce.

## Fix

`apply_fixes_to_content_detailed` now tracks whether each applied insert's `new_text` was whitespace-only. A whitespace-only insert is dropped if another already-applied insert exists at the exact same point whose `new_text` was *not* whitespace-only — the structural fix wins; the cosmetic reformatting fix (computed against a structure that fix is about to change immediately adjacent to anyway) is skipped. Multiple same-point whitespace-only inserts still stack exactly as before (this was previously untested — added a test locking it in).

This is a small, targeted change to the shared conflict-resolution logic, so it protects any two rules whose fixes land on the same point, not just this specific pair.

The set of same-point offsets carrying a structural (content-inserting) insert is computed up front over the whole fix set, so the decision is independent of the order fixes happen to be processed in. (An earlier revision decided this by scanning already-applied fixes inside the apply loop, which review correctly flagged as order-dependent: a structural insert whose own `new_text` carries *more* leading whitespace than the competing reformatting insert gets sorted second by the ascending-indent tiebreak, so a scan-what's-applied-so-far check would miss the conflict. There's now a dedicated regression test for that reversed ordering.)

## A second, unrelated bug found along the way (filed as #300)

After this fix, running the *full* default `--fix` on the same fixture still leaves one trailing-whitespace discrepancy at end-of-file. Running `indent` completely alone (no `unmatched-braces` involved) on the same fixture reproduces the same symptom — `indent`'s own depth-tracking produces bogus `(expected, found)` indentation targets once brace counts stop balancing (the fixture has 3 genuinely unclosed braces by design). This is `indent`'s own pre-existing bug on syntactically-unclosed input, unrelated to the fix-conflict issue this PR addresses, so it's tracked separately.

## Test plan

- [x] `cargo test` (default features), `cargo test --features plugins`, `cargo test --no-default-features --features cli,wasm-builtin-plugins` — all green
- [x] `cargo clippy --workspace --features plugins -- -D clippy::all` clean, `cargo fmt --check` clean
- [x] Three new focused tests on `apply_fixes_to_content_detailed`: same-point whitespace-only inserts still stack (previously-untested behavior, now locked in); a structural insert + whitespace-only insert at the same point drops the whitespace one; and the same conflict with the structural insert carrying *more* leading whitespace than the reformatting one (guarding order-independence). Verified each fails without the corresponding fix (temporarily reverted and confirmed failure).
- [x] Verified via `nginx-lint --rule-only unmatched-braces,indent --fix` and the full default `--fix` that the brace positions in `unmatched_braces/001_basic` now match `expected/nginx.conf` exactly (the one remaining diff is the unrelated #300 issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
