### PR TITLE
fix: skip indent on files with unbalanced closing braces

### DIFF
--- a/src/rules/style/indent.rs
+++ b/src/rules/style/indent.rs
@@ -56,7 +56,15 @@ impl Indent {
     /// Check indentation on content string directly (used by WASM and docs)
     pub fn check_content(&self, content: &str) -> Vec<LintError> {
         // Parse with error recovery so we get an AST even for broken configs
-        let (config, _errors) = crate::parser::parse_string_with_errors(content);
+        let (config, errors) = crate::parser::parse_string_with_errors(content);
+        // Unbalanced braces make the recovered AST's block nesting a guess, so
+        // every depth we'd compute — and every fix built from it — is unreliable
+        // (e.g. closing braces synthesised at EOF produce spurious "indent the
+        // end of file" fixes). Skip until the braces are balanced; the brace
+        // problem itself is reported by unmatched-braces and the syntax-error pass.
+        if has_brace_structure_error(&errors) {
+            return Vec::new();
+        }
         self.check_config(&config)
     }
 
@@ -156,6 +164,32 @@ impl LintRule for Indent {
     fn check(&self, config: &Config, _path: &Path) -> Vec<LintError> {
         self.check_config(config)
     }
+
+    fn wants_content(&self) -> bool {
+        true
+    }
+
+    fn check_with_content(&self, _config: &Config, _path: &Path, content: &str) -> Vec<LintError> {
+        // Re-check from content so we can see the parser's syntax errors and
+        // skip on unbalanced braces (see `check_content`). The passed `config`
+        // is parsed from this same content, so re-parsing yields the same AST.
+        self.check_content(content)
+    }
+}
+
+/// Whether any parser syntax error indicates an unbalanced closing brace — a
+/// missing `}` (`"expected '}'"`, `"expected '}' for lua block"`) or an extra
+/// one (`"unexpected '}'"`). Either leaves the recovered AST's block nesting —
+/// and therefore indentation depth — a guess.
+///
+/// `SyntaxError` carries no typed kind, so we key off the message, gating on
+/// the `}` character. Deliberately *not* gated: `"expected ';' or '{'"`, which
+/// the parser emits both for a missing semicolon (braces still balanced,
+/// nesting intact — indent should keep working) and for a missing opening
+/// brace; since the message can't tell them apart and the missing-`;` case is
+/// the common one, this diagnostic doesn't suppress indentation.
+fn has_brace_structure_error(errors: &[crate::parser::parser::SyntaxError]) -> bool {
+    errors.iter().any(|e| e.message.contains('}'))
 }
 
 /// Detect indent size from AST by finding the first item inside a top-level block
@@ -579,5 +613,76 @@ content_by_lua_block {
             result.contains("location /static/"),
             "Directives after lua block should be preserved"
         );
+    }
+
+    /// Regression test for https://github.com/walf443/nginx-lint/issues/300.
+    ///
+    /// With unbalanced braces the recovered AST's nesting is a guess: the 3
+    /// unclosed blocks here all get closing braces synthesised at EOF, and
+    /// the trailing marker comments land inside the innermost block. Computing
+    /// indentation from that produced spurious "Expected N spaces" errors —
+    /// including fixes that insert whitespace at end-of-file where no line
+    /// exists. Indent must skip such files entirely rather than emit guesses.
+    #[test]
+    fn test_no_indent_errors_on_unclosed_braces() {
+        let content = r#"http {
+  server {
+    listen 80;
+
+    location / {
+      root /var/www/html;
+    # Missing closing brace for location
+  # Missing closing brace for server
+# Missing closing brace for http
+"#;
+        let errors = check_content(content);
+        assert!(
+            errors.is_empty(),
+            "indent must not report on a file with unbalanced braces, got: {:?}",
+            errors
+        );
+    }
+
+    /// The opposite direction of #300: an *extra* closing brace also makes the
+    /// brace structure malformed, so indent skips it too.
+    #[test]
+    fn test_no_indent_errors_on_extra_closing_brace() {
+        let content = "http {\n  server {\n    listen 80;\n  }\n}\n}\n";
+        let errors = check_content(content);
+        assert!(
+            errors.is_empty(),
+            "indent must not report on a file with an extra closing brace, got: {:?}",
+            errors
+        );
+    }
+
+    /// A *non-brace* syntax error (here a missing semicolon) leaves the brace
+    /// structure — and therefore nesting — intact, so indent must still run
+    /// and catch genuine indentation problems.
+    #[test]
+    fn test_indent_still_runs_when_only_a_semicolon_is_missing() {
+        // `listen 80` is missing its `;`, but every brace is balanced.
+        // The inner directives are wrongly indented (4 spaces under a
+        // 2-space file), which indent should still flag.
+        let content = "http {\n  server {\n      listen 80\n  }\n}\n";
+        let errors = check_content(content);
+        assert!(
+            !errors.is_empty(),
+            "indent should still report indentation issues when braces are balanced"
+        );
+    }
+
+    #[test]
+    fn test_has_brace_structure_error() {
+        use crate::parser::parse_string_with_errors;
+
+        let (_c, unclosed) = parse_string_with_errors("http {\n  server {\n");
+        assert!(has_brace_structure_error(&unclosed));
+
+        let (_c, extra) = parse_string_with_errors("http {\n}\n}\n");
+        assert!(has_brace_structure_error(&extra));
+
+        let (_c, clean) = parse_string_with_errors("http {\n  server {\n  }\n}\n");
+        assert!(!has_brace_structure_error(&clean));
     }
 }

--- a/src/rules/style/indent.rs
+++ b/src/rules/style/indent.rs
@@ -188,7 +188,7 @@ impl LintRule for Indent {
 /// nesting intact — indent should keep working) and for a missing opening
 /// brace; since the message can't tell them apart and the missing-`;` case is
 /// the common one, this diagnostic doesn't suppress indentation.
-fn has_brace_structure_error(errors: &[crate::parser::parser::SyntaxError]) -> bool {
+pub(crate) fn has_brace_structure_error(errors: &[crate::parser::parser::SyntaxError]) -> bool {
     errors.iter().any(|e| e.message.contains('}'))
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -189,12 +189,19 @@ pub fn lint_with_config(content: &str, config_toml: &str) -> Result<WasmLintResu
     let mut errors = pre_parse_errors;
 
     // Create linter to get rule names for ignore validation
-    let linter = Linter::with_config(lint_config.as_ref(), None);
+    let mut linter = Linter::with_config(lint_config.as_ref(), None);
 
     // Build ignore tracker with rule name validation using linter's rule names
+    // (captured before removing indent below, so `indent` stays a valid ignore
+    // target).
     let valid_rules = linter.rule_names();
     let (mut tracker, ignore_warnings) =
         IgnoreTracker::from_content_with_rules(content, Some(&valid_rules));
+
+    // Indent is run separately below on the already-parsed AST (avoiding a
+    // second parse), so drop it from the linter here — otherwise `linter.lint`
+    // would run and report it a second time.
+    linter.remove_rules_by_name(|name| name == "indent");
 
     // Parse with error recovery — always produces an AST even with syntax errors
     let (config, syntax_errors) = parse_string_with_errors(content);
@@ -206,8 +213,13 @@ pub fn lint_with_config(content: &str, config_toml: &str) -> Result<WasmLintResu
         errors.extend(syntax_errors_to_lint_errors(&syntax_errors, content));
     }
 
-    // Run indentation check using the already-parsed AST
-    if is_enabled("indent") {
+    // Run indentation check using the already-parsed AST — but only when the
+    // braces are balanced. Unbalanced braces make the recovered AST's nesting
+    // (and thus every indentation depth) a guess, so indent would emit spurious
+    // fixes (see the indent rule); the brace problem itself is already reported.
+    if is_enabled("indent")
+        && !crate::rules::style::indent::has_brace_structure_error(&syntax_errors)
+    {
         let indent_rule = if let Some(indent_size) = lint_config
             .as_ref()
             .and_then(|c| c.get_rule_config("indent"))


### PR DESCRIPTION
## Summary

Fixes #300.

`indent` derives each line's expected depth from the parsed AST's block nesting. When a file has a missing or extra `}`, error recovery still produces an AST, but its nesting is a guess — unclosed blocks get closing braces synthesised at end-of-file, and trailing content lands inside whichever block happened to still be open. Computing indentation from that produced spurious `Expected N spaces` warnings, including **fixes anchored at EOF** (where no line exists to indent) that appended trailing whitespace.

This was also the leftover discrepancy noted in #296: after fixing the fix-conflict mechanism, the full default `--fix` on `unmatched_braces/001_basic` *still* didn't match its `expected/nginx.conf` — purely because of indent's own bogus EOF fix. With this PR, that fixture now round-trips exactly.

## Fix

`check_content` now inspects the parser's syntax errors and returns no diagnostics when the brace structure is unbalanced. The brace problem itself is still reported by `unmatched-braces` and the syntax-error pass, and indent resumes automatically once the braces balance. `Indent` opts into `wants_content()` so the CLI routes through `check_with_content`, which sees the same errors. (The bare `check(config)` path has no content and keeps its previous behaviour — it's only reached by direct callers passing well-formed configs.)

## WASM / web path (added after review)

Review caught that the gate initially landed only on the CLI path: the WASM entry point (`wasm.rs`) runs indent via `check_config` directly, so the web UI would still emit the bogus warnings and EOF-anchored fix buttons. Tracing it surfaced a second, pre-existing bug — indent is a registered linter rule *and* run manually on the already-parsed AST (the manual run added in `386178b` to avoid a second parse), so `linter.lint` reported it a second time, both ungated. `wasm.rs` now removes indent from the linter (after capturing rule names for ignore validation) and gates the manual block on the syntax errors it already computed. Verified: a well-formed mis-indented file now reports one indent error (was two), an unbalanced-brace file reports none.

**Scoping:** gated specifically on error messages mentioning `}` (missing/extra closing brace), *not* on `"expected ';' or '{'"`. The parser emits that same message for a plain missing semicolon — where braces stay balanced and nesting is intact — so indent must keep working there. `SyntaxError` has no typed kind, so keying off the message is the available signal; the choice is documented in `has_brace_structure_error`.

## Test plan

- [x] `cargo test` (default), `--features plugins`, `--no-default-features --features cli,wasm-builtin-plugins` — all green
- [x] `cargo clippy --workspace --features plugins -- -D clippy::all` clean, `cargo fmt --check` clean
- [x] New regression tests: no indent output on unclosed braces (the #300 shape); none on an extra closing brace; indent **still runs** when only a semicolon is missing (braces balanced); plus a unit test for `has_brace_structure_error`. Verified the main test fails without the gate (temporarily neutered and confirmed failure).
- [x] Verified `nginx-lint --rule-only indent --fix` now leaves the #300 fixture untouched (only the real `expected '}'` syntax error remains), and the full default `nginx-lint --fix` matches `unmatched_braces/001_basic/expected/nginx.conf` byte-for-byte.
- [x] Verified a missing-semicolon file (`listen 80` without `;`, braces balanced) still gets its `Expected 4 spaces, found 6` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
