### PR TITLE
feat: add map-unnamed-capture rule (nginx CVE-2026-42533)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "map-unnamed-capture-plugin"
+version = "0.17.0"
+dependencies = [
+ "nginx-lint-plugin",
+ "tokio",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1819,7 @@ dependencies = [
  "invalid-directive-context-plugin",
  "listen-http2-deprecated-plugin",
  "map-missing-default-plugin",
+ "map-unnamed-capture-plugin",
  "missing-error-log-plugin",
  "nginx-lint-common",
  "nginx-lint-plugin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "plugins/builtin/security/deprecated_ssl_protocol",
     "plugins/builtin/security/weak_ssl_ciphers",
     "plugins/builtin/security/nginx_rift",
+    "plugins/builtin/security/map_unnamed_capture",
     "plugins/builtin/style/space_before_semicolon",
     "plugins/builtin/style/trailing_whitespace",
     "plugins/builtin/style/block_lines",
@@ -63,6 +64,7 @@ native-builtin-plugins = [
     "dep:deprecated-ssl-protocol-plugin",
     "dep:weak-ssl-ciphers-plugin",
     "dep:nginx-rift-plugin",
+    "dep:map-unnamed-capture-plugin",
     "dep:space-before-semicolon-plugin",
     "dep:trailing-whitespace-plugin",
     "dep:block-lines-plugin",
@@ -119,6 +121,7 @@ autoindex-enabled-plugin = { path = "plugins/builtin/security/autoindex_enabled"
 deprecated-ssl-protocol-plugin = { path = "plugins/builtin/security/deprecated_ssl_protocol", optional = true, default-features = false }
 weak-ssl-ciphers-plugin = { path = "plugins/builtin/security/weak_ssl_ciphers", optional = true, default-features = false }
 nginx-rift-plugin = { path = "plugins/builtin/security/nginx_rift", optional = true, default-features = false }
+map-unnamed-capture-plugin = { path = "plugins/builtin/security/map_unnamed_capture", optional = true, default-features = false }
 space-before-semicolon-plugin = { path = "plugins/builtin/style/space_before_semicolon", optional = true, default-features = false }
 trailing-whitespace-plugin = { path = "plugins/builtin/style/trailing_whitespace", optional = true, default-features = false }
 block-lines-plugin = { path = "plugins/builtin/style/block_lines", optional = true, default-features = false }

--- a/crates/nginx-lint-common/src/config.rs
+++ b/crates/nginx-lint-common/src/config.rs
@@ -707,6 +707,7 @@ impl LintConfig {
         "proxy-missing-host-header",
         "client-max-body-size-not-set",
         "nginx-rift",
+        "map-unnamed-capture",
     ];
 
     /// Check if a rule is enabled

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -142,19 +142,13 @@ pub fn extract_domain(host: &str) -> &str {
     host.split(':').next().unwrap_or(host)
 }
 
+use crate::regex_scan::{Group, scan};
+
 /// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
 ///
-/// nginx stores unnamed captures in the shared `$1`..`$9` slots, so rules that
-/// care about capture collisions need to tell a real capture group apart from a
-/// paren that merely looks like one.
-///
-/// Skips: escapes (`\(`), `\Q...\E` literal spans, character classes (`[...]`,
-/// including a leading `]` member), the `(?...)` family — non-capturing
-/// `(?:...)`, named `(?<name>...)` / `(?P<name>...)`, lookarounds `(?=...)` /
-/// `(?!...)` / `(?<=...)` / `(?<!...)`, atomic `(?>...)`, comments `(?#...)`,
-/// inline modifiers `(?i)`, and conditionals `(?(1)...)` — and the `(*VERB)`
-/// family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`, `(*FAIL)`,
-/// `(*MARK:name)`, etc.
+/// A view over [`crate::regex_scan::scan`], which is the single place that
+/// knows PCRE syntax — see its docs for what counts as a capture group and why
+/// this is not a parser of its own.
 ///
 /// # Examples
 ///
@@ -169,176 +163,21 @@ pub fn extract_domain(host: &str) -> &str {
 /// assert!(find_unnamed_capture_positions(r"\(literal\)").is_empty());
 /// assert!(find_unnamed_capture_positions("[()]").is_empty());
 /// assert!(find_unnamed_capture_positions("(*PRUNE)").is_empty());
-///
-/// // `]` first in a class is a member, so these parens are still inside it
 /// assert!(find_unnamed_capture_positions("[]()]").is_empty());
-/// assert!(find_unnamed_capture_positions("[^]()]").is_empty());
-/// assert!(find_unnamed_capture_positions("[[:alpha:]()]").is_empty());
-///
-/// // `\Q...\E` makes its contents literal
-/// assert!(find_unnamed_capture_positions(r"\Q(a)\E").is_empty());
-///
-/// // The inner paren of a conditional is syntax, not a group
-/// assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
-///
-/// // A `(?#...)` comment body is opaque text — parens in it are not groups,
-/// // and a `[` or `\Q` in it must not swallow the captures that follow
-/// assert!(find_unnamed_capture_positions("^/a(?#()$").is_empty());
-/// assert_eq!(find_unnamed_capture_positions("(?# [ )(a)"), vec![7]);
-///
-/// // Negated POSIX classes are classes too
 /// assert!(find_unnamed_capture_positions("[[:^print:]()]").is_empty());
+/// assert!(find_unnamed_capture_positions(r"\Q(a)\E").is_empty());
+/// assert_eq!(find_unnamed_capture_positions("(?# [ )(a)"), vec![7]);
 /// ```
 pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
-    let bytes = regex.as_bytes();
-    let mut positions = Vec::new();
-    let mut i = 0;
-    let mut in_char_class = false;
-
-    // Byte offset just past `[` (and an optional negating `^`), where a `]` is
-    // a literal member rather than the class terminator.
-    let mut class_body_start = 0;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-
-        if b == b'\\' && i + 1 < bytes.len() {
-            // `\Q...\E` quotes everything up to `\E` (or end of pattern).
-            if bytes[i + 1] == b'Q' {
-                i = find_literal_span_end(bytes, i + 2);
-                continue;
-            }
-            // Any other escape — skip both bytes.
-            i += 2;
-            continue;
-        }
-
-        if in_char_class {
-            // A POSIX class such as `[:alpha:]` nests inside the class, and its
-            // `]` does not end the enclosing one.
-            if b == b'['
-                && bytes.get(i + 1) == Some(&b':')
-                && let Some(end) = find_posix_class_end(bytes, i + 2)
-            {
-                i = end;
-                continue;
-            }
-            // PCRE reads `]` as a member when it opens the class body, so only
-            // a later one closes it. `[]()]`, `[^]()]` are single classes.
-            if b == b']' && i > class_body_start {
-                in_char_class = false;
-            }
-            i += 1;
-            continue;
-        }
-
-        if b == b'[' {
-            in_char_class = true;
-            class_body_start = i + 1;
-            if bytes.get(class_body_start) == Some(&b'^') {
-                class_body_start += 1;
-            }
-            i += 1;
-            continue;
-        }
-
-        if b == b'(' {
-            match bytes.get(i + 1).copied() {
-                // `(*VERB)` / `(*MARK:name)` — never a capture, and the name
-                // is arbitrary text, so step over the whole thing rather than
-                // scanning it as regex.
-                Some(b'*') => {
-                    i = find_close_paren(bytes, i + 2);
-                    continue;
-                }
-                Some(b'?') => match bytes.get(i + 2).copied() {
-                    // `(?#...)` is a comment: its body is arbitrary text and
-                    // runs to the very next `)`, with no escaping. Scanning it
-                    // as regex both invents groups and — via a stray `[` or
-                    // `\Q` — swallows the real ones after it.
-                    Some(b'#') => {
-                        i = find_close_paren(bytes, i + 3);
-                        continue;
-                    }
-                    // A conditional `(?(1)...)` / `(?(<name>)...)` nests a
-                    // paren that is syntax, not a group.
-                    Some(b'(') => {
-                        i += 3;
-                        continue;
-                    }
-                    // Every other `(?...)` construct is not a capture, but its
-                    // body is regex and must still be scanned.
-                    _ => {}
-                },
-                _ => positions.push(i),
-            }
-        }
-
-        i += 1;
-    }
-
-    positions
-}
-
-/// Offset just past the next `)` at or after `from`, or the end of the input
-/// when there is none. Used for constructs whose body is opaque text — a
-/// `(?#...)` comment or a `(*VERB:name)` — which PCRE ends at the first `)`.
-///
-/// **Escapes are deliberately not honoured, and must not be.** PCRE gives no
-/// way to put a `)` inside these: a comment ends at the first one even when a
-/// backslash precedes it, so `a(?#x\)b` is `a`, a comment, then `b` — it
-/// matches `ab`. Teaching this function to skip `\)` would desynchronise it
-/// from PCRE and hide the group that follows. Pinned by
-/// `comment_ends_at_first_paren_even_after_a_backslash`.
-fn find_close_paren(bytes: &[u8], from: usize) -> usize {
-    let mut i = from;
-    while i < bytes.len() {
-        if bytes[i] == b')' {
-            return i + 1;
-        }
-        i += 1;
-    }
-    bytes.len()
-}
-
-/// Offset just past the `:]` closing a POSIX class whose body starts at
-/// `from`, or `None` when there is none — in which case the `[` was an
-/// ordinary member and should be treated as such.
-fn find_posix_class_end(bytes: &[u8], from: usize) -> Option<usize> {
-    // `[[:^alpha:]]` negates the class; the `^` is part of the syntax, not the
-    // name. Missing it ended the class at the `:]` and exposed everything after
-    // it as regex.
-    let mut i = from + usize::from(bytes.get(from) == Some(&b'^'));
-
-    while i + 1 < bytes.len() {
-        if bytes[i] == b':' && bytes[i + 1] == b']' {
-            return Some(i + 2);
-        }
-        // A POSIX class name is alphabetic; anything else means this was not
-        // one, e.g. a literal `[` followed by `:` in the class.
-        if !bytes[i].is_ascii_alphabetic() {
-            return None;
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Offset just past the `\E` closing a `\Q` literal span that starts at
-/// `from`, or the end of the pattern when it is unterminated.
-fn find_literal_span_end(bytes: &[u8], from: usize) -> usize {
-    let mut i = from;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'\\' && bytes[i + 1] == b'E' {
-            return i + 2;
-        }
-        i += 1;
-    }
-    bytes.len()
+    scan(regex)
+        .into_iter()
+        .filter(|(_, group)| *group == Group::Unnamed)
+        .map(|(pos, _)| pos)
+        .collect()
 }
 
 /// Whether a regex source string contains at least one unnamed PCRE capture
-/// group. See [`find_unnamed_capture_positions`] for what counts as one.
+/// group. See [`find_unnamed_capture_positions`].
 ///
 /// # Examples
 ///
@@ -350,12 +189,14 @@ fn find_literal_span_end(bytes: &[u8], from: usize) -> usize {
 /// assert!(!has_unnamed_capture("^/old/(?:.*)$"));
 /// ```
 pub fn has_unnamed_capture(regex: &str) -> bool {
-    !find_unnamed_capture_positions(regex).is_empty()
+    scan(regex)
+        .iter()
+        .any(|(_, group)| *group == Group::Unnamed)
 }
 
-/// Detect whether a regex source string contains any named capture group
-/// (`(?<name>...)` or `(?P<name>...)`). Lookbehinds `(?<=...)` / `(?<!...)`
-/// are NOT named captures and don't count.
+/// Detect whether a regex source string contains any named capture group —
+/// `(?<name>...)`, `(?'name'...)` or `(?P<name>...)`. Lookbehinds
+/// `(?<=...)` / `(?<!...)` are NOT named captures and don't count.
 ///
 /// # Examples
 ///
@@ -363,6 +204,7 @@ pub fn has_unnamed_capture(regex: &str) -> bool {
 /// use nginx_lint_plugin::helpers::regex_has_named_capture;
 ///
 /// assert!(regex_has_named_capture("(?<name>.*)"));
+/// assert!(regex_has_named_capture("(?'name'.*)"));
 /// assert!(regex_has_named_capture("(?P<name>.*)"));
 ///
 /// assert!(!regex_has_named_capture("(.*)"));
@@ -370,58 +212,7 @@ pub fn has_unnamed_capture(regex: &str) -> bool {
 /// assert!(!regex_has_named_capture("(?<!foo)bar"));
 /// ```
 pub fn regex_has_named_capture(regex: &str) -> bool {
-    let bytes = regex.as_bytes();
-    let mut i = 0;
-    let mut in_char_class = false;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-
-        if b == b'\\' && i + 1 < bytes.len() {
-            i += 2;
-            continue;
-        }
-
-        if in_char_class {
-            if b == b']' {
-                in_char_class = false;
-            }
-            i += 1;
-            continue;
-        }
-
-        if b == b'[' {
-            in_char_class = true;
-            i += 1;
-            continue;
-        }
-
-        if b == b'(' && i + 3 < bytes.len() && bytes[i + 1] == b'?' {
-            // `(?<name>...)` — named iff the char after `<` is a name-start
-            // byte. `(?<=...)` and `(?<!...)` are lookbehinds; not captures.
-            if bytes[i + 2] == b'<' {
-                let after_lt = bytes[i + 3];
-                if after_lt != b'=' && after_lt != b'!' {
-                    return true;
-                }
-            }
-            // `(?'name'...)` — the quoted form. Missing it let callers treat a
-            // named group as unnamed, which silently misnumbers the rest.
-            if bytes[i + 2] == b'\'' {
-                return true;
-            }
-            // `(?P<name>...)` — Python-style named capture.
-            // (Only `bytes[i + 3]` is read; the outer `i + 3 < bytes.len()`
-            // guard is already sufficient.)
-            if bytes[i + 2] == b'P' && bytes[i + 3] == b'<' {
-                return true;
-            }
-        }
-
-        i += 1;
-    }
-
-    false
+    scan(regex).iter().any(|(_, group)| *group == Group::Named)
 }
 
 #[cfg(test)]
@@ -500,84 +291,5 @@ mod tests {
         assert_eq!(extract_domain("example.com:8080"), "example.com");
         assert_eq!(extract_domain("localhost:3000"), "localhost");
         assert_eq!(extract_domain("127.0.0.1:80"), "127.0.0.1");
-    }
-
-    /// PCRE reads `]` as a member when it opens the class body, so the class
-    /// runs on past it. Terminating there made the following literal parens
-    /// look like groups.
-    #[test]
-    fn class_with_leading_bracket_member_is_not_a_capture() {
-        assert!(find_unnamed_capture_positions("[]()]").is_empty());
-        assert!(find_unnamed_capture_positions("[^]()]").is_empty());
-        assert!(find_unnamed_capture_positions("[[:alpha:]()]").is_empty());
-        // A `]` that is not first still closes the class.
-        assert_eq!(find_unnamed_capture_positions("[abc](d)"), vec![5]);
-    }
-
-    /// `\Q...\E` quotes its contents, so parens inside are literal.
-    #[test]
-    fn quoted_literal_span_is_not_scanned() {
-        assert!(find_unnamed_capture_positions(r"\Q(a)\E").is_empty());
-        assert_eq!(find_unnamed_capture_positions(r"\Q(a)\E(b)"), vec![7]);
-        // Unterminated `\Q` quotes to the end.
-        assert!(find_unnamed_capture_positions(r"\Q(a)").is_empty());
-    }
-
-    /// The paren nested in a conditional is syntax, not a group.
-    #[test]
-    fn conditional_inner_paren_is_not_a_capture() {
-        assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
-        assert!(find_unnamed_capture_positions("(?(<n>)x|y)").is_empty());
-    }
-
-    /// A `(?#...)` comment body is opaque text ending at the first `)`.
-    /// Scanning it as regex invented groups, and a stray `[` or `\Q` in the
-    /// prose swallowed every real capture after it.
-    #[test]
-    fn comment_body_is_skipped() {
-        // `(` in the prose is not a group.
-        assert!(find_unnamed_capture_positions("^/a(?#()$").is_empty());
-        // A capture after such a comment is still found.
-        assert_eq!(find_unnamed_capture_positions("^/a(?#()/(.*)$"), vec![9]);
-        // `[` / `\Q` in the prose must not swallow what follows.
-        assert_eq!(find_unnamed_capture_positions("(?# [ )(a)"), vec![7]);
-        assert_eq!(find_unnamed_capture_positions(r"(?#\Q)(a)"), vec![6]);
-        assert_eq!(find_unnamed_capture_positions("(?#c)(a)"), vec![5]);
-    }
-
-    /// `(*MARK:name)` carries arbitrary text; a `[` in it must not swallow the
-    /// rest of the pattern.
-    #[test]
-    fn verb_name_is_skipped() {
-        assert_eq!(find_unnamed_capture_positions("(*MARK:[)(a)"), vec![9]);
-        assert!(find_unnamed_capture_positions("(*PRUNE)").is_empty());
-    }
-
-    /// `[[:^alpha:]]` negates the class — the `^` is syntax, not the name.
-    /// Missing it closed the class at the `:]`.
-    #[test]
-    fn negated_posix_class_does_not_end_the_class() {
-        assert!(find_unnamed_capture_positions("[[:^print:]()]").is_empty());
-        assert!(find_unnamed_capture_positions("[[:^alpha:]]").is_empty());
-        // Still finds a real capture after the class.
-        assert_eq!(find_unnamed_capture_positions("[[:^print:]](a)"), vec![12]);
-    }
-
-    /// PCRE has three named-capture syntaxes; treating `(?'n'...)` as unnamed
-    /// made callers renumber the groups around it.
-    #[test]
-    fn quoted_named_capture_is_recognised() {
-        assert!(regex_has_named_capture("(?'a'x)"));
-        assert!(regex_has_named_capture("(?'a'x)(y)"));
-        // Not a named capture.
-        assert!(!regex_has_named_capture("(x)"));
-    }
-
-    /// PCRE gives no way to put a `)` inside a `(?#...)` comment — the first
-    /// one ends it, backslash or not (`a(?#x\)b` matches "ab"). So the group
-    /// after it is real, and skipping `\)` here would hide it.
-    #[test]
-    fn comment_ends_at_first_paren_even_after_a_backslash() {
-        assert_eq!(find_unnamed_capture_positions(r"(?#x\)(a)"), vec![6]);
     }
 }

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -248,7 +248,7 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
                 // is arbitrary text, so step over the whole thing rather than
                 // scanning it as regex.
                 Some(b'*') => {
-                    i = find_unescaped_close_paren(bytes, i + 2);
+                    i = find_close_paren(bytes, i + 2);
                     continue;
                 }
                 Some(b'?') => match bytes.get(i + 2).copied() {
@@ -257,7 +257,7 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
                     // as regex both invents groups and — via a stray `[` or
                     // `\Q` — swallows the real ones after it.
                     Some(b'#') => {
-                        i = find_unescaped_close_paren(bytes, i + 3);
+                        i = find_close_paren(bytes, i + 3);
                         continue;
                     }
                     // A conditional `(?(1)...)` / `(?(<name>)...)` nests a
@@ -283,7 +283,14 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
 /// Offset just past the next `)` at or after `from`, or the end of the input
 /// when there is none. Used for constructs whose body is opaque text — a
 /// `(?#...)` comment or a `(*VERB:name)` — which PCRE ends at the first `)`.
-fn find_unescaped_close_paren(bytes: &[u8], from: usize) -> usize {
+///
+/// **Escapes are deliberately not honoured, and must not be.** PCRE gives no
+/// way to put a `)` inside these: a comment ends at the first one even when a
+/// backslash precedes it, so `a(?#x\)b` is `a`, a comment, then `b` — it
+/// matches `ab`. Teaching this function to skip `\)` would desynchronise it
+/// from PCRE and hide the group that follows. Pinned by
+/// `comment_ends_at_first_paren_even_after_a_backslash`.
+fn find_close_paren(bytes: &[u8], from: usize) -> usize {
     let mut i = from;
     while i < bytes.len() {
         if bytes[i] == b')' {
@@ -564,5 +571,13 @@ mod tests {
         assert!(regex_has_named_capture("(?'a'x)(y)"));
         // Not a named capture.
         assert!(!regex_has_named_capture("(x)"));
+    }
+
+    /// PCRE gives no way to put a `)` inside a `(?#...)` comment — the first
+    /// one ends it, backslash or not (`a(?#x\)b` matches "ab"). So the group
+    /// after it is real, and skipping `\)` here would hide it.
+    #[test]
+    fn comment_ends_at_first_paren_even_after_a_backslash() {
+        assert_eq!(find_unnamed_capture_positions(r"(?#x\)(a)"), vec![6]);
     }
 }

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -148,12 +148,13 @@ pub fn extract_domain(host: &str) -> &str {
 /// care about capture collisions need to tell a real capture group apart from a
 /// paren that merely looks like one.
 ///
-/// Skips: escapes (`\(`), character classes (`[...]`), the `(?...)` family —
-/// non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
-/// lookarounds `(?=...)` / `(?!...)` / `(?<=...)` / `(?<!...)`, atomic
-/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)` — and the
-/// `(*VERB)` family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`,
-/// `(*FAIL)`, `(*MARK:name)`, etc.
+/// Skips: escapes (`\(`), `\Q...\E` literal spans, character classes (`[...]`,
+/// including a leading `]` member), the `(?...)` family — non-capturing
+/// `(?:...)`, named `(?<name>...)` / `(?P<name>...)`, lookarounds `(?=...)` /
+/// `(?!...)` / `(?<=...)` / `(?<!...)`, atomic `(?>...)`, comments `(?#...)`,
+/// inline modifiers `(?i)`, and conditionals `(?(1)...)` — and the `(*VERB)`
+/// family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`, `(*FAIL)`,
+/// `(*MARK:name)`, etc.
 ///
 /// # Examples
 ///
@@ -168,6 +169,17 @@ pub fn extract_domain(host: &str) -> &str {
 /// assert!(find_unnamed_capture_positions(r"\(literal\)").is_empty());
 /// assert!(find_unnamed_capture_positions("[()]").is_empty());
 /// assert!(find_unnamed_capture_positions("(*PRUNE)").is_empty());
+///
+/// // `]` first in a class is a member, so these parens are still inside it
+/// assert!(find_unnamed_capture_positions("[]()]").is_empty());
+/// assert!(find_unnamed_capture_positions("[^]()]").is_empty());
+/// assert!(find_unnamed_capture_positions("[[:alpha:]()]").is_empty());
+///
+/// // `\Q...\E` makes its contents literal
+/// assert!(find_unnamed_capture_positions(r"\Q(a)\E").is_empty());
+///
+/// // The inner paren of a conditional is syntax, not a group
+/// assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
 /// ```
 pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     let bytes = regex.as_bytes();
@@ -175,17 +187,37 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     let mut i = 0;
     let mut in_char_class = false;
 
+    // Byte offset just past `[` (and an optional negating `^`), where a `]` is
+    // a literal member rather than the class terminator.
+    let mut class_body_start = 0;
+
     while i < bytes.len() {
         let b = bytes[i];
 
         if b == b'\\' && i + 1 < bytes.len() {
-            // Escaped byte — skip both bytes.
+            // `\Q...\E` quotes everything up to `\E` (or end of pattern).
+            if bytes[i + 1] == b'Q' {
+                i = find_literal_span_end(bytes, i + 2);
+                continue;
+            }
+            // Any other escape — skip both bytes.
             i += 2;
             continue;
         }
 
         if in_char_class {
-            if b == b']' {
+            // A POSIX class such as `[:alpha:]` nests inside the class, and its
+            // `]` does not end the enclosing one.
+            if b == b'['
+                && bytes.get(i + 1) == Some(&b':')
+                && let Some(end) = find_posix_class_end(bytes, i + 2)
+            {
+                i = end;
+                continue;
+            }
+            // PCRE reads `]` as a member when it opens the class body, so only
+            // a later one closes it. `[]()]`, `[^]()]` are single classes.
+            if b == b']' && i > class_body_start {
                 in_char_class = false;
             }
             i += 1;
@@ -194,16 +226,28 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
 
         if b == b'[' {
             in_char_class = true;
+            class_body_start = i + 1;
+            if bytes.get(class_body_start) == Some(&b'^') {
+                class_body_start += 1;
+            }
             i += 1;
             continue;
         }
 
         if b == b'(' {
-            let next = bytes.get(i + 1).copied();
-            // `(?...)` constructs and `(*VERB)` control verbs are never
-            // unnamed captures.
-            if next != Some(b'?') && next != Some(b'*') {
-                positions.push(i);
+            match bytes.get(i + 1).copied() {
+                // `(*VERB)` control verbs are never captures.
+                Some(b'*') => {}
+                // The `(?...)` family is never a capture. A conditional
+                // `(?(1)...)` / `(?(<name>)...)` nests a paren that is syntax,
+                // not a group — step over it so it is not counted.
+                Some(b'?') => {
+                    if bytes.get(i + 2) == Some(&b'(') {
+                        i += 3;
+                        continue;
+                    }
+                }
+                _ => positions.push(i),
             }
         }
 
@@ -211,6 +255,38 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     }
 
     positions
+}
+
+/// Offset just past the `:]` closing a POSIX class whose body starts at
+/// `from`, or `None` when there is none — in which case the `[` was an
+/// ordinary member and should be treated as such.
+fn find_posix_class_end(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut i = from;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b':' && bytes[i + 1] == b']' {
+            return Some(i + 2);
+        }
+        // A POSIX class name is alphabetic; anything else means this was not
+        // one, e.g. a literal `[` followed by `:` in the class.
+        if !bytes[i].is_ascii_alphabetic() {
+            return None;
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Offset just past the `\E` closing a `\Q` literal span that starts at
+/// `from`, or the end of the pattern when it is unterminated.
+fn find_literal_span_end(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'\\' && bytes[i + 1] == b'E' {
+            return i + 2;
+        }
+        i += 1;
+    }
+    bytes.len()
 }
 
 /// Whether a regex source string contains at least one unnamed PCRE capture
@@ -371,5 +447,33 @@ mod tests {
         assert_eq!(extract_domain("example.com:8080"), "example.com");
         assert_eq!(extract_domain("localhost:3000"), "localhost");
         assert_eq!(extract_domain("127.0.0.1:80"), "127.0.0.1");
+    }
+
+    /// PCRE reads `]` as a member when it opens the class body, so the class
+    /// runs on past it. Terminating there made the following literal parens
+    /// look like groups.
+    #[test]
+    fn class_with_leading_bracket_member_is_not_a_capture() {
+        assert!(find_unnamed_capture_positions("[]()]").is_empty());
+        assert!(find_unnamed_capture_positions("[^]()]").is_empty());
+        assert!(find_unnamed_capture_positions("[[:alpha:]()]").is_empty());
+        // A `]` that is not first still closes the class.
+        assert_eq!(find_unnamed_capture_positions("[abc](d)"), vec![5]);
+    }
+
+    /// `\Q...\E` quotes its contents, so parens inside are literal.
+    #[test]
+    fn quoted_literal_span_is_not_scanned() {
+        assert!(find_unnamed_capture_positions(r"\Q(a)\E").is_empty());
+        assert_eq!(find_unnamed_capture_positions(r"\Q(a)\E(b)"), vec![7]);
+        // Unterminated `\Q` quotes to the end.
+        assert!(find_unnamed_capture_positions(r"\Q(a)").is_empty());
+    }
+
+    /// The paren nested in a conditional is syntax, not a group.
+    #[test]
+    fn conditional_inner_paren_is_not_a_capture() {
+        assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
+        assert!(find_unnamed_capture_positions("(?(<n>)x|y)").is_empty());
     }
 }

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -142,6 +142,159 @@ pub fn extract_domain(host: &str) -> &str {
     host.split(':').next().unwrap_or(host)
 }
 
+/// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
+///
+/// nginx stores unnamed captures in the shared `$1`..`$9` slots, so rules that
+/// care about capture collisions need to tell a real capture group apart from a
+/// paren that merely looks like one.
+///
+/// Skips: escapes (`\(`), character classes (`[...]`), the `(?...)` family —
+/// non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
+/// lookarounds `(?=...)` / `(?!...)` / `(?<=...)` / `(?<!...)`, atomic
+/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)` — and the
+/// `(*VERB)` family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`,
+/// `(*FAIL)`, `(*MARK:name)`, etc.
+///
+/// # Examples
+///
+/// ```
+/// use nginx_lint_plugin::helpers::find_unnamed_capture_positions;
+///
+/// assert_eq!(find_unnamed_capture_positions("^/api/(.*)$"), vec![6]);
+/// assert_eq!(find_unnamed_capture_positions("(a)(b)(?:c)(d)"), vec![0, 3, 11]);
+///
+/// // Not unnamed captures
+/// assert!(find_unnamed_capture_positions("^/(?<name>.*)$").is_empty());
+/// assert!(find_unnamed_capture_positions(r"\(literal\)").is_empty());
+/// assert!(find_unnamed_capture_positions("[()]").is_empty());
+/// assert!(find_unnamed_capture_positions("(*PRUNE)").is_empty());
+/// ```
+pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
+    let bytes = regex.as_bytes();
+    let mut positions = Vec::new();
+    let mut i = 0;
+    let mut in_char_class = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'\\' && i + 1 < bytes.len() {
+            // Escaped byte — skip both bytes.
+            i += 2;
+            continue;
+        }
+
+        if in_char_class {
+            if b == b']' {
+                in_char_class = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'[' {
+            in_char_class = true;
+            i += 1;
+            continue;
+        }
+
+        if b == b'(' {
+            let next = bytes.get(i + 1).copied();
+            // `(?...)` constructs and `(*VERB)` control verbs are never
+            // unnamed captures.
+            if next != Some(b'?') && next != Some(b'*') {
+                positions.push(i);
+            }
+        }
+
+        i += 1;
+    }
+
+    positions
+}
+
+/// Whether a regex source string contains at least one unnamed PCRE capture
+/// group. See [`find_unnamed_capture_positions`] for what counts as one.
+///
+/// # Examples
+///
+/// ```
+/// use nginx_lint_plugin::helpers::has_unnamed_capture;
+///
+/// assert!(has_unnamed_capture("^/old/(.*)$"));
+/// assert!(!has_unnamed_capture("^/old/(?<rest>.*)$"));
+/// assert!(!has_unnamed_capture("^/old/(?:.*)$"));
+/// ```
+pub fn has_unnamed_capture(regex: &str) -> bool {
+    !find_unnamed_capture_positions(regex).is_empty()
+}
+
+/// Detect whether a regex source string contains any named capture group
+/// (`(?<name>...)` or `(?P<name>...)`). Lookbehinds `(?<=...)` / `(?<!...)`
+/// are NOT named captures and don't count.
+///
+/// # Examples
+///
+/// ```
+/// use nginx_lint_plugin::helpers::regex_has_named_capture;
+///
+/// assert!(regex_has_named_capture("(?<name>.*)"));
+/// assert!(regex_has_named_capture("(?P<name>.*)"));
+///
+/// assert!(!regex_has_named_capture("(.*)"));
+/// assert!(!regex_has_named_capture("(?<=foo)bar"));
+/// assert!(!regex_has_named_capture("(?<!foo)bar"));
+/// ```
+pub fn regex_has_named_capture(regex: &str) -> bool {
+    let bytes = regex.as_bytes();
+    let mut i = 0;
+    let mut in_char_class = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+
+        if in_char_class {
+            if b == b']' {
+                in_char_class = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'[' {
+            in_char_class = true;
+            i += 1;
+            continue;
+        }
+
+        if b == b'(' && i + 3 < bytes.len() && bytes[i + 1] == b'?' {
+            // `(?<name>...)` — named iff the char after `<` is a name-start
+            // byte. `(?<=...)` and `(?<!...)` are lookbehinds; not captures.
+            if bytes[i + 2] == b'<' {
+                let after_lt = bytes[i + 3];
+                if after_lt != b'=' && after_lt != b'!' {
+                    return true;
+                }
+            }
+            // `(?P<name>...)` — Python-style named capture.
+            // (Only `bytes[i + 3]` is read; the outer `i + 3 < bytes.len()`
+            // guard is already sufficient.)
+            if bytes[i + 2] == b'P' && bytes[i + 3] == b'<' {
+                return true;
+            }
+        }
+
+        i += 1;
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -180,6 +180,14 @@ pub fn extract_domain(host: &str) -> &str {
 ///
 /// // The inner paren of a conditional is syntax, not a group
 /// assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
+///
+/// // A `(?#...)` comment body is opaque text — parens in it are not groups,
+/// // and a `[` or `\Q` in it must not swallow the captures that follow
+/// assert!(find_unnamed_capture_positions("^/a(?#()$").is_empty());
+/// assert_eq!(find_unnamed_capture_positions("(?# [ )(a)"), vec![7]);
+///
+/// // Negated POSIX classes are classes too
+/// assert!(find_unnamed_capture_positions("[[:^print:]()]").is_empty());
 /// ```
 pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     let bytes = regex.as_bytes();
@@ -236,17 +244,32 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
 
         if b == b'(' {
             match bytes.get(i + 1).copied() {
-                // `(*VERB)` control verbs are never captures.
-                Some(b'*') => {}
-                // The `(?...)` family is never a capture. A conditional
-                // `(?(1)...)` / `(?(<name>)...)` nests a paren that is syntax,
-                // not a group — step over it so it is not counted.
-                Some(b'?') => {
-                    if bytes.get(i + 2) == Some(&b'(') {
+                // `(*VERB)` / `(*MARK:name)` — never a capture, and the name
+                // is arbitrary text, so step over the whole thing rather than
+                // scanning it as regex.
+                Some(b'*') => {
+                    i = find_unescaped_close_paren(bytes, i + 2);
+                    continue;
+                }
+                Some(b'?') => match bytes.get(i + 2).copied() {
+                    // `(?#...)` is a comment: its body is arbitrary text and
+                    // runs to the very next `)`, with no escaping. Scanning it
+                    // as regex both invents groups and — via a stray `[` or
+                    // `\Q` — swallows the real ones after it.
+                    Some(b'#') => {
+                        i = find_unescaped_close_paren(bytes, i + 3);
+                        continue;
+                    }
+                    // A conditional `(?(1)...)` / `(?(<name>)...)` nests a
+                    // paren that is syntax, not a group.
+                    Some(b'(') => {
                         i += 3;
                         continue;
                     }
-                }
+                    // Every other `(?...)` construct is not a capture, but its
+                    // body is regex and must still be scanned.
+                    _ => {}
+                },
                 _ => positions.push(i),
             }
         }
@@ -257,11 +280,29 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
     positions
 }
 
+/// Offset just past the next `)` at or after `from`, or the end of the input
+/// when there is none. Used for constructs whose body is opaque text — a
+/// `(?#...)` comment or a `(*VERB:name)` — which PCRE ends at the first `)`.
+fn find_unescaped_close_paren(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b')' {
+            return i + 1;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
 /// Offset just past the `:]` closing a POSIX class whose body starts at
 /// `from`, or `None` when there is none — in which case the `[` was an
 /// ordinary member and should be treated as such.
 fn find_posix_class_end(bytes: &[u8], from: usize) -> Option<usize> {
-    let mut i = from;
+    // `[[:^alpha:]]` negates the class; the `^` is part of the syntax, not the
+    // name. Missing it ended the class at the `:]` and exposed everything after
+    // it as regex.
+    let mut i = from + usize::from(bytes.get(from) == Some(&b'^'));
+
     while i + 1 < bytes.len() {
         if bytes[i] == b':' && bytes[i + 1] == b']' {
             return Some(i + 2);
@@ -356,6 +397,11 @@ pub fn regex_has_named_capture(regex: &str) -> bool {
                 if after_lt != b'=' && after_lt != b'!' {
                     return true;
                 }
+            }
+            // `(?'name'...)` — the quoted form. Missing it let callers treat a
+            // named group as unnamed, which silently misnumbers the rest.
+            if bytes[i + 2] == b'\'' {
+                return true;
             }
             // `(?P<name>...)` — Python-style named capture.
             // (Only `bytes[i + 3]` is read; the outer `i + 3 < bytes.len()`
@@ -475,5 +521,48 @@ mod tests {
     fn conditional_inner_paren_is_not_a_capture() {
         assert_eq!(find_unnamed_capture_positions("(a)(?(1)x|y)"), vec![0]);
         assert!(find_unnamed_capture_positions("(?(<n>)x|y)").is_empty());
+    }
+
+    /// A `(?#...)` comment body is opaque text ending at the first `)`.
+    /// Scanning it as regex invented groups, and a stray `[` or `\Q` in the
+    /// prose swallowed every real capture after it.
+    #[test]
+    fn comment_body_is_skipped() {
+        // `(` in the prose is not a group.
+        assert!(find_unnamed_capture_positions("^/a(?#()$").is_empty());
+        // A capture after such a comment is still found.
+        assert_eq!(find_unnamed_capture_positions("^/a(?#()/(.*)$"), vec![9]);
+        // `[` / `\Q` in the prose must not swallow what follows.
+        assert_eq!(find_unnamed_capture_positions("(?# [ )(a)"), vec![7]);
+        assert_eq!(find_unnamed_capture_positions(r"(?#\Q)(a)"), vec![6]);
+        assert_eq!(find_unnamed_capture_positions("(?#c)(a)"), vec![5]);
+    }
+
+    /// `(*MARK:name)` carries arbitrary text; a `[` in it must not swallow the
+    /// rest of the pattern.
+    #[test]
+    fn verb_name_is_skipped() {
+        assert_eq!(find_unnamed_capture_positions("(*MARK:[)(a)"), vec![9]);
+        assert!(find_unnamed_capture_positions("(*PRUNE)").is_empty());
+    }
+
+    /// `[[:^alpha:]]` negates the class — the `^` is syntax, not the name.
+    /// Missing it closed the class at the `:]`.
+    #[test]
+    fn negated_posix_class_does_not_end_the_class() {
+        assert!(find_unnamed_capture_positions("[[:^print:]()]").is_empty());
+        assert!(find_unnamed_capture_positions("[[:^alpha:]]").is_empty());
+        // Still finds a real capture after the class.
+        assert_eq!(find_unnamed_capture_positions("[[:^print:]](a)"), vec![12]);
+    }
+
+    /// PCRE has three named-capture syntaxes; treating `(?'n'...)` as unnamed
+    /// made callers renumber the groups around it.
+    #[test]
+    fn quoted_named_capture_is_recognised() {
+        assert!(regex_has_named_capture("(?'a'x)"));
+        assert!(regex_has_named_capture("(?'a'x)(y)"));
+        // Not a named capture.
+        assert!(!regex_has_named_capture("(x)"));
     }
 }

--- a/crates/nginx-lint-plugin/src/helpers.rs
+++ b/crates/nginx-lint-plugin/src/helpers.rs
@@ -176,24 +176,6 @@ pub fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
         .collect()
 }
 
-/// Whether a regex source string contains at least one unnamed PCRE capture
-/// group. See [`find_unnamed_capture_positions`].
-///
-/// # Examples
-///
-/// ```
-/// use nginx_lint_plugin::helpers::has_unnamed_capture;
-///
-/// assert!(has_unnamed_capture("^/old/(.*)$"));
-/// assert!(!has_unnamed_capture("^/old/(?<rest>.*)$"));
-/// assert!(!has_unnamed_capture("^/old/(?:.*)$"));
-/// ```
-pub fn has_unnamed_capture(regex: &str) -> bool {
-    scan(regex)
-        .iter()
-        .any(|(_, group)| *group == Group::Unnamed)
-}
-
 /// Detect whether a regex source string contains any named capture group —
 /// `(?<name>...)`, `(?'name'...)` or `(?P<name>...)`. Lookbehinds
 /// `(?<=...)` / `(?<!...)` are NOT named captures and don't count.

--- a/crates/nginx-lint-plugin/src/lib.rs
+++ b/crates/nginx-lint-plugin/src/lib.rs
@@ -100,6 +100,8 @@ pub use nginx_lint_common::parser;
 /// This re-exports all core types ([`Plugin`], [`PluginSpec`], [`LintError`], [`Fix`],
 /// [`Config`], [`Directive`], etc.), extension traits ([`ConfigExt`], [`DirectiveExt`]),
 /// the [`helpers`] module, and the [`export_component_plugin!`] macro.
+pub mod regex_scan;
+
 pub mod prelude {
     pub use super::export_component_plugin;
     pub use super::helpers;

--- a/crates/nginx-lint-plugin/src/regex_scan.rs
+++ b/crates/nginx-lint-plugin/src/regex_scan.rs
@@ -344,4 +344,53 @@ mod tests {
         assert_eq!(unnamed("(*MARK:[)(a)"), vec![9]);
         assert!(unnamed("(*PRUNE)").is_empty());
     }
+
+    /// Truncated and degenerate inputs. PCRE rejects all of these, so nginx
+    /// would refuse the config either way — what matters is only that `scan`
+    /// does not panic and does not read past the end.
+    ///
+    /// `(?'` answering "named" is a deliberate loosening: the previous walker
+    /// guarded on `i + 3 < len` and said "no", this one asks `bytes.get()` and
+    /// says "yes". Callers use the answer to decline an autofix, so erring
+    /// towards "named" on a regex that cannot compile costs nothing.
+    #[test]
+    fn truncated_input_is_handled_without_panicking() {
+        assert!(!named("("));
+        assert!(!named("(?"));
+        assert!(!named("(?<"));
+        assert!(!named("(?P"));
+        assert!(!named("(?<="));
+        assert!(!named("(?<!"));
+        assert!(!named(""));
+        assert!(named("(?'"));
+
+        assert_eq!(unnamed("("), vec![0]);
+        assert!(unnamed("").is_empty());
+        assert!(unnamed(")").is_empty());
+    }
+
+    /// Byte offsets must land on the `(` itself even when multibyte characters
+    /// precede it, or a caller slicing at them would split a char.
+    #[test]
+    fn offsets_are_char_boundaries_with_multibyte_input() {
+        for (regex, expected) in [
+            ("é(a)", vec![2]),
+            (r"\é(a)", vec![3]),
+            ("あ(.*)い", vec![3]),
+        ] {
+            let found = unnamed(regex);
+            assert_eq!(found, expected, "{regex}");
+            for pos in found {
+                assert!(
+                    regex.is_char_boundary(pos),
+                    "{regex}: offset {pos} splits a char"
+                );
+                assert_eq!(
+                    regex.as_bytes()[pos],
+                    b'(',
+                    "{regex}: offset {pos} is not a paren"
+                );
+            }
+        }
+    }
 }

--- a/crates/nginx-lint-plugin/src/regex_scan.rs
+++ b/crates/nginx-lint-plugin/src/regex_scan.rs
@@ -1,0 +1,347 @@
+//! A single pass over PCRE syntax, shared by every rule that reasons about
+//! capture groups.
+//!
+//! nginx stores unnamed captures in the shared `$1`..`$9` slots, so rules need
+//! to tell a real capture group apart from a paren that merely looks like one —
+//! and rules that autofix rewrite source bytes at the offsets found here, so a
+//! paren misjudged is a user's config corrupted.
+//!
+//! # Why one walker
+//!
+//! This used to be two: one to find unnamed captures, one to answer "does this
+//! regex have a named capture at all". They drifted, as duplicated parsers do.
+//! `(?'name'...)` was taught to the first and not the second, which defeated
+//! nginx_rift's mixed-named/unnamed guard and silently renumbered a live
+//! `rewrite`'s captures. Later, `\Q...\E`, `(?#...)` comments and POSIX classes
+//! were taught to the first and not the second, so the second still claimed
+//! `\Q(?<n>x)\E` had a named group.
+//!
+//! [`scan`] is now the only place that knows PCRE syntax; everything else is a
+//! filter over its output, so a construct learned once is learned by all.
+//!
+//! # Scope
+//!
+//! This classifies parens. It does not validate the regex — an input PCRE
+//! rejects may produce anything, which is fine because nginx would refuse such
+//! a config anyway.
+
+/// What a `(` in the pattern opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Group {
+    /// `(...)` — a capture reachable only as `$1`..`$9`.
+    Unnamed,
+    /// `(?<n>...)`, `(?'n'...)`, `(?P<n>...)` — reachable by name. Still a
+    /// capturing group as far as PCRE's count is concerned.
+    Named,
+}
+
+/// Every capture group in `regex`, as (byte offset of its `(`, kind), in source
+/// order.
+///
+/// Skipped, because PCRE does not read them as capture groups: escapes (`\(`),
+/// `\Q...\E` literal spans, character classes (including a leading `]` member,
+/// negated `[^...]`, and nested POSIX classes like `[[:^alpha:]]`), the
+/// non-capturing `(?...)` family — `(?:...)`, lookarounds, atomic `(?>...)`,
+/// inline modifiers, conditionals `(?(1)...)` — comments `(?#...)`, and the
+/// `(*VERB)` / `(*MARK:name)` family.
+///
+/// Comment and verb bodies are opaque text ending at the first `)`, and are
+/// stepped over rather than scanned: they can contain anything, and a stray `[`
+/// or `\Q` in one would otherwise open a class or literal span that never
+/// closes, hiding every real capture after it.
+///
+/// # Examples
+///
+/// ```
+/// use nginx_lint_plugin::regex_scan::{scan, Group};
+///
+/// assert_eq!(scan("(a)(?<n>b)(?:c)"), vec![(0, Group::Unnamed), (3, Group::Named)]);
+/// assert!(scan(r"\Q(?<n>x)\E").is_empty());
+/// assert!(scan("[[:^alpha:]()]").is_empty());
+/// ```
+pub fn scan(regex: &str) -> Vec<(usize, Group)> {
+    let bytes = regex.as_bytes();
+    let mut groups = Vec::new();
+    let mut i = 0;
+    let mut in_char_class = false;
+
+    // Byte offset just past `[` (and an optional negating `^`), where a `]` is
+    // a literal member rather than the class terminator.
+    let mut class_body_start = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'\\' && i + 1 < bytes.len() {
+            // `\Q...\E` quotes everything up to `\E` (or end of pattern).
+            if bytes[i + 1] == b'Q' {
+                i = find_literal_span_end(bytes, i + 2);
+                continue;
+            }
+            // Any other escape — skip both bytes.
+            i += 2;
+            continue;
+        }
+
+        if in_char_class {
+            // A POSIX class such as `[:alpha:]` nests inside the class, and its
+            // `]` does not end the enclosing one.
+            if b == b'['
+                && bytes.get(i + 1) == Some(&b':')
+                && let Some(end) = find_posix_class_end(bytes, i + 2)
+            {
+                i = end;
+                continue;
+            }
+            // PCRE reads `]` as a member when it opens the class body, so only
+            // a later one closes it. `[]()]`, `[^]()]` are single classes.
+            if b == b']' && i > class_body_start {
+                in_char_class = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'[' {
+            in_char_class = true;
+            class_body_start = i + 1;
+            if bytes.get(class_body_start) == Some(&b'^') {
+                class_body_start += 1;
+            }
+            i += 1;
+            continue;
+        }
+
+        if b == b'(' {
+            match bytes.get(i + 1).copied() {
+                // `(*VERB)` / `(*MARK:name)` — never a capture, and the name is
+                // arbitrary text.
+                Some(b'*') => {
+                    i = find_close_paren(bytes, i + 2);
+                    continue;
+                }
+                Some(b'?') => match bytes.get(i + 2).copied() {
+                    // `(?#...)` is a comment; its body is arbitrary text.
+                    Some(b'#') => {
+                        i = find_close_paren(bytes, i + 3);
+                        continue;
+                    }
+                    // A conditional `(?(1)...)` / `(?(<name>)...)` nests a paren
+                    // that is syntax, not a group.
+                    Some(b'(') => {
+                        i += 3;
+                        continue;
+                    }
+                    // `(?'name'...)`.
+                    Some(b'\'') => groups.push((i, Group::Named)),
+                    // `(?<name>...)`, but `(?<=...)` / `(?<!...)` are
+                    // lookbehinds and capture nothing.
+                    Some(b'<') if !matches!(bytes.get(i + 3), Some(b'=') | Some(b'!') | None) => {
+                        groups.push((i, Group::Named))
+                    }
+                    // `(?P<name>...)`.
+                    Some(b'P') if bytes.get(i + 3) == Some(&b'<') => groups.push((i, Group::Named)),
+                    // Every other `(?...)` construct captures nothing, but its
+                    // body is regex and must still be scanned.
+                    _ => {}
+                },
+                _ => groups.push((i, Group::Unnamed)),
+            }
+        }
+
+        i += 1;
+    }
+
+    groups
+}
+
+/// Offset just past the next `)` at or after `from`, or the end of the input
+/// when there is none. Used for constructs whose body is opaque text — a
+/// `(?#...)` comment or a `(*VERB:name)` — which PCRE ends at the first `)`.
+///
+/// **Escapes are deliberately not honoured, and must not be.** PCRE gives no
+/// way to put a `)` inside these: a comment ends at the first one even when a
+/// backslash precedes it, so `a(?#x\)b` is `a`, a comment, then `b` — it
+/// matches `ab`. Teaching this function to skip `\)` would desynchronise it
+/// from PCRE and hide the group that follows. Pinned by
+/// `comment_ends_at_first_paren_even_after_a_backslash`.
+fn find_close_paren(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b')' {
+            return i + 1;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Offset just past the `:]` closing a POSIX class whose body starts at `from`,
+/// or `None` when there is none — in which case the `[` was an ordinary member
+/// and should be treated as such.
+fn find_posix_class_end(bytes: &[u8], from: usize) -> Option<usize> {
+    // `[[:^alpha:]]` negates the class; the `^` is part of the syntax, not the
+    // name.
+    let mut i = from + usize::from(bytes.get(from) == Some(&b'^'));
+
+    while i + 1 < bytes.len() {
+        if bytes[i] == b':' && bytes[i + 1] == b']' {
+            return Some(i + 2);
+        }
+        // A POSIX class name is alphabetic; anything else means this was not
+        // one, e.g. a literal `[` followed by `:` in the class.
+        if !bytes[i].is_ascii_alphabetic() {
+            return None;
+        }
+        i += 1;
+    }
+
+    None
+}
+
+/// Offset just past the `\E` closing a `\Q` literal span that starts at `from`,
+/// or the end of the pattern when it is unterminated.
+fn find_literal_span_end(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'\\' && bytes[i + 1] == b'E' {
+            return i + 2;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unnamed(regex: &str) -> Vec<usize> {
+        scan(regex)
+            .into_iter()
+            .filter(|(_, g)| *g == Group::Unnamed)
+            .map(|(pos, _)| pos)
+            .collect()
+    }
+
+    fn named(regex: &str) -> bool {
+        scan(regex).iter().any(|(_, g)| *g == Group::Named)
+    }
+
+    /// The whole point of the merge: every construct below is one the two old
+    /// walkers disagreed about. A single `scan` cannot disagree with itself.
+    #[test]
+    fn both_views_agree_on_constructs_that_used_to_diverge() {
+        // `\Q...\E` is literal text: no groups of either kind.
+        assert!(unnamed(r"\Q(a)\E").is_empty());
+        assert!(!named(r"\Q(?<n>x)\E"));
+
+        // A comment body is opaque: no groups of either kind.
+        assert!(unnamed("(?#(a)x").is_empty());
+        assert!(!named("(?#(?<n)x"));
+
+        // Verb names are arbitrary text.
+        assert!(unnamed("(*MARK:(a))").is_empty());
+        assert!(!named("(*MARK:(?<n>x))"));
+
+        // Character classes, including the awkward forms.
+        assert!(unnamed("[]()]").is_empty());
+        assert!(!named("[(?<x>]"));
+        assert!(unnamed("[[:^print:]()]").is_empty());
+    }
+
+    #[test]
+    fn all_three_named_syntaxes_are_recognised() {
+        assert!(named("(?<n>x)"));
+        assert!(named("(?'n'x)"));
+        assert!(named("(?P<n>x)"));
+
+        // Lookbehinds are not captures.
+        assert!(!named("(?<=foo)bar"));
+        assert!(!named("(?<!foo)bar"));
+        // Truncated input must not be read as a name.
+        assert!(!named("(?<"));
+    }
+
+    #[test]
+    fn mixed_groups_keep_their_order_and_kind() {
+        assert_eq!(
+            scan("(a)(?<n>b)(?:c)(?'m'd)(e)"),
+            vec![
+                (0, Group::Unnamed),
+                (3, Group::Named),
+                (15, Group::Named),
+                (22, Group::Unnamed),
+            ]
+        );
+    }
+
+    /// PCRE gives no way to put a `)` inside a `(?#...)` comment — the first one
+    /// ends it, backslash or not (`a(?#x\)b` matches "ab"). So the group after
+    /// it is real, and skipping `\)` here would hide it.
+    #[test]
+    fn comment_ends_at_first_paren_even_after_a_backslash() {
+        assert_eq!(unnamed(r"(?#x\)(a)"), vec![6]);
+    }
+
+    #[test]
+    fn escaped_parens_are_not_groups() {
+        assert!(unnamed(r"\(literal\)").is_empty());
+        assert!(unnamed("(*PRUNE)").is_empty());
+        assert_eq!(unnamed("(a)(?(1)x|y)"), vec![0]);
+    }
+
+    /// PCRE reads `]` as a member when it opens the class body, so the class
+    /// runs on past it.
+    #[test]
+    fn class_with_leading_bracket_member_is_not_a_capture() {
+        assert!(unnamed("[]()]").is_empty());
+        assert!(unnamed("[^]()]").is_empty());
+        assert!(unnamed("[[:alpha:]()]").is_empty());
+        // A `]` that is not first still closes the class.
+        assert_eq!(unnamed("[abc](d)"), vec![5]);
+    }
+
+    /// `[[:^alpha:]]` negates the class — the `^` is syntax, not the name.
+    #[test]
+    fn negated_posix_class_does_not_end_the_class() {
+        assert!(unnamed("[[:^print:]()]").is_empty());
+        assert!(unnamed("[[:^alpha:]]").is_empty());
+        // Still finds a real capture after the class.
+        assert_eq!(unnamed("[[:^print:]](a)"), vec![12]);
+    }
+
+    /// `\Q...\E` quotes its contents, so parens inside are literal.
+    #[test]
+    fn quoted_literal_span_is_not_scanned() {
+        assert!(unnamed(r"\Q(a)\E").is_empty());
+        assert_eq!(unnamed(r"\Q(a)\E(b)"), vec![7]);
+        // Unterminated `\Q` quotes to the end.
+        assert!(unnamed(r"\Q(a)").is_empty());
+    }
+
+    /// The paren nested in a conditional is syntax, not a group.
+    #[test]
+    fn conditional_inner_paren_is_not_a_capture() {
+        assert_eq!(unnamed("(a)(?(1)x|y)"), vec![0]);
+        assert!(unnamed("(?(<n>)x|y)").is_empty());
+    }
+
+    /// A `(?#...)` comment body is opaque text ending at the first `)`.
+    #[test]
+    fn comment_body_is_skipped() {
+        assert!(unnamed("^/a(?#()$").is_empty());
+        assert_eq!(unnamed("^/a(?#()/(.*)$"), vec![9]);
+        assert_eq!(unnamed("(?# [ )(a)"), vec![7]);
+        assert_eq!(unnamed(r"(?#\Q)(a)"), vec![6]);
+        assert_eq!(unnamed("(?#c)(a)"), vec![5]);
+    }
+
+    /// `(*MARK:name)` carries arbitrary text; a `[` in it must not swallow the
+    /// rest of the pattern.
+    #[test]
+    fn verb_name_is_skipped() {
+        assert_eq!(unnamed("(*MARK:[)(a)"), vec![9]);
+        assert!(unnamed("(*PRUNE)").is_empty());
+    }
+}

--- a/crates/nginx-lint-plugin/src/regex_scan.rs
+++ b/crates/nginx-lint-plugin/src/regex_scan.rs
@@ -24,6 +24,19 @@
 //! This classifies parens. It does not validate the regex — an input PCRE
 //! rejects may produce anything, which is fine because nginx would refuse such
 //! a config anyway.
+//!
+//! It also tracks no nesting, which bounds one case deliberately: `(?n)` (PCRE2
+//! 10.43+) turns off auto-capture until the end of the *enclosing group*, and
+//! `(?n:...)` only within its own. Honouring that needs a group stack, so it is
+//! not honoured — `(?n)(a)` is reported as an unnamed capture though PCRE gives
+//! it none.
+//!
+//! That over-reports, which is the safe direction and costs nothing real: the
+//! spurious warning lands on a regex that has no captures to leak, and the
+//! rewrite it invites, `(?n)(a)` -> `(?n)(?:a)`, has the same zero captures and
+//! still loads (checked on nginx 1.29). A global flag was tried and rejected:
+//! it made `(?n:(a))(b)` report *no* captures where PCRE has one, turning a
+//! harmless over-report into a security rule missing a real capture.
 
 /// What a `(` in the pattern opens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,15 +127,37 @@ pub fn scan(regex: &str) -> Vec<(usize, Group)> {
 
         if b == b'(' {
             match bytes.get(i + 1).copied() {
-                // `(*VERB)` / `(*MARK:name)` — never a capture, and the name is
-                // arbitrary text.
                 Some(b'*') => {
-                    i = find_close_paren(bytes, i + 2);
+                    // `(*` spells two unrelated things. A control verb or
+                    // option setting — `(*PRUNE)`, `(*MARK:name)`, `(*UTF)`,
+                    // `(*:name)` — carries arbitrary text, so it is opaque. But
+                    // `(*pla:...)`, `(*atomic:...)`, `(*sr:...)` and friends are
+                    // *groups*, spelled with a lowercase name, and their bodies
+                    // are regex holding real captures. Skipping those as if they
+                    // were verbs hid every capture inside them.
+                    if is_alpha_group_prefix(bytes, i + 2) {
+                        i += 2;
+                    } else {
+                        i = find_close_paren(bytes, i + 2);
+                    }
                     continue;
                 }
                 Some(b'?') => match bytes.get(i + 2).copied() {
                     // `(?#...)` is a comment; its body is arbitrary text.
                     Some(b'#') => {
+                        i = find_close_paren(bytes, i + 3);
+                        continue;
+                    }
+                    // A callout with a string argument — `(?C'...'`, `(?C"..."`,
+                    // `` (?C`...` ``, `(?C{...}` etc. Like a comment, the body is
+                    // arbitrary text: a `[` or `\Q` in it would otherwise open a
+                    // class or literal span that never closes. Numeric callouts
+                    // `(?C1)` have no body and need no special case.
+                    Some(b'C')
+                        if bytes
+                            .get(i + 3)
+                            .is_some_and(|c| !c.is_ascii_digit() && *c != b')') =>
+                    {
                         i = find_close_paren(bytes, i + 3);
                         continue;
                     }
@@ -134,9 +169,15 @@ pub fn scan(regex: &str) -> Vec<(usize, Group)> {
                     }
                     // `(?'name'...)`.
                     Some(b'\'') => groups.push((i, Group::Named)),
-                    // `(?<name>...)`, but `(?<=...)` / `(?<!...)` are
-                    // lookbehinds and capture nothing.
-                    Some(b'<') if !matches!(bytes.get(i + 3), Some(b'=') | Some(b'!') | None) => {
+                    // `(?<name>...)`. Not `(?<=...)` / `(?<!...)` (lookbehinds)
+                    // nor `(?<*...)` (non-atomic lookbehind) — those capture
+                    // nothing.
+                    Some(b'<')
+                        if !matches!(
+                            bytes.get(i + 3),
+                            Some(b'=') | Some(b'!') | Some(b'*') | None
+                        ) =>
+                    {
                         groups.push((i, Group::Named))
                     }
                     // `(?P<name>...)`.
@@ -153,6 +194,29 @@ pub fn scan(regex: &str) -> Vec<(usize, Group)> {
     }
 
     groups
+}
+
+/// Whether `(*` at `from - 2` introduces a *group* rather than a control verb.
+///
+/// PCRE spells both with `(*`. Groups use a lowercase name followed by `:` —
+/// `(*pla:`, `(*plb:`, `(*nla:`, `(*nlb:`, `(*napla:`, `(*naplb:`,
+/// `(*atomic:`, `(*sr:`, `(*asr:`, and the long forms
+/// (`(*positive_lookahead:`, `(*script_run:`, `(*atomic_script_run:`, ...).
+/// Their bodies are regex and hold real captures.
+///
+/// Verbs and option settings use uppercase (`(*PRUNE)`, `(*MARK:name)`,
+/// `(*UTF)`) or no name at all (`(*:name)`), and carry arbitrary text.
+///
+/// Underscores appear in the long forms, so they count as part of a name.
+fn is_alpha_group_prefix(bytes: &[u8], from: usize) -> bool {
+    let mut i = from;
+    while bytes
+        .get(i)
+        .is_some_and(|b| b.is_ascii_lowercase() || *b == b'_')
+    {
+        i += 1;
+    }
+    i > from && bytes.get(i) == Some(&b':')
 }
 
 /// Offset just past the next `)` at or after `from`, or the end of the input
@@ -392,5 +456,52 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `(*` spells two unrelated things, and treating them alike hid captures.
+    /// A lowercase name plus `:` is a *group* whose body is regex —
+    /// `(*pla:...)`, `(*atomic:...)`, `(*script_run:...)` — while verbs and
+    /// option settings carry opaque text. All verified against libpcre2: the
+    /// group forms really do hold the captures below.
+    #[test]
+    fn alpha_groups_are_scanned_but_verbs_stay_opaque() {
+        // Groups: the body is regex, so its captures count.
+        assert_eq!(unnamed("(*atomic:(a))b"), vec![9]);
+        assert_eq!(unnamed("(*sr:(a))b"), vec![5]);
+        assert_eq!(unnamed("(*nla:(a))b"), vec![6]);
+        assert_eq!(unnamed("(*script_run:(a))b"), vec![13]);
+        assert_eq!(unnamed("(*positive_lookahead:(a))b"), vec![21]);
+        assert!(named("^/a(*pla:(?<n>x))(.*)$"));
+        assert_eq!(unnamed("^/a(*pla:(y))(.*)$"), vec![9, 13]);
+
+        // Verbs and option settings: opaque, and no capture of their own.
+        assert_eq!(unnamed("(*MARK:n)(a)"), vec![9]);
+        assert_eq!(unnamed("(*PRUNE)(a)"), vec![8]);
+        assert_eq!(unnamed("(*:name)(a)"), vec![8]);
+        assert_eq!(unnamed("(*UTF)(a)"), vec![6]);
+        assert_eq!(unnamed("(*MARK:[)(a)"), vec![9]);
+    }
+
+    /// A callout's string argument is arbitrary text, exactly like a comment
+    /// body — a `[` or `\Q` in one used to open a class or literal span that
+    /// never closed, hiding every capture after it.
+    #[test]
+    fn callout_string_bodies_are_opaque() {
+        assert_eq!(unnamed("(?C'[')(a)"), vec![7]);
+        assert_eq!(unnamed(r"(?C'\Q')(a)"), vec![8]);
+        // ...and their contents are not groups.
+        assert!(unnamed("(?C'(a)')x").is_empty());
+        // A numeric callout has no body.
+        assert_eq!(unnamed("(?C1)(a)"), vec![5]);
+        assert_eq!(unnamed("(?C)(a)"), vec![4]);
+    }
+
+    /// `(?<*...)` is a non-atomic lookbehind, not a name.
+    #[test]
+    fn non_atomic_lookbehind_is_not_named() {
+        assert!(!named("(?<*ab)c"));
+        assert!(!named("(?<=ab)c"));
+        assert!(!named("(?<!ab)c"));
+        assert!(named("(?<n>x)"));
     }
 }

--- a/crates/nginx-lint-plugin/src/regex_scan.rs
+++ b/crates/nginx-lint-plugin/src/regex_scan.rs
@@ -149,16 +149,16 @@ pub fn scan(regex: &str) -> Vec<(usize, Group)> {
                         continue;
                     }
                     // A callout with a string argument — `(?C'...'`, `(?C"..."`,
-                    // `` (?C`...` ``, `(?C{...}` etc. Like a comment, the body is
-                    // arbitrary text: a `[` or `\Q` in it would otherwise open a
-                    // class or literal span that never closes. Numeric callouts
-                    // `(?C1)` have no body and need no special case.
-                    Some(b'C')
-                        if bytes
-                            .get(i + 3)
-                            .is_some_and(|c| !c.is_ascii_digit() && *c != b')') =>
-                    {
-                        i = find_close_paren(bytes, i + 3);
+                    // `` (?C`...` ``, `(?C{...}` etc. The body is arbitrary
+                    // text: a `[` or `\Q` in it would otherwise open a class or
+                    // literal span that never closes. Numeric callouts `(?C1)`
+                    // and the bare `(?C)` have no body and need no case.
+                    //
+                    // Unlike a comment, this does NOT end at the first `)` — it
+                    // ends at the delimiter, so the body may contain parens.
+                    Some(b'C') if callout_delimiter(bytes.get(i + 3)).is_some() => {
+                        let close = callout_delimiter(bytes.get(i + 3)).unwrap();
+                        i = find_callout_end(bytes, i + 4, close);
                         continue;
                     }
                     // A conditional `(?(1)...)` / `(?(<name>)...)` nests a paren
@@ -194,6 +194,47 @@ pub fn scan(regex: &str) -> Vec<(usize, Group)> {
     }
 
     groups
+}
+
+/// The closing delimiter for a callout's string argument, given the byte right
+/// after `(?C`, or `None` when there is no string argument (`(?C)`, `(?C1)`).
+///
+/// PCRE2 accepts several delimiters and closes on the matching one, not on the
+/// first `)` — a callout string may legitimately contain parens. Doubling the
+/// delimiter escapes it (`(?C'a''b')`), which [`find_callout_end`] handles.
+fn callout_delimiter(after_c: Option<&u8>) -> Option<u8> {
+    match after_c? {
+        b'`' => Some(b'`'),
+        b'\'' => Some(b'\''),
+        b'"' => Some(b'"'),
+        b'^' => Some(b'^'),
+        b'%' => Some(b'%'),
+        b'#' => Some(b'#'),
+        b'$' => Some(b'$'),
+        b'{' => Some(b'}'),
+        _ => None,
+    }
+}
+
+/// Offset just past the `)` closing a callout whose string body starts at
+/// `from` and ends at `close`, or the end of the input when unterminated.
+///
+/// A doubled delimiter is a literal one and does not end the string.
+fn find_callout_end(bytes: &[u8], from: usize, close: u8) -> usize {
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == close {
+            if bytes.get(i + 1) == Some(&close) {
+                // Doubled — a literal delimiter, keep going.
+                i += 2;
+                continue;
+            }
+            // The `)` that ends the whole callout follows the delimiter.
+            return find_close_paren(bytes, i + 1);
+        }
+        i += 1;
+    }
+    bytes.len()
 }
 
 /// Whether `(*` at `from - 2` introduces a *group* rather than a control verb.
@@ -482,18 +523,41 @@ mod tests {
         assert_eq!(unnamed("(*MARK:[)(a)"), vec![9]);
     }
 
-    /// A callout's string argument is arbitrary text, exactly like a comment
-    /// body — a `[` or `\Q` in one used to open a class or literal span that
-    /// never closed, hiding every capture after it.
+    /// A callout's string argument is arbitrary text — a `[` or `\Q` in one
+    /// would otherwise open a class or literal span that never closes, hiding
+    /// every capture after it.
+    ///
+    /// Unlike a `(?#...)` comment, it does NOT end at the first `)`: it ends at
+    /// its delimiter, so the body may contain parens. Treating it like a
+    /// comment both invented captures out of the body and lost the real ones.
+    /// Every case below was checked against libpcre2.
     #[test]
-    fn callout_string_bodies_are_opaque() {
+    fn callout_string_bodies_are_opaque_and_end_at_their_delimiter() {
+        // The body may contain parens; the capture after it is the only one.
+        assert_eq!(unnamed("(?C'a)(b')(x)"), vec![10]);
+        assert_eq!(unnamed("(?C{a)(b})(x)"), vec![10]);
+        assert_eq!(unnamed(r#"(?C"a)(b")(x)"#), vec![10]);
+        // A `[` in the body must not swallow what follows.
+        assert_eq!(unnamed("(?C'a)[b')(x)"), vec![10]);
         assert_eq!(unnamed("(?C'[')(a)"), vec![7]);
         assert_eq!(unnamed(r"(?C'\Q')(a)"), vec![8]);
-        // ...and their contents are not groups.
+        // A doubled delimiter is a literal one, not the end.
+        assert_eq!(unnamed("(?C'a''b')(x)"), vec![10]);
+        // The body's own parens are not groups.
         assert!(unnamed("(?C'(a)')x").is_empty());
-        // A numeric callout has no body.
+        // Every delimiter PCRE accepts.
+        for p in [
+            "(?C^a)(b^)(x)",
+            "(?C%a)(b%)(x)",
+            "(?C$a)(b$)(x)",
+            "(?C#a)(b#)(x)",
+        ] {
+            assert_eq!(unnamed(p), vec![10], "{p}");
+        }
+        // No body at all.
         assert_eq!(unnamed("(?C1)(a)"), vec![5]);
         assert_eq!(unnamed("(?C)(a)"), vec![4]);
+        assert_eq!(unnamed("(a)(?C'x')(b)"), vec![0, 10]);
     }
 
     /// `(?<*...)` is a non-atomic lookbehind, not a name.

--- a/plugins/builtin/security/map_unnamed_capture/Cargo.toml
+++ b/plugins/builtin/security/map_unnamed_capture/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "map-unnamed-capture-plugin"
+version = "0.17.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+nginx-lint-plugin = { path = "../../../../crates/nginx-lint-plugin" }
+
+[dev-dependencies]
+nginx-lint-plugin = { path = "../../../../crates/nginx-lint-plugin", features = ["container-testing"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["wit-export"]
+wit-export = ["nginx-lint-plugin/wit-export"]

--- a/plugins/builtin/security/map_unnamed_capture/examples/bad.conf
+++ b/plugins/builtin/security/map_unnamed_capture/examples/bad.conf
@@ -1,0 +1,22 @@
+http {
+    # Volatile map with an unnamed capture. On affected nginx (< 1.30.4 /
+    # < 1.31.3) the map is re-evaluated inside subrequests (e.g. under `slice`);
+    # when it mismatches it leaves a stale capture count, and reading an unnamed
+    # positional $1 then reads uninitialized memory — a worker crash or
+    # potential RCE (CVE-2026-42533).
+    map $uri $svc {
+        volatile;
+        ~^/svc/(.*)$   $1;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(.*)$ {
+            slice 1m;
+            proxy_set_header X-Svc  $svc;
+            proxy_set_header X-Path $1;
+            proxy_pass http://127.0.0.1:8080;
+        }
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/examples/good.conf
+++ b/plugins/builtin/security/map_unnamed_capture/examples/good.conf
@@ -1,0 +1,21 @@
+http {
+    # The mitigation is config-wide: use named captures in the map AND in every
+    # block that reads the value, referencing them by name instead of $1..$9.
+    # Named captures resolve through a path that never touches the stale capture
+    # count, so the volatile map stays safe.
+    map $uri $svc {
+        volatile;
+        ~^/svc/(?<svc_name>.*)$   $svc_name;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(?<api_path>.*)$ {
+            slice 1m;
+            proxy_set_header X-Svc  $svc;
+            proxy_set_header X-Path $api_path;
+            proxy_pass http://127.0.0.1:8080;
+        }
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/src/lib.rs
+++ b/plugins/builtin/security/map_unnamed_capture/src/lib.rs
@@ -19,15 +19,27 @@
 //! (`sr->variables = r->variables`), a non-volatile map is equally exposed
 //! whenever its **first** evaluation happens inside the clone.
 //!
-//! Both stock clone paths were tested. Under `slice` the main request proxies
-//! the first slice itself, so it evaluates and caches the map before any clone
-//! exists — non-volatile stays clean there. Under
-//! `proxy_cache_background_update`, the clone is created during cache open and
-//! the main request then answers from cache without ever evaluating
-//! `proxy_set_header`, leaving the background subrequest as the map's first
-//! evaluator — and a **non-volatile** map crashes the worker (verified on
-//! 1.29 and 1.31.2; see `non_volatile_map_via_background_update`). Gating on
-//! `volatile` would therefore miss the more mainstream of the two paths.
+//! Two stock callers pass `NGX_HTTP_SUBREQUEST_CLONE`:
+//! `ngx_http_slice_filter_module.c` and, via
+//! `ngx_http_upstream_cache_background_update()`, `proxy_cache_background_update
+//! on` + `proxy_cache_use_stale updating`. Under `slice` a non-volatile map
+//! happens to stay clean, but only because the main request proxies the first
+//! slice itself and so evaluates and caches the map before any clone exists —
+//! a property of that path, not of non-volatile maps. Under
+//! `proxy_cache_background_update` the clone is created during
+//! `ngx_http_file_cache_open()`, *before* `create_request`, and the main
+//! request then answers straight from cache without ever evaluating
+//! `proxy_set_header` — leaving the background subrequest as the map's first
+//! evaluator, with `realloc_captures` already set.
+//!
+//! A **non-volatile** map has been observed crashing a worker through that
+//! background-update path (nginx 1.29, x86_64). It is not covered by a
+//! container test: whether the stale read faults there depends on what the
+//! uninitialized memory holds, and the outcome flips on unrelated config
+//! details — a test asserting it passes or fails by luck. The rule's scope
+//! rests on the structural facts above, which the tested `slice` path
+//! demonstrates end-to-end. Gating on `volatile` would miss the more
+//! mainstream of the two clone paths.
 //!
 //! The vendor mitigation is to use named captures instead of unnamed ones:
 //! named captures resolve through a separate code path that never touches the
@@ -100,6 +112,20 @@ impl Plugin for MapUnnamedCapturePlugin {
 
         for ctx in config.all_directives_with_context() {
             if !ctx.directive.is("map") {
+                continue;
+            }
+
+            // `stream` cannot reach this bug: it has no subrequests, and
+            // `ngx_stream_regex_exec()` allocates `s->captures` only
+            // `if (s->captures == NULL)` — there is no `realloc_captures`
+            // equivalent, so the array is never reallocated and the count is
+            // never left stale.
+            //
+            // Tested as `!is_inside("stream")` rather than `is_inside("http")`
+            // on purpose: a snippet `include`d into `http` does not have the
+            // `http` block in its own parse tree, and missing a real
+            // vulnerability is worse than reporting one in a stray fragment.
+            if ctx.is_inside("stream") {
                 continue;
             }
 
@@ -177,10 +203,12 @@ fn non_capturing_fixes(entry: &Directive, pattern: &str, positions: &[usize]) ->
         return None;
     }
 
-    // `positions` are byte offsets into `pattern`, which sits `~` / `~*` bytes
-    // into the key token.
-    let modifier_len = entry.name.len() - pattern.len();
-    let pattern_start = entry.name_span.start.offset + modifier_len;
+    // `positions` index into `pattern`, which is a slice of `entry.name` — the
+    // *decoded* key. Rewriting bytes needs source offsets, and `name_span`
+    // covers the raw token, so the two only line up once the quoting is
+    // accounted for.
+    let key_start = entry.name_span.start.offset + key_quote_len(entry)?;
+    let pattern_start = key_start + (entry.name.len() - pattern.len());
 
     Some(
         positions
@@ -191,6 +219,33 @@ fn non_capturing_fixes(entry: &Directive, pattern: &str, positions: &[usize]) ->
             })
             .collect(),
     )
+}
+
+/// Width of the opening quote on this entry's key, or `None` when offsets into
+/// the decoded key cannot be mapped back onto the source.
+///
+/// The parser hands back `name` decoded but `name_span` covering the raw token,
+/// so the gap between them is what the quoting occupies:
+///
+/// - `0` — a bare token such as `~^/old/(.*)$`; offsets already line up.
+/// - `2` — a plain `"..."` / `'...'` with nothing else decoded away, so the
+///   opening quote is one byte and the rest of the key maps over one-to-one.
+///
+/// Any other gap means the parser also unescaped something inside the key, and
+/// positions in the decoded string no longer correspond linearly to source
+/// bytes — in that case there is no fix, only the warning. Rewriting on a
+/// mis-mapped offset would silently corrupt the config: a key like
+/// `"~^/a{2,3}/(x|y)$"` (quoted because nginx requires it for `{n,m}`) would
+/// get its `/` rewritten instead of its `(`, leaving unbalanced parens that
+/// nginx refuses to load.
+fn key_quote_len(entry: &Directive) -> Option<usize> {
+    let raw_len = entry.name_span.end.offset - entry.name_span.start.offset;
+
+    match raw_len.checked_sub(entry.name.len())? {
+        0 => Some(0),
+        2 => Some(1),
+        _ => None,
+    }
 }
 
 /// Whether the text reads a positional capture — `$1`..`$9` or `${1}`.
@@ -363,8 +418,29 @@ http {
         );
     }
 
+    /// `stream` has no subrequests, and `ngx_stream_regex_exec()` allocates
+    /// `s->captures` only when it is null — it never reallocates, so the stale
+    /// count this CVE depends on cannot arise. Reporting here would be a pure
+    /// false positive.
     #[test]
-    fn test_map_in_stream() {
+    fn test_map_in_stream_is_ignored() {
+        runner().assert_no_errors(
+            r#"
+stream {
+    map $ssl_preread_server_name $backend {
+        default default_backend;
+        ~^(.+)\.example\.com$ $1_backend;
+    }
+}
+"#,
+        );
+    }
+
+    /// A map inside `http` is still reported when a `stream` block sits
+    /// alongside it — the skip must key off the map's own context, not the
+    /// presence of `stream` anywhere in the file.
+    #[test]
+    fn test_http_map_is_reported_alongside_a_stream_block() {
         runner().assert_has_errors(
             r#"
 stream {
@@ -372,6 +448,26 @@ stream {
         default default_backend;
         ~^(.+)\.example\.com$ $1_backend;
     }
+}
+http {
+    map $uri $target {
+        default /;
+        ~^/old/(.*)$ /new/$1;
+    }
+}
+"#,
+        );
+    }
+
+    /// A bare `map` with no visible `http` parent — the shape of an
+    /// `include`d snippet — must still be reported.
+    #[test]
+    fn test_map_without_visible_http_parent_is_reported() {
+        runner().assert_has_errors(
+            r#"
+map $uri $target {
+    default /;
+    ~^/old/(.*)$ /new/$1;
 }
 "#,
         );
@@ -572,6 +668,76 @@ http {
             "expected only the unnamed group to change, got:\n{fixed}"
         );
         runner().assert_no_errors(&fixed);
+    }
+
+    /// Regression: nginx requires quoting for keys containing `{n,m}`, and the
+    /// parser decodes `name` while `name_span` still covers the quotes. Getting
+    /// this wrong rewrote the `/` instead of the `(`, emitting a config with
+    /// unbalanced parens that nginx refuses to load.
+    #[test]
+    fn test_quoted_key_is_fixed_at_the_right_offset() {
+        let source = r#"
+http {
+    map $uri $flag {
+        default 0;
+        "~^/a{2,3}/(x|y)$" 1;
+    }
+}
+"#;
+        let errors = runner().check_string(source).unwrap();
+        let fixed = apply_fixes(source, &errors);
+
+        assert!(
+            fixed.contains(r#""~^/a{2,3}/(?:x|y)$" 1;"#),
+            "quoted key must be rewritten at the right offset, got:\n{fixed}"
+        );
+        runner().assert_no_errors(&fixed);
+    }
+
+    #[test]
+    fn test_single_quoted_key_is_fixed_at_the_right_offset() {
+        let source = "
+http {
+    map $uri $flag {
+        default 0;
+        '~^/a{2,3}/(x|y)$' 1;
+    }
+}
+";
+        let errors = runner().check_string(source).unwrap();
+        let fixed = apply_fixes(source, &errors);
+
+        assert!(
+            fixed.contains("'~^/a{2,3}/(?:x|y)$' 1;"),
+            "single-quoted key must be rewritten at the right offset, got:\n{fixed}"
+        );
+        runner().assert_no_errors(&fixed);
+    }
+
+    /// An escape inside the key means the decoded `name` is shorter than the
+    /// source by an amount that is not just the quotes, so positions no longer
+    /// map linearly. Report, but do not risk a corrupting rewrite.
+    #[test]
+    fn test_key_with_escapes_is_reported_without_a_fix() {
+        let errors = runner()
+            .check_string(
+                r#"
+http {
+    map $uri $flag {
+        default 0;
+        "~^/a\"b/(x|y)$" 1;
+    }
+}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].fixes.is_empty(),
+            "a key with escapes must not be autofixed, got: {:?}",
+            errors[0].fixes
+        );
     }
 
     #[test]

--- a/plugins/builtin/security/map_unnamed_capture/src/lib.rs
+++ b/plugins/builtin/security/map_unnamed_capture/src/lib.rs
@@ -1,0 +1,589 @@
+//! map-unnamed-capture plugin (nginx CVE-2026-42533)
+//!
+//! This plugin warns when a regex entry in a `map` block uses an unnamed
+//! capture group `(...)`. A capturing `map` regex makes nginx reallocate its
+//! shared capture array (`r->captures`); when that regex runs inside a cloned
+//! subrequest (`NGX_HTTP_SUBREQUEST_CLONE`) and does not match, nginx — before
+//! the fix — leaves the capture count (`r->ncaptures`) stale. A later read of
+//! an unnamed positional capture (`$1`..`$9`) then indexes into the
+//! uninitialized reallocated array, causing an out-of-bounds read that can
+//! crash the worker (potential RCE on affected builds).
+//!
+//! # Why this is not gated on `volatile`
+//!
+//! An earlier version of this rule only flagged `volatile` maps, on the theory
+//! that a cached map never re-runs inside the subrequest. That is wrong.
+//! `volatile` *guarantees* the regex re-runs there, but the real precondition
+//! is only that the regex executes while `realloc_captures` is set. Because
+//! `ngx_http_subrequest()` shares the variable cache rather than copying it
+//! (`sr->variables = r->variables`), a non-volatile map is equally exposed
+//! whenever its **first** evaluation happens inside the clone.
+//!
+//! Both stock clone paths were tested. Under `slice` the main request proxies
+//! the first slice itself, so it evaluates and caches the map before any clone
+//! exists — non-volatile stays clean there. Under
+//! `proxy_cache_background_update`, the clone is created during cache open and
+//! the main request then answers from cache without ever evaluating
+//! `proxy_set_header`, leaving the background subrequest as the map's first
+//! evaluator — and a **non-volatile** map crashes the worker (verified on
+//! 1.29 and 1.31.2; see `non_volatile_map_via_background_update`). Gating on
+//! `volatile` would therefore miss the more mainstream of the two paths.
+//!
+//! The vendor mitigation is to use named captures instead of unnamed ones:
+//! named captures resolve through a separate code path that never touches the
+//! stale-`ncaptures` read. Fixed upstream in nginx 1.30.4 / 1.31.3 (commit
+//! `0cca8e055a2d`, which resets `r->ncaptures = 0` at the realloc site).
+//!
+//! Build with:
+//! ```sh
+//! cargo build --target wasm32-unknown-unknown --release
+//! ```
+
+use nginx_lint_plugin::helpers::find_unnamed_capture_positions;
+use nginx_lint_plugin::prelude::*;
+
+/// Check that map regex entries use named captures instead of `(...)`
+#[derive(Default)]
+pub struct MapUnnamedCapturePlugin;
+
+impl Plugin for MapUnnamedCapturePlugin {
+    fn spec(&self) -> PluginSpec {
+        PluginSpec::new(
+            "map-unnamed-capture",
+            "security",
+            "Warns when a map regex entry uses an unnamed capture group (CVE-2026-42533)",
+        )
+        .with_severity("warning")
+        .with_why(
+            "A capture group in a `map` regex makes nginx reallocate its shared capture array. On \
+             builds before nginx 1.30.4 / 1.31.3 (CVE-2026-42533), when that regex runs inside a \
+             cloned subrequest (`slice`, or the background subrequest of \
+             `proxy_cache_background_update`) and does not match, the capture count is left stale; \
+             a later read of an unnamed positional capture (`$1`..`$9`) then reads uninitialized \
+             memory, causing an out-of-bounds read that can crash the worker or be leveraged for \
+             remote code execution. This applies whether or not the map is `volatile` — the \
+             variable cache is shared with subrequests, so a cached map is also exposed when its \
+             first evaluation lands inside the clone. The fix is config-wide, not map-only: naming \
+             the map's capture alone does NOT remove the crash, because a named group still \
+             reallocates the array — every `location`/`if`/`rewrite` on the request path must stop \
+             reading unnamed `$1`..`$9` too. So replace `(...)` with a named capture \
+             `(?<name>...)` in the map AND reference captures by name (`$name`) in the blocks that \
+             consume them; named captures resolve through a separate path that never touches the \
+             stale-count read. Use a non-capturing group `(?:...)` when the group is only for \
+             grouping — this is the right fix for alternations like `~*(bot|crawler)`, which do \
+             not need a capture at all.",
+        )
+        .with_bad_example(include_str!("../examples/bad.conf").trim())
+        .with_good_example(include_str!("../examples/good.conf").trim())
+        .with_references(vec![
+            "https://nginx.org/en/docs/http/ngx_http_map_module.html".to_string(),
+            "https://github.com/nginx/nginx/commit/0cca8e055a2d909f1a00c2071665b502ec2fe94c"
+                .to_string(),
+        ])
+        .with_min_version("0.9.6")
+        // Inclusive upper bound. The fix shipped on two branches — stable
+        // 1.30.4 and mainline 1.31.3 — so the affected set is
+        // `[0.9.6, 1.30.3]` plus mainline `[1.31.0, 1.31.2]`, which a single
+        // min..max interval cannot express exactly. We take `1.31.2` (the last
+        // affected mainline release) rather than the stable fix point `1.30.3`:
+        // for a security rule a false negative (staying silent on an affected
+        // build) is worse than a false positive, and `1.31.2` keeps every
+        // affected version in range. The only imprecision is that a
+        // `target_nginx_version` on a fixed stable release (1.30.4..=1.31.2)
+        // still gets the warning — harmless over-reporting.
+        .with_max_version("1.31.2")
+    }
+
+    fn check(&self, config: &Config, _path: &str) -> Vec<LintError> {
+        let mut errors = Vec::new();
+        let err = self.spec().error_builder();
+
+        for ctx in config.all_directives_with_context() {
+            if !ctx.directive.is("map") {
+                continue;
+            }
+
+            let Some(block) = ctx.directive.block.as_ref() else {
+                continue;
+            };
+
+            // Deliberately NOT gated on `volatile`. `volatile` guarantees the
+            // regex re-runs inside the clone, but it is not required: the
+            // variable cache is shared with subrequests
+            // (`sr->variables = r->variables`), so a cached map is also
+            // vulnerable whenever its *first* evaluation lands inside the
+            // clone. Verified — see `non_volatile_map_via_background_update`
+            // in the container tests.
+            for entry in block.directives() {
+                let Some(pattern) = map_regex_pattern(&entry.name) else {
+                    continue;
+                };
+
+                let positions = find_unnamed_capture_positions(pattern);
+                if positions.is_empty() {
+                    continue;
+                }
+
+                let mut error = err.warning_at(
+                    "map regex uses an unnamed capture group (CVE-2026-42533); use `(?:...)` if \
+                     the group only needs to group, otherwise use a named capture `(?<name>...)` \
+                     here and read it by name (`$name`) in the blocks that consume it — naming it \
+                     here alone is not enough",
+                    entry,
+                );
+
+                if let Some(fixes) = non_capturing_fixes(entry, pattern, &positions) {
+                    error = error.with_fixes(fixes);
+                }
+
+                errors.push(error);
+            }
+        }
+
+        errors
+    }
+}
+
+/// Fixes turning every unnamed group in this entry's regex into `(?:...)`, or
+/// `None` when rewriting them would change what the entry means.
+///
+/// This is the one remediation that can be applied mechanically. Naming a
+/// capture cannot be: the value has to be rewritten to `$name`, and so does
+/// every `location`/`if`/`rewrite` that reads the capture — which block that is
+/// depends on which regex ran first at request time, may live in another
+/// `include`d file, and needs a variable name that is guaranteed not to
+/// collide. None of that is decidable here.
+///
+/// Going non-capturing is also the *stronger* fix. `ngx_http_regex_exec()`
+/// reallocates only `if (re->ncaptures)`, and PCRE counts named groups too — so
+/// a named capture still reallocates and only makes its own read safe, whereas
+/// dropping to `(?:...)` means the array is never reallocated for this regex at
+/// all.
+///
+/// Only safe when the entry's value does not read a positional capture: the
+/// group is then pure grouping (`~*(bot|crawler) 1;`), and `(?:...)` is the
+/// better idiom regardless of the CVE. If the value reads `$1`, rewriting is
+/// refused and the warning is reported without a fix.
+///
+/// Caveat: nginx also lets a *later* directive read `$1` left behind by a
+/// matching map regex. That aliasing is exactly the footgun this CVE is about
+/// and cannot be detected from the map block, so it is not accounted for here.
+fn non_capturing_fixes(entry: &Directive, pattern: &str, positions: &[usize]) -> Option<Vec<Fix>> {
+    if entry
+        .args
+        .iter()
+        .any(|arg| reads_positional_capture(&arg.raw))
+    {
+        return None;
+    }
+
+    // `positions` are byte offsets into `pattern`, which sits `~` / `~*` bytes
+    // into the key token.
+    let modifier_len = entry.name.len() - pattern.len();
+    let pattern_start = entry.name_span.start.offset + modifier_len;
+
+    Some(
+        positions
+            .iter()
+            .map(|&pos| {
+                let paren = pattern_start + pos;
+                Fix::replace_range(paren, paren + 1, "(?:")
+            })
+            .collect(),
+    )
+}
+
+/// Whether the text reads a positional capture — `$1`..`$9` or `${1}`.
+///
+/// Deliberately blunt: anything that looks like a positional reference counts,
+/// so an odd spelling suppresses the autofix rather than risking a rewrite that
+/// changes behaviour.
+fn reads_positional_capture(raw: &str) -> bool {
+    let bytes = raw.as_bytes();
+
+    for (i, _) in bytes.iter().enumerate().filter(|&(_, &b)| b == b'$') {
+        match bytes.get(i + 1) {
+            Some(b) if b.is_ascii_digit() => return true,
+            Some(b'{') => {
+                let mut end = i + 2;
+                while bytes.get(end).is_some_and(|b| b.is_ascii_digit()) {
+                    end += 1;
+                }
+                if end > i + 2 && bytes.get(end) == Some(&b'}') {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+/// Strip the `~` / `~*` match modifier off a map entry key.
+///
+/// Returns `None` for literal keys (`/old`), for `hostnames` / `volatile` /
+/// `default`, and for a bare `~` with no pattern behind it.
+fn map_regex_pattern(key: &str) -> Option<&str> {
+    let rest = key.strip_prefix('~')?;
+    let pattern = rest.strip_prefix('*').unwrap_or(rest);
+    (!pattern.is_empty()).then_some(pattern)
+}
+
+nginx_lint_plugin::export_component_plugin!(MapUnnamedCapturePlugin);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nginx_lint_plugin::testing::PluginTestRunner;
+
+    fn runner() -> PluginTestRunner<MapUnnamedCapturePlugin> {
+        PluginTestRunner::new(MapUnnamedCapturePlugin)
+    }
+
+    #[test]
+    fn test_unnamed_capture_is_reported() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $uri $target {
+        default /;
+        ~^/old/(.*)$ /new/$1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_unnamed_capture_reported_even_when_value_ignores_it() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $uri $is_old {
+        default 0;
+        ~^/old/(.*)$ 1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_named_capture_is_ok() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $uri $target {
+        default /;
+        ~^/old/(?<rest>.*)$ /new/$rest;
+        ~^/x/(?'seg'.*)$ /y/$seg;
+        ~^/p/(?P<seg2>.*)$ /q/$seg2;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_non_capturing_and_lookaround_are_ok() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/a/(?:foo|bar)$ 1;
+        ~^/b/(?=foo) 1;
+        ~^/c/(?!foo) 1;
+        ~^/d/(?<=foo)bar 1;
+        ~^/e/(?<!foo)bar 1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_literal_and_special_keys_are_ok() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $http_host $name {
+        hostnames;
+        default 0;
+        example.com 1;
+        *.example.com 1;
+        /path/(not-a-regex) 2;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_escaped_and_bracketed_parens_are_ok() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/esc/\(literal\)$ 1;
+        ~^/cls/[()]$ 2;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_case_insensitive_map_regex() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $uri $target {
+        default /;
+        ~*^/OLD/(.*)$ /new/$1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_mixed_named_and_unnamed_is_reported() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $uri $target {
+        default /;
+        ~^/(?<head>[a-z]+)/(.*)$ /$head/$2;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_map_in_stream() {
+        runner().assert_has_errors(
+            r#"
+stream {
+    map $ssl_preread_server_name $backend {
+        default default_backend;
+        ~^(.+)\.example\.com$ $1_backend;
+    }
+}
+"#,
+        );
+    }
+
+    /// `volatile` is not a precondition for the bug, so it must not gate the
+    /// rule: a cached map is exploitable too when its first evaluation lands
+    /// inside a clone subrequest (verified by the
+    /// `non_volatile_map_via_background_update` container test, which crashes a
+    /// worker with exactly this shape of map).
+    ///
+    /// This alternation also shows why the resulting report is not mere noise:
+    /// `(bot|crawler)` never needed to capture, and `(?:bot|crawler)` is the
+    /// better idiom regardless of the CVE.
+    #[test]
+    fn test_non_volatile_map_is_also_reported() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $http_user_agent $is_bot {
+        default 0;
+        ~*(bot|crawler) 1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_volatile_map_is_reported() {
+        runner().assert_has_errors(
+            r#"
+http {
+    map $uri $target {
+        volatile;
+        default /;
+        ~^/old/(.*)$ /new/$1;
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_capture_outside_map_is_ignored() {
+        runner().assert_no_errors(
+            r#"
+http {
+    server {
+        location ~ ^/api/(.*)$ {
+            rewrite ^/api/(.*)$ /$1 break;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_reports_each_offending_entry() {
+        let errors = runner()
+            .check_string(
+                r#"
+http {
+    map $uri $a {
+        default /;
+        ~^/one/(.*)$ /1/$1;
+        ~^/two/(?<r>.*)$ /2/$r;
+        ~^/three/(.*)$ /3/$1;
+    }
+}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(errors.len(), 2, "Expected 2 errors, got: {:?}", errors);
+    }
+
+    /// Apply every range-based fix to the source, right-to-left so earlier
+    /// offsets stay valid.
+    fn apply_fixes(source: &str, errors: &[LintError]) -> String {
+        let mut fixes: Vec<_> = errors.iter().flat_map(|e| e.fixes.iter()).collect();
+        fixes.sort_by_key(|f| std::cmp::Reverse(f.start_offset.unwrap()));
+
+        let mut out = source.to_string();
+        for fix in fixes {
+            out.replace_range(
+                fix.start_offset.unwrap()..fix.end_offset.unwrap(),
+                &fix.new_text,
+            );
+        }
+        out
+    }
+
+    #[test]
+    fn test_grouping_only_entry_is_fixed_to_non_capturing() {
+        let source = r#"
+http {
+    map $http_user_agent $is_bot {
+        default 0;
+        ~*(bot|crawler) 1;
+    }
+}
+"#;
+        let errors = runner().check_string(source).unwrap();
+        let fixed = apply_fixes(source, &errors);
+
+        assert!(
+            fixed.contains("~*(?:bot|crawler) 1;"),
+            "expected the group to become non-capturing, got:\n{fixed}"
+        );
+        // The fix must fully resolve the finding, not just move it.
+        runner().assert_no_errors(&fixed);
+    }
+
+    #[test]
+    fn test_multiple_groups_in_one_entry_are_all_fixed() {
+        let source = r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/(a|b)/(c|d)$ 1;
+    }
+}
+"#;
+        let errors = runner().check_string(source).unwrap();
+        let fixed = apply_fixes(source, &errors);
+
+        assert!(
+            fixed.contains("~^/(?:a|b)/(?:c|d)$ 1;"),
+            "expected both groups to become non-capturing, got:\n{fixed}"
+        );
+        runner().assert_no_errors(&fixed);
+    }
+
+    /// The value reads `$1`, so going non-capturing would break the map.
+    /// Report, but offer no fix.
+    #[test]
+    fn test_entry_whose_value_reads_capture_is_not_fixed() {
+        let errors = runner()
+            .check_string(
+                r#"
+http {
+    map $uri $target {
+        default /;
+        ~^/old/(.*)$ /new/$1;
+    }
+}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].fixes.is_empty(),
+            "must not autofix an entry whose value reads $1, got: {:?}",
+            errors[0].fixes
+        );
+    }
+
+    /// `${1}` is the same reference in braced form.
+    #[test]
+    fn test_braced_capture_reference_blocks_the_fix() {
+        let errors = runner()
+            .check_string(
+                r#"
+http {
+    map $host $backend {
+        default default_backend;
+        ~^(.+)\.example\.com$ ${1}_backend;
+    }
+}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].fixes.is_empty(), "`${{1}}` must block the fix");
+    }
+
+    /// A named group in the same entry is left alone — only the unnamed one is
+    /// rewritten, and `$name` keeps resolving because PCRE still numbers it.
+    #[test]
+    fn test_named_group_is_preserved_while_unnamed_is_fixed() {
+        let source = r#"
+http {
+    map $uri $target {
+        default /;
+        ~^/(?<head>[a-z]+)/(x|y)$ /$head/;
+    }
+}
+"#;
+        let errors = runner().check_string(source).unwrap();
+        let fixed = apply_fixes(source, &errors);
+
+        assert!(
+            fixed.contains("~^/(?<head>[a-z]+)/(?:x|y)$ /$head/;"),
+            "expected only the unnamed group to change, got:\n{fixed}"
+        );
+        runner().assert_no_errors(&fixed);
+    }
+
+    #[test]
+    fn test_examples() {
+        runner().test_examples(
+            include_str!("../examples/bad.conf"),
+            include_str!("../examples/good.conf"),
+        );
+    }
+
+    #[test]
+    fn test_fixtures() {
+        runner().test_fixtures(nginx_lint_plugin::fixtures_dir!());
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/src/lib.rs
+++ b/plugins/builtin/security/map_unnamed_capture/src/lib.rs
@@ -22,12 +22,14 @@
 //! Two stock callers pass `NGX_HTTP_SUBREQUEST_CLONE`:
 //! `ngx_http_slice_filter_module.c` and, via
 //! `ngx_http_upstream_cache_background_update()`, `proxy_cache_background_update
-//! on` + `proxy_cache_use_stale updating`. Under `slice` a non-volatile map
-//! happens to stay clean, but only because the main request proxies the first
-//! slice itself and so evaluates and caches the map before any clone exists —
-//! a property of that path, not of non-volatile maps. Under
-//! `proxy_cache_background_update` the clone is created during
-//! `ngx_http_file_cache_open()`, *before* `create_request`, and the main
+//! on` (reached via `proxy_cache_use_stale updating`, or equally via
+//! `stale-while-revalidate` from the upstream's own `Cache-Control`). Under
+//! `slice` a non-volatile map happens to stay clean, but only because the main
+//! request proxies the first slice itself and so evaluates and caches the map
+//! before any clone exists — a property of that path, not of non-volatile
+//! maps. Under `proxy_cache_background_update` the clone is created when
+//! `ngx_http_upstream_cache()` sees `ngx_http_file_cache_open()` return
+//! `NGX_HTTP_CACHE_STALE`, which is *before* `create_request`; the main
 //! request then answers straight from cache without ever evaluating
 //! `proxy_set_header` — leaving the background subrequest as the map's first
 //! evaluator, with `realloc_captures` already set.
@@ -84,10 +86,14 @@ impl Plugin for MapUnnamedCapturePlugin {
              stale-count read. Better still, use a non-capturing group `(?:...)` when the group is \
              only for grouping (as in `~*(bot|crawler)`): with no capture left the regex stops \
              reallocating at all, which is the one remediation that needs no change outside the \
-             map. Scope note: this rule reports only unnamed captures, so a map whose captures are \
-             already named is not reported even though it still arms the bug — that combination \
-             (named map, unnamed `$1` read elsewhere) is a known blind spot, traded away to keep \
-             the rule quiet on configs that follow the vendor's advice.",
+             map. Scope warning: this rule reports only UNNAMED captures, so a map whose captures \
+             are already named is never reported — even though it still reallocates and so still \
+             arms the bug for any unnamed `$1`..`$9` read elsewhere on the request path. That is \
+             not a rounding error: on a config with a named map capture and an unnamed `$1` \
+             consumer, nginx 1.29 fails 100% of requests while this rule reports nothing at all \
+             (measured). Silence from this rule therefore does not mean the config is safe; it \
+             means no map regex has an unnamed capture. Detecting the rest needs the `$1`..`$9` \
+             readers checked too, which this rule does not do.",
         )
         .with_bad_example(include_str!("../examples/bad.conf").trim())
         .with_good_example(include_str!("../examples/good.conf").trim())
@@ -260,6 +266,14 @@ fn non_capturing_fixes(entry: &Directive, pattern: &str, positions: &[usize]) ->
 /// `"~^/a{2,3}/(x|y)$"` (quoted because nginx requires it for `{n,m}`) would
 /// get its `/` rewritten instead of its `(`, leaving unbalanced parens that
 /// nginx refuses to load.
+///
+/// The `2` case leans on a quirk of *this* parser: nginx's own
+/// `ngx_conf_read_token` decodes `\\`, `\"`, `\'`, `\t`, `\r`, `\n` in
+/// unquoted tokens as well, and if nginx-lint's parser ever did the same, two
+/// such escapes in a bare key would also give a gap of 2 and shift every fix
+/// by a byte. It does not decode them today (checked), so a gap of 2 means
+/// quotes and nothing else. If that ever changes, this must become an explicit
+/// "is the first byte a quote" test against the source text.
 fn key_quote_len(entry: &Directive) -> Option<usize> {
     let raw_len = entry.name_span.end.offset - entry.name_span.start.offset;
 
@@ -284,8 +298,9 @@ fn references_group_by_number(pattern: &str) -> bool {
     for (i, &b) in bytes.iter().enumerate() {
         let next = bytes.get(i + 1).copied();
         match b {
-            // `\1`, `\g...`. Any other escape is skipped by the `\\` arm below
-            // only when it is the escape itself, so check before that.
+            // `\1`, `\g...`. Every byte is inspected, escape pairs included —
+            // no skipping. That over-matches (a literal `\\1` trips the second
+            // `\`), but over-blocking only costs a fix, so it stays blunt.
             b'\\' => match next {
                 Some(c) if c.is_ascii_digit() => return true,
                 Some(b'g') | Some(b'k') => return true,
@@ -304,7 +319,13 @@ fn references_group_by_number(pattern: &str) -> bool {
     false
 }
 
-/// Whether the text reads a positional capture — `$1`..`$9` or `${1}`.
+/// Whether the text reads a positional capture — `$1`..`$9`.
+///
+/// `${1}` is also matched, but only out of bluntness: it is NOT a braced
+/// positional reference. `ngx_http_script_compile()` tests the digit before the
+/// brace, so `${1}` takes the variable path and becomes a variable *named* "1",
+/// which nginx rejects at load with `unknown "1" variable`. Blocking the fix
+/// there costs nothing — the config never ran.
 ///
 /// Deliberately blunt: anything that looks like a positional reference counts,
 /// so an odd spelling suppresses the autofix rather than risking a rewrite that
@@ -683,9 +704,14 @@ http {
         );
     }
 
-    /// `${1}` is the same reference in braced form.
+    /// `${1}` is NOT a braced positional reference — nginx reads it as a
+    /// variable named "1" and refuses to load (`unknown "1" variable`),
+    /// verified on 1.29. The fix is blocked anyway because
+    /// [`reads_positional_capture`] is deliberately blunt, which is free: the
+    /// config could never have run. Pinned so nobody "simplifies" the check on
+    /// the false premise that `${1}` means `$1`.
     #[test]
-    fn test_braced_capture_reference_blocks_the_fix() {
+    fn test_braced_variable_named_1_blocks_the_fix() {
         let errors = runner()
             .check_string(
                 r#"
@@ -863,6 +889,27 @@ http {
         ~^/q/\Q(a)\E$ 1;
         ~^/c/[]()]$ 2;
         ~^/p/[[:alpha:]()]$ 3;
+    }
+}
+"#,
+        );
+    }
+
+    /// Known miss, pinned so it is not mistaken for correct behaviour.
+    ///
+    /// nginx honours a quote only at the start of a token
+    /// (`ngx_conf_read_token` checks `last_space`), so `~^/"a"/(x|y)$` is one
+    /// key with a literal `"` in it and loads fine. nginx-lint's parser splits
+    /// the token at the quote instead, so the plugin never sees the capture and
+    /// stays silent. The fix belongs in the parser, not here.
+    #[test]
+    fn test_key_with_embedded_quote_is_missed() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/"a"/(x|y)$ 1;
     }
 }
 "#,

--- a/plugins/builtin/security/map_unnamed_capture/src/lib.rs
+++ b/plugins/builtin/security/map_unnamed_capture/src/lib.rs
@@ -81,9 +81,13 @@ impl Plugin for MapUnnamedCapturePlugin {
              reading unnamed `$1`..`$9` too. So replace `(...)` with a named capture \
              `(?<name>...)` in the map AND reference captures by name (`$name`) in the blocks that \
              consume them; named captures resolve through a separate path that never touches the \
-             stale-count read. Use a non-capturing group `(?:...)` when the group is only for \
-             grouping — this is the right fix for alternations like `~*(bot|crawler)`, which do \
-             not need a capture at all.",
+             stale-count read. Better still, use a non-capturing group `(?:...)` when the group is \
+             only for grouping (as in `~*(bot|crawler)`): with no capture left the regex stops \
+             reallocating at all, which is the one remediation that needs no change outside the \
+             map. Scope note: this rule reports only unnamed captures, so a map whose captures are \
+             already named is not reported even though it still arms the bug — that combination \
+             (named map, unnamed `$1` read elsewhere) is a known blind spot, traded away to keep \
+             the rule quiet on configs that follow the vendor's advice.",
         )
         .with_bad_example(include_str!("../examples/bad.conf").trim())
         .with_good_example(include_str!("../examples/good.conf").trim())
@@ -92,10 +96,15 @@ impl Plugin for MapUnnamedCapturePlugin {
             "https://github.com/nginx/nginx/commit/0cca8e055a2d909f1a00c2071665b502ec2fe94c"
                 .to_string(),
         ])
-        .with_min_version("0.9.6")
+        // The vulnerability report says 0.9.6+, which is when `map` learned
+        // regex entries — but the bug also needs a cloned subrequest to exist,
+        // and `NGX_HTTP_SUBREQUEST_CLONE` arrived with the slice module in
+        // 1.9.8 (`CHANGES`: "Changes with nginx 1.9.8 ... Feature: the
+        // ngx_http_slice_module"). Nothing in `[0.9.6, 1.9.7]` can reach it.
+        .with_min_version("1.9.8")
         // Inclusive upper bound. The fix shipped on two branches — stable
         // 1.30.4 and mainline 1.31.3 — so the affected set is
-        // `[0.9.6, 1.30.3]` plus mainline `[1.31.0, 1.31.2]`, which a single
+        // `[1.9.8, 1.30.3]` plus mainline `[1.31.0, 1.31.2]`, which a single
         // min..max interval cannot express exactly. We take `1.31.2` (the last
         // affected mainline release) rather than the stable fix point `1.30.3`:
         // for a security rule a false negative (staying silent on an affected
@@ -138,8 +147,7 @@ impl Plugin for MapUnnamedCapturePlugin {
             // variable cache is shared with subrequests
             // (`sr->variables = r->variables`), so a cached map is also
             // vulnerable whenever its *first* evaluation lands inside the
-            // clone. Verified — see `non_volatile_map_via_background_update`
-            // in the container tests.
+            // clone. See the module docs for the evidence.
             for entry in block.directives() {
                 let Some(pattern) = map_regex_pattern(&entry.name) else {
                     continue;
@@ -180,16 +188,26 @@ impl Plugin for MapUnnamedCapturePlugin {
 /// `include`d file, and needs a variable name that is guaranteed not to
 /// collide. None of that is decidable here.
 ///
-/// Going non-capturing is also the *stronger* fix. `ngx_http_regex_exec()`
-/// reallocates only `if (re->ncaptures)`, and PCRE counts named groups too — so
-/// a named capture still reallocates and only makes its own read safe, whereas
-/// dropping to `(?:...)` means the array is never reallocated for this regex at
-/// all.
+/// Going non-capturing is also the *stronger* fix, when it removes the last
+/// capture. `ngx_http_regex_exec()` reallocates only `if (re->ncaptures)`, and
+/// PCRE counts named groups too — so a named capture still reallocates and only
+/// makes its own read safe. Dropping every unnamed group to `(?:...)` stops the
+/// realloc outright *if no named group remains*; if one does, the regex still
+/// reallocates and this only removes the unnamed reads.
 ///
-/// Only safe when the entry's value does not read a positional capture: the
-/// group is then pure grouping (`~*(bot|crawler) 1;`), and `(?:...)` is the
-/// better idiom regardless of the CVE. If the value reads `$1`, rewriting is
-/// refused and the warning is reported without a fix.
+/// Refused unless the whole entry is safe to rewrite:
+///
+/// - the **value** must not read a positional capture — otherwise `(?:...)`
+///   deletes the group it names (`~^/old/(.*)$ /new/$1;`);
+/// - the **pattern** must not reference a group by number either. A
+///   backreference outlives the group: `~^/(a|b)/\1$` rewrites to
+///   `~^/(?:a|b)/\1$`, whose `\1` now points at nothing, and nginx refuses to
+///   start with `pcre_compile() failed`. Same for `\g{1}`, recursion `(?1)`,
+///   and conditionals `(?(1)...)`.
+///
+/// What survives is pure grouping (`~*(bot|crawler) 1;`), where `(?:...)` is
+/// the better idiom regardless of the CVE. Anything else is reported without a
+/// fix.
 ///
 /// Caveat: nginx also lets a *later* directive read `$1` left behind by a
 /// matching map regex. That aliasing is exactly the footgun this CVE is about
@@ -200,6 +218,10 @@ fn non_capturing_fixes(entry: &Directive, pattern: &str, positions: &[usize]) ->
         .iter()
         .any(|arg| reads_positional_capture(&arg.raw))
     {
+        return None;
+    }
+
+    if references_group_by_number(pattern) {
         return None;
     }
 
@@ -246,6 +268,40 @@ fn key_quote_len(entry: &Directive) -> Option<usize> {
         2 => Some(1),
         _ => None,
     }
+}
+
+/// Whether the regex refers to one of its own groups by number, which makes
+/// dropping that group to `(?:...)` a breaking change rather than a no-op.
+///
+/// Covers backreferences (`\1`, `\g1`, `\g{1}`, `\g{-1}`), subroutine calls and
+/// recursion (`(?1)`, `(?+1)`, `(?R)`), and conditionals (`(?(1)...)`). Like
+/// [`reads_positional_capture`] this is deliberately blunt: anything resembling
+/// a numeric reference suppresses the autofix rather than risking a rewrite
+/// that nginx then refuses to load.
+fn references_group_by_number(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+
+    for (i, &b) in bytes.iter().enumerate() {
+        let next = bytes.get(i + 1).copied();
+        match b {
+            // `\1`, `\g...`. Any other escape is skipped by the `\\` arm below
+            // only when it is the escape itself, so check before that.
+            b'\\' => match next {
+                Some(c) if c.is_ascii_digit() => return true,
+                Some(b'g') | Some(b'k') => return true,
+                _ => {}
+            },
+            // `(?1)`, `(?+1)`, `(?-1)`, `(?R)`, `(?(1)...)`, `(?&name)`
+            b'(' if next == Some(b'?') => match bytes.get(i + 2).copied() {
+                Some(c) if c.is_ascii_digit() => return true,
+                Some(b'+') | Some(b'-') | Some(b'R') | Some(b'(') | Some(b'&') => return true,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    false
 }
 
 /// Whether the text reads a positional capture — `$1`..`$9` or `${1}`.
@@ -475,9 +531,8 @@ map $uri $target {
 
     /// `volatile` is not a precondition for the bug, so it must not gate the
     /// rule: a cached map is exploitable too when its first evaluation lands
-    /// inside a clone subrequest (verified by the
-    /// `non_volatile_map_via_background_update` container test, which crashes a
-    /// worker with exactly this shape of map).
+    /// inside a clone subrequest. See the module docs for why that is not
+    /// covered by a container test.
     ///
     /// This alternation also shows why the resulting report is not mere noise:
     /// `(bot|crawler)` never needed to capture, and `(?:bot|crawler)` is the
@@ -650,6 +705,13 @@ http {
 
     /// A named group in the same entry is left alone — only the unnamed one is
     /// rewritten, and `$name` keeps resolving because PCRE still numbers it.
+    ///
+    /// Note what this fix does NOT achieve. The surviving named group keeps
+    /// `re->ncaptures` non-zero, so the regex still reallocates and still arms
+    /// the bug for any unnamed `$1` read elsewhere on the request path. The
+    /// rule reports nothing afterwards because its predicate is "unnamed
+    /// capture in a map regex", not "this regex is now harmless" — the
+    /// `assert_no_errors` below pins the predicate, not safety.
     #[test]
     fn test_named_group_is_preserved_while_unnamed_is_fixed() {
         let source = r#"
@@ -737,6 +799,73 @@ http {
             errors[0].fixes.is_empty(),
             "a key with escapes must not be autofixed, got: {:?}",
             errors[0].fixes
+        );
+    }
+
+    /// Regression: `(?:...)` deletes the group a backreference points at, and
+    /// nginx then refuses to start (`pcre_compile() failed`). Verified against
+    /// nginx 1.29: `~^/(a|b)/\1$` loads, `~^/(?:a|b)/\1$` does not.
+    #[test]
+    fn test_backreference_in_pattern_blocks_the_fix() {
+        let errors = runner()
+            .check_string(
+                r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/(a|b)/\1$ 1;
+    }
+}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].fixes.is_empty(),
+            "a backreference must block the fix, got: {:?}",
+            errors[0].fixes
+        );
+    }
+
+    /// Same class as the backreference: these all name a group by number, so
+    /// removing the group breaks them.
+    #[test]
+    fn test_numeric_group_references_block_the_fix() {
+        for pattern in [
+            r"~^/(a|b)/\g{1}$",
+            r"~^/(a|b)(?1)$",
+            r"~^/(a)(?(1)x|y)$",
+            r"~^/(a|b)/\g1$",
+        ] {
+            let errors = runner()
+                .check_string(&format!(
+                    "http {{\n    map $uri $flag {{\n        default 0;\n        {pattern} 1;\n    }}\n}}\n"
+                ))
+                .unwrap();
+
+            assert!(
+                !errors.is_empty() && errors[0].fixes.is_empty(),
+                "{pattern} must be reported without a fix, got: {errors:?}"
+            );
+        }
+    }
+
+    /// The detector must not see regex syntax inside a `\Q...\E` literal span
+    /// or a character class whose first member is `]`.
+    #[test]
+    fn test_literal_parens_are_not_reported() {
+        runner().assert_no_errors(
+            r#"
+http {
+    map $uri $flag {
+        default 0;
+        ~^/q/\Q(a)\E$ 1;
+        ~^/c/[]()]$ 2;
+        ~^/p/[[:alpha:]()]$ 3;
+    }
+}
+"#,
         );
     }
 

--- a/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
+++ b/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
@@ -388,12 +388,20 @@ async fn unnamed_map_capture_breaks_the_slice_subrequest() {
 // The remediations neutralise it on the same affected build
 // ============================================================================
 //
-// Same image, no version gate beyond observability: these prove the fixes
-// actually work rather than merely compiling.
+// These only mean something on a build that actually has the bug — on a fixed
+// one the config would serve either way, so they would pass without proving
+// anything. Hence the `is_affected_build` skip.
 
 #[tokio::test]
 #[ignore]
 async fn named_captures_keep_the_subrequest_working() {
+    if !is_stock_nginx() {
+        eprintln!(
+            "SKIP named_captures_keep_the_subrequest_working: fix status not established for {}",
+            nginx_server_name()
+        );
+        return;
+    }
     if !has_slice_module().await {
         eprintln!("SKIP named_captures_keep_the_subrequest_working: image lacks http_slice_module");
         return;
@@ -403,6 +411,13 @@ async fn named_captures_keep_the_subrequest_working() {
         .health_path("/healthz")
         .start(safe_config().as_str())
         .await;
+
+    if !is_affected_build(&nginx).await {
+        eprintln!(
+            "SKIP named_captures_keep_the_subrequest_working: build is not affected, so there is nothing to neutralise"
+        );
+        return;
+    }
 
     seed_backend_file(&nginx).await;
     let seen = drive(&nginx, "/big.txt").await;
@@ -417,6 +432,13 @@ async fn named_captures_keep_the_subrequest_working() {
 #[tokio::test]
 #[ignore]
 async fn autofix_keeps_the_subrequest_working() {
+    if !is_stock_nginx() {
+        eprintln!(
+            "SKIP autofix_keeps_the_subrequest_working: fix status not established for {}",
+            nginx_server_name()
+        );
+        return;
+    }
     if !has_slice_module().await {
         eprintln!("SKIP autofix_keeps_the_subrequest_working: image lacks http_slice_module");
         return;
@@ -426,6 +448,13 @@ async fn autofix_keeps_the_subrequest_working() {
         .health_path("/healthz")
         .start(autofixed_config().as_str())
         .await;
+
+    if !is_affected_build(&nginx).await {
+        eprintln!(
+            "SKIP autofix_keeps_the_subrequest_working: build is not affected, so there is nothing to neutralise"
+        );
+        return;
+    }
 
     seed_backend_file(&nginx).await;
     let seen = drive(&nginx, "/big.txt").await;

--- a/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
+++ b/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
@@ -1,0 +1,648 @@
+//! Container-based integration tests for the map-unnamed-capture rule
+//! (nginx CVE-2026-42533, "stale regex captures").
+//!
+//! These tests prove the rule targets a *real* nginx bug by exercising the
+//! flagged pattern against a vulnerable nginx and observing the bug's
+//! signature — a deterministic worker SIGSEGV — directly from the master's
+//! error log.
+//!
+//! # The bug
+//!
+//! nginx keeps regex captures in a shared `r->captures` array sized by
+//! `r->ncaptures`. When a *capturing* `map` regex is (re-)evaluated inside a
+//! cloned subrequest and does NOT match, `ngx_http_regex_exec()` reallocates
+//! `r->captures` but — before the fix — leaves `r->ncaptures` at its previous
+//! value. A later regex that reads an unnamed positional capture (`$1`..`$9`)
+//! then indexes into the freshly-allocated, uninitialized array, reading
+//! garbage offsets → out-of-bounds read → worker crash (potential RCE on
+//! affected builds). Fixed upstream by commit `0cca8e055a2d` which adds
+//! `r->ncaptures = 0;` at the realloc site.
+//!
+//! # The exact trigger (all three are required)
+//!
+//! 1. A `map` with a **capturing** regex entry that **mismatches** at runtime
+//!    (`~mismatch(.*) 1;`). A capture group — named or unnamed — is what makes
+//!    nginx reallocate `r->captures`.
+//! 2. The map is **`volatile`**, so it is re-evaluated inside the subrequest
+//!    (a non-volatile map is evaluated and cached in the main request and
+//!    never re-runs in the subrequest, so it never reallocates there).
+//! 3. A **cloned** subrequest: among stock modules only `slice`
+//!    (`NGX_HTTP_SUBREQUEST_CLONE`) shares/reallocates the capture array, and
+//!    an **unnamed** `$1` is read while that stale `ncaptures` is live.
+//!
+//! # Why named captures are the fix (and the rule's remediation)
+//!
+//! Named captures (`(?<name>...)`) resolve through `r->variables`, a code
+//! path that never touches the `if (n < r->ncaptures)` uninitialized read.
+//! This matches the vendor mitigation: "do not use unnamed captures; use
+//! named captures instead and only use them in the same block with the regex
+//! match." The mitigation is config-wide, not map-only: naming *just* the
+//! map's capture while a consumer still reads an unnamed `$1` does not
+//! reliably remove the crash (it still reallocates the array, and the crash
+//! then depends on heap layout — observed still crashing on 1.31.2). The
+//! [`safe_config`] here applies the mitigation fully — named capture in the
+//! map *and* in the consuming `location` — which is clean on every affected
+//! build.
+//!
+//! # Version window
+//!
+//! The bug is fixed in **1.30.4** and **1.31.3** (verified by file content
+//! per release tag; backports are cherry-picks, so commit-ancestry checks
+//! mislead). With the padded request [`hammer`] sends, this self-contained
+//! repro crashes deterministically on **1.29.x, 1.30.0–1.30.3, and
+//! 1.31.0–1.31.2** (8/8 across runs); it is not observable on 1.27/1.28
+//! (pre-trigger). The crash tests gate on that observable window, detected
+//! from `nginx -v`.
+//!
+//! Run with (default image is intentionally a vulnerable one):
+//!   NGINX_IMAGE=nginx:1.29 cargo test -p map-unnamed-capture-plugin \
+//!       --test container_test -- --ignored
+
+use nginx_lint_plugin::container_testing::{NginxContainer, reqwest};
+
+/// Backend document root file the `slice`/`proxy_pass` upstream serves.
+/// 200 bytes so `slice 50;` produces several range subrequests.
+const BACKEND_FILE: &str = "/usr/share/nginx/html/big.txt";
+
+/// Vulnerable pattern: a `volatile` map whose regex entry uses an **unnamed**
+/// capture and mismatches, feeding a `slice` location that reads `$1`.
+/// This is exactly the shape the lint rule flags.
+fn vulnerable_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+error_log /tmp/nginx-err.log info;
+http {
+    map test $my_map {
+        volatile;
+        ~mismatch(.*)  1;
+        default        "";
+    }
+
+    server {
+        listen 8081;
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    server {
+        listen 80;
+
+        location = /healthz {
+            return 200 "ok";
+        }
+
+        location ~(.*) {
+            slice 50;
+            proxy_set_header Test  "[$my_map|$1]";
+            proxy_set_header Range $slice_range;
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+"#
+}
+
+/// The vendor mitigation applied fully: named captures in **both** the map
+/// (`(.*)` → `(?<x>.*)`) and the consuming `location` (`~(.*)` → `~(?<p>.*)`,
+/// read as `$p` instead of `$1`). Named captures resolve through a path that
+/// never touches the stale-`ncaptures` read, so the crash disappears on every
+/// affected build. (Naming only the map is not enough — see the module docs.)
+fn safe_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+error_log /tmp/nginx-err.log info;
+http {
+    map test $my_map {
+        volatile;
+        ~mismatch(?<x>.*)  1;
+        default            "";
+    }
+
+    server {
+        listen 8081;
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    server {
+        listen 80;
+
+        location = /healthz {
+            return 200 "ok";
+        }
+
+        location ~(?<p>.*) {
+            slice 50;
+            proxy_set_header Test  "[$my_map|$p]";
+            proxy_set_header Range $slice_range;
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+"#
+}
+
+/// The same unnamed-capture map and `$1`-reading `slice` location as
+/// [`vulnerable_config`], with **only** `volatile;` removed.
+///
+/// This stays clean, but note carefully *why* — it is a property of the `slice`
+/// path, not of non-volatile maps in general. Under `slice` the main request
+/// proxies the first slice itself, so it evaluates `$my_map` and caches it
+/// before any clone exists; the clones then read the cached value and never
+/// run the regex. Change the clone source to `proxy_cache_background_update`
+/// and the same non-volatile map *does* crash — see
+/// [`non_volatile_background_update_config`]. Do not read this test as
+/// "non-volatile is safe".
+fn non_volatile_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+error_log /tmp/nginx-err.log info;
+http {
+    map test $my_map {
+        ~mismatch(.*)  1;
+        default        "";
+    }
+
+    server {
+        listen 8081;
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    server {
+        listen 80;
+
+        location = /healthz {
+            return 200 "ok";
+        }
+
+        location ~(.*) {
+            slice 50;
+            proxy_set_header Test  "[$my_map|$1]";
+            proxy_set_header Range $slice_range;
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+"#
+}
+
+/// A **non-volatile** map with an unnamed capture, reached through the *other*
+/// stock `NGX_HTTP_SUBREQUEST_CLONE` caller: `proxy_cache_background_update`
+/// (`ngx_http_upstream.c:1157`, gated at `:941` by `proxy_cache_use_stale
+/// updating` + `proxy_cache_background_update on`).
+///
+/// The hypothesis this config tests: `volatile` is not actually required. What
+/// the bug needs is for the map's regex to *execute* while `realloc_captures`
+/// is set — i.e. inside the clone. `volatile` guarantees that by disabling
+/// caching, but a non-volatile map reaches it too if its **first** evaluation
+/// happens inside the clone, because `sr->variables = r->variables`
+/// (`ngx_http_core_module.c:2508`) makes the variable cache shared, not copied.
+///
+/// On a stale cache hit nginx creates the background clone during
+/// `ngx_http_file_cache_open()` — *before* `create_request` — and then answers
+/// the main request straight from cache, so the main request never evaluates
+/// `proxy_set_header`. That leaves the background subrequest as the first (and
+/// only) evaluator of `$my_map`, with `realloc_captures` already set.
+///
+/// (This is why the `slice` config above stays clean without `volatile`: there
+/// the main request proxies the first slice itself, so it evaluates and caches
+/// the map before any clone exists.)
+fn non_volatile_background_update_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+error_log /tmp/nginx-err.log info;
+http {
+    proxy_cache_path /tmp/cache levels=1:2 keys_zone=z:10m inactive=60m;
+
+    log_format probe '$request_uri test=[$http_test]';
+
+    map test $my_map {
+        ~mismatch(.*)  1;
+        default        "";
+    }
+
+    server {
+        listen 8081;
+        access_log /tmp/backend.log probe;
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    server {
+        listen 80;
+
+        location = /healthz {
+            return 200 "ok";
+        }
+
+        location ~(.*) {
+            proxy_cache                     z;
+            proxy_cache_valid               200 1s;
+            proxy_cache_use_stale           updating;
+            proxy_cache_background_update   on;
+            add_header X-Cache $upstream_cache_status always;
+            proxy_set_header Test  "[$my_map|$1]";
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+"#
+}
+
+/// Exactly what the rule's autofix produces from [`vulnerable_config`]: the
+/// map's `(.*)` becomes `(?:.*)`, and **nothing else changes** — the consuming
+/// `location ~(.*)` still reads an unnamed `$1`. (The map's value is `1`, which
+/// reads no positional capture, so the autofix applies here.)
+///
+/// This is the sharpest test of the fix's premise. Naming *only* the map is
+/// known NOT to be enough — a named group is still a capturing group, so
+/// `ngx_http_regex_exec()` still reallocates and the crash survives on 1.31.2.
+/// Going non-capturing instead makes `re->ncaptures` zero, so the realloc never
+/// happens for this regex at all, and the crash should disappear even with the
+/// unnamed `$1` consumer left untouched.
+fn autofixed_config() -> &'static str {
+    r#"events {
+    worker_connections 1024;
+}
+error_log /tmp/nginx-err.log info;
+http {
+    map test $my_map {
+        volatile;
+        ~mismatch(?:.*)  1;
+        default          "";
+    }
+
+    server {
+        listen 8081;
+        location / {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    server {
+        listen 80;
+
+        location = /healthz {
+            return 200 "ok";
+        }
+
+        location ~(.*) {
+            slice 50;
+            proxy_set_header Test  "[$my_map|$1]";
+            proxy_set_header Range $slice_range;
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+}
+"#
+}
+
+/// Parse `major.minor.patch` and the engine prefix out of `nginx -v` stderr,
+/// e.g. `"nginx version: nginx/1.29.8"` → `("nginx", (1, 29, 8))`.
+fn parse_nginx_version(stderr: &str) -> Option<(String, (u32, u32, u32))> {
+    let after = stderr.split('/').nth(1)?;
+    let ver = after.split_whitespace().next()?;
+    let engine = stderr
+        .split(':')
+        .nth(1)?
+        .trim()
+        .split('/')
+        .next()?
+        .to_string();
+    let mut it = ver.split('.');
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next()?.parse().ok()?;
+    let patch = it.next().unwrap_or("0").parse().unwrap_or(0);
+    Some((engine, (major, minor, patch)))
+}
+
+/// Whether the deterministic crash is observable on the running build. True
+/// for stock nginx in the confirmed vulnerable window: 1.29.x, 1.30.0–1.30.3,
+/// and 1.31.0–1.31.2. Everything else (patched 1.30.4+/1.31.3+, pre-trigger
+/// 1.27/1.28, non-nginx engines) is skipped.
+async fn crash_observable(nginx: &NginxContainer) -> bool {
+    let out = nginx.exec(&["nginx", "-v"]).await;
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    match parse_nginx_version(&combined) {
+        Some((engine, _)) if engine != "nginx" => false,
+        Some((_, (1, 29, _))) => true,
+        Some((_, (1, 30, patch))) => patch <= 3,
+        Some((_, (1, 31, patch))) => patch <= 2,
+        _ => false,
+    }
+}
+
+/// Create the upstream document the `slice` subrequests fetch. 200 'A' bytes.
+async fn seed_backend_file(nginx: &NginxContainer) {
+    let out = nginx
+        .exec_shell(&format!("yes A | head -200 | tr -d '\\n' > {BACKEND_FILE}"))
+        .await;
+    assert_eq!(out.exit_code, 0, "failed to seed backend file: {out:?}");
+}
+
+/// Count `worker process ... exited on signal` lines in the master's error log.
+async fn worker_crash_count(nginx: &NginxContainer) -> u32 {
+    let out = nginx
+        .exec_shell("grep -ac 'exited on signal' /tmp/nginx-err.log")
+        .await;
+    out.stdout.trim().parse().unwrap_or(0)
+}
+
+/// Drive the vulnerable path a handful of times. A long query string loads
+/// non-zero bytes into the request pool so the stale-`ncaptures` read lands on
+/// garbage offsets — this single request shape crashes every vulnerable build
+/// (1.29.x, 1.30.0–1.30.3, 1.31.0–1.31.2) deterministically. The requests that
+/// crash the worker fail at the connection level, so errors are expected and
+/// ignored — the crash itself is asserted from the error log, not the client.
+async fn hammer(nginx: &NginxContainer) {
+    let query = "D".repeat(800);
+    for _ in 0..8 {
+        let _ = reqwest::get(nginx.url(&format!("/big.txt?q={query}"))).await;
+    }
+}
+
+// ============================================================================
+// The flagged config is valid nginx (runs on every version)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn vulnerable_config_is_valid_nginx() {
+    // The harness only returns once `/healthz` answers 200, so a successful
+    // start already proves the flagged pattern is a config nginx accepts —
+    // the rule is not flagging something nginx would reject at load time.
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_config())
+        .await;
+
+    let resp = reqwest::get(nginx.url("/healthz")).await.unwrap();
+    assert_eq!(resp.status(), 200, "vulnerable-pattern config must load");
+}
+
+// ============================================================================
+// On a vulnerable build, the flagged pattern crashes the worker
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn unnamed_map_capture_crashes_worker() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_config())
+        .await;
+
+    if !crash_observable(&nginx).await {
+        eprintln!(
+            "Skipping: crash not observable on this nginx build \
+             (need 1.29.x / 1.30.0-1.30.3 / 1.31.0-1.31.2)"
+        );
+        return;
+    }
+
+    seed_backend_file(&nginx).await;
+    hammer(&nginx).await;
+
+    let crashes = worker_crash_count(&nginx).await;
+    assert!(
+        crashes > 0,
+        "expected the unnamed-capture map + slice + $1 pattern to crash a \
+         worker (CVE-2026-42533 stale-captures signature), but saw no \
+         `exited on signal` lines"
+    );
+}
+
+// ============================================================================
+// The full mitigation removes the signature on the same vulnerable build
+// ============================================================================
+//
+// Critical: same vulnerable image, no version gate beyond observability.
+// Proves the remediation (named captures, applied to the map and its
+// consumer) actually neutralises the bug rather than merely compiling.
+
+#[tokio::test]
+#[ignore]
+async fn named_captures_remove_crash() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_config())
+        .await;
+
+    if !crash_observable(&nginx).await {
+        eprintln!("Skipping: crash not observable on this nginx build; nothing to neutralise");
+        return;
+    }
+
+    seed_backend_file(&nginx).await;
+    hammer(&nginx).await;
+
+    let crashes = worker_crash_count(&nginx).await;
+    assert_eq!(
+        crashes, 0,
+        "using named captures in the map and its consumer must remove the \
+         stale-captures crash on a vulnerable build, but saw {crashes} worker \
+         crash(es)"
+    );
+}
+
+// ============================================================================
+// Under `slice` specifically, dropping `volatile` removes the crash
+// ============================================================================
+//
+// Same vulnerable image, same unnamed capture, same `slice` + unnamed `$1`
+// consumer — only `volatile;` is gone. This pins down the mechanism (the map
+// must actually execute inside the clone), but it is NOT a licence to gate the
+// lint rule on `volatile`: the background-update test below crashes with a
+// non-volatile map.
+
+#[tokio::test]
+#[ignore]
+async fn non_volatile_map_does_not_crash() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(non_volatile_config())
+        .await;
+
+    if !crash_observable(&nginx).await {
+        eprintln!("Skipping: crash not observable on this nginx build; nothing to compare against");
+        return;
+    }
+
+    seed_backend_file(&nginx).await;
+    hammer(&nginx).await;
+
+    let crashes = worker_crash_count(&nginx).await;
+    assert_eq!(
+        crashes, 0,
+        "under `slice` the main request evaluates and caches the map before any \
+         clone exists, so a non-volatile map must not crash here, but saw \
+         {crashes} crash(es)"
+    );
+}
+
+// ============================================================================
+// The rule's autofix neutralises the bug on its own
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn autofixed_config_removes_crash() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(autofixed_config())
+        .await;
+
+    if !crash_observable(&nginx).await {
+        eprintln!("Skipping: crash not observable on this nginx build; nothing to neutralise");
+        return;
+    }
+
+    seed_backend_file(&nginx).await;
+    hammer(&nginx).await;
+
+    let crashes = worker_crash_count(&nginx).await;
+    assert_eq!(
+        crashes, 0,
+        "making the map's group non-capturing must remove the crash even with \
+         the unnamed `$1` consumer untouched (this is what the autofix relies \
+         on), but saw {crashes} worker crash(es)"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn autofixed_config_serves_request() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(autofixed_config())
+        .await;
+
+    seed_backend_file(&nginx).await;
+
+    let resp = reqwest::get(nginx.url("/big.txt")).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "autofixed config must still serve the proxied file, got {}",
+        resp.status()
+    );
+}
+
+// ============================================================================
+// Does the bug need `volatile` at all? (background-update clone path)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn non_volatile_map_via_background_update() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(non_volatile_background_update_config())
+        .await;
+
+    if !crash_observable(&nginx).await {
+        eprintln!("Skipping: crash not observable on this nginx build");
+        return;
+    }
+
+    seed_backend_file(&nginx).await;
+
+    let query = "D".repeat(800);
+    let path = format!("/big.txt?q={query}");
+
+    // Populate the cache, let the entry go stale, then hit it again: the stale
+    // hit is what spawns the background clone.
+    let mut statuses = Vec::new();
+    for _ in 0..8 {
+        let _ = reqwest::get(nginx.url(&path)).await;
+        nginx.exec_shell("sleep 2").await;
+        if let Ok(resp) = reqwest::get(nginx.url(&path)).await {
+            let status = resp
+                .headers()
+                .get("x-cache")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("<none>")
+                .to_string();
+            statuses.push(status);
+        }
+    }
+    nginx.exec_shell("sleep 1").await;
+
+    // Guard against a vacuous pass: if the second request never reports STALE
+    // or UPDATING, the background clone was never created and this config
+    // proves nothing about the hypothesis.
+    eprintln!("cache statuses on the second request: {statuses:?}");
+    assert!(
+        statuses.iter().any(|s| s == "STALE" || s == "UPDATING"),
+        "background-update path was never exercised (statuses: {statuses:?}) — \
+         this test would pass vacuously"
+    );
+
+    // What the upstream actually received tells us whether the background
+    // clone evaluated the map at all, and what `$1` resolved to there.
+    let backend = nginx.exec_shell("cut -c1-60 /tmp/backend.log").await;
+    eprintln!("--- backend saw ---\n{}\n---", backend.stdout);
+
+    let crashes = worker_crash_count(&nginx).await;
+    assert!(
+        crashes > 0,
+        "expected a NON-volatile map to crash a worker through the \
+         background-update clone path (this is what proves the lint rule must \
+         not gate on `volatile`), but saw no `exited on signal` lines"
+    );
+}
+
+// ============================================================================
+// The fixed config still serves normal traffic (runs on every version)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn safe_config_serves_request() {
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_config())
+        .await;
+
+    seed_backend_file(&nginx).await;
+
+    let resp = reqwest::get(nginx.url("/big.txt")).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "safe config must still serve the proxied file, got {}",
+        resp.status()
+    );
+}
+
+#[cfg(test)]
+mod unit {
+    use super::*;
+
+    #[test]
+    fn parses_stock_nginx_version() {
+        let (engine, v) = parse_nginx_version("nginx version: nginx/1.29.8").unwrap();
+        assert_eq!(engine, "nginx");
+        assert_eq!(v, (1, 29, 8));
+    }
+
+    #[test]
+    fn parses_two_component_version() {
+        let (_, v) = parse_nginx_version("nginx version: nginx/1.31").unwrap();
+        assert_eq!(v, (1, 31, 0));
+    }
+
+    #[test]
+    fn parses_openresty_engine() {
+        let (engine, v) = parse_nginx_version("nginx version: openresty/1.29.2.4").unwrap();
+        assert_eq!(engine, "openresty");
+        assert_eq!(v, (1, 29, 2));
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
+++ b/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
@@ -1,373 +1,294 @@
 //! Container-based integration tests for the map-unnamed-capture rule
 //! (nginx CVE-2026-42533, "stale regex captures").
 //!
-//! These tests prove the rule targets a *real* nginx bug by exercising the
-//! flagged pattern against a vulnerable nginx and observing the bug's
-//! signature — a deterministic worker SIGSEGV — directly from the master's
-//! error log.
+//! These tests prove the rule targets a *real* nginx bug: they run the flagged
+//! pattern against real nginx and show that it breaks on affected builds and
+//! works on fixed ones, with the same config either way.
 //!
 //! # The bug
 //!
 //! nginx keeps regex captures in a shared `r->captures` array sized by
-//! `r->ncaptures`. When a *capturing* `map` regex is (re-)evaluated inside a
-//! cloned subrequest and does NOT match, `ngx_http_regex_exec()` reallocates
+//! `r->ncaptures`. When a *capturing* `map` regex runs inside a cloned
+//! subrequest and does NOT match, `ngx_http_regex_exec()` reallocates
 //! `r->captures` but — before the fix — leaves `r->ncaptures` at its previous
-//! value. A later regex that reads an unnamed positional capture (`$1`..`$9`)
-//! then indexes into the freshly-allocated, uninitialized array, reading
-//! garbage offsets → out-of-bounds read → worker crash (potential RCE on
-//! affected builds). Fixed upstream by commit `0cca8e055a2d` which adds
+//! value and returns early. A later read of an unnamed positional capture
+//! (`$1`..`$9`) then indexes into the freshly-allocated, uninitialized array,
+//! reading garbage offsets — an out-of-bounds read (potential RCE on affected
+//! builds). Fixed upstream by commit `0cca8e055a2d`, which adds
 //! `r->ncaptures = 0;` at the realloc site.
 //!
-//! # The exact trigger (all three are required)
+//! # What these tests observe, and why not the crash
+//!
+//! An earlier version asserted a worker SIGSEGV. That was a mistake: whether
+//! the out-of-bounds read faults depends on what the uninitialized memory
+//! happens to hold, which varies by CPU architecture. The same repro crashes
+//! 8/8 on arm64 and never crashes on x86_64 — so a crash assertion passes
+//! locally on an Apple-silicon laptop and fails in x86_64 CI.
+//!
+//! What *is* deterministic on both architectures is that the subrequest breaks.
+//! Reading the stale capture either faults (arm64) or makes nginx fail the
+//! subrequest internally — `unexpected status code 500 in slice response`
+//! (x86_64). Either way the client request fails and the upstream never sees
+//! the subrequest. On a fixed build `$1` is empty instead, the subrequest is
+//! well-formed, and the upstream receives it.
+//!
+//! So the signature is taken from two places that agree across architectures:
+//!   - the client: every request fails on an affected build, succeeds on a
+//!     fixed one;
+//!   - the upstream's access log: `[|]` (an empty `$1`, i.e. the fix's
+//!     `ncaptures = 0`) appears only on fixed builds.
+//!
+//! Measured 8/8 across {arm64, x86_64} × {1.29, 1.30.3, 1.30.4, 1.31.3}, and
+//! the 1.30.3 → 1.30.4 boundary lands exactly on the upstream fix.
+//!
+//! # The trigger
 //!
 //! 1. A `map` with a **capturing** regex entry that **mismatches** at runtime
-//!    (`~mismatch(.*) 1;`). A capture group — named or unnamed — is what makes
-//!    nginx reallocate `r->captures`.
-//! 2. The map is **`volatile`**, so it is re-evaluated inside the subrequest
-//!    (a non-volatile map is evaluated and cached in the main request and
-//!    never re-runs in the subrequest, so it never reallocates there).
-//! 3. A **cloned** subrequest: among stock modules only `slice`
-//!    (`NGX_HTTP_SUBREQUEST_CLONE`) shares/reallocates the capture array, and
-//!    an **unnamed** `$1` is read while that stale `ncaptures` is live.
-//!
-//! # Why named captures are the fix (and the rule's remediation)
-//!
-//! Named captures (`(?<name>...)`) resolve through `r->variables`, a code
-//! path that never touches the `if (n < r->ncaptures)` uninitialized read.
-//! This matches the vendor mitigation: "do not use unnamed captures; use
-//! named captures instead and only use them in the same block with the regex
-//! match." The mitigation is config-wide, not map-only: naming *just* the
-//! map's capture while a consumer still reads an unnamed `$1` does not
-//! reliably remove the crash (it still reallocates the array, and the crash
-//! then depends on heap layout — observed still crashing on 1.31.2). The
-//! [`safe_config`] here applies the mitigation fully — named capture in the
-//! map *and* in the consuming `location` — which is clean on every affected
-//! build.
+//!    (`~mismatch(.*) 1;`). The capture group — named or unnamed — is what
+//!    makes nginx reallocate `r->captures`.
+//! 2. The map regex must actually *run* inside the clone. `volatile` (used
+//!    here) guarantees that by disabling caching. It is not required in
+//!    general — see the rule's docs — but it is what makes this repro
+//!    deterministic.
+//! 3. A **cloned** subrequest (`NGX_HTTP_SUBREQUEST_CLONE`) — here `slice` —
+//!    with an **unnamed** `$1` read while the stale `ncaptures` is live.
 //!
 //! # Version window
 //!
-//! The bug is fixed in **1.30.4** and **1.31.3** (verified by file content
-//! per release tag; backports are cherry-picks, so commit-ancestry checks
-//! mislead). With the padded request [`hammer`] sends, this self-contained
-//! repro crashes deterministically on **1.29.x, 1.30.0–1.30.3, and
-//! 1.31.0–1.31.2** (8/8 across runs); it is not observable on 1.27/1.28
-//! (pre-trigger). The crash tests gate on that observable window, detected
-//! from `nginx -v`.
+//! Fixed in **1.30.4** and **1.31.3** (verified by file content per release
+//! tag; backports are cherry-picks, so commit-ancestry checks mislead). Not
+//! observable on 1.27/1.28. [`is_affected_build`] gates on that window.
 //!
 //! Run with (default image is intentionally a vulnerable one):
 //!   NGINX_IMAGE=nginx:1.29 cargo test -p map-unnamed-capture-plugin \
 //!       --test container_test -- --ignored
 
-use nginx_lint_plugin::container_testing::{NginxContainer, reqwest};
+use nginx_lint_plugin::container_testing::{
+    NginxContainer, nginx_html_root, nginx_server_name, reqwest,
+};
 
-/// Backend document root file the `slice`/`proxy_pass` upstream serves.
-/// 200 bytes so `slice 50;` produces several range subrequests.
-const BACKEND_FILE: &str = "/usr/share/nginx/html/big.txt";
-
-/// Vulnerable pattern: a `volatile` map whose regex entry uses an **unnamed**
-/// capture and mismatches, feeding a `slice` location that reads `$1`.
-/// This is exactly the shape the lint rule flags.
-fn vulnerable_config() -> &'static str {
-    r#"events {
-    worker_connections 1024;
+/// Upstream document the `slice` subrequests fetch. 200 bytes, so `slice 50;`
+/// produces one main-request range plus three subrequest ranges.
+fn backend_file() -> String {
+    format!("{}/big.txt", nginx_html_root())
 }
+
+/// Shared prologue: an upstream on :8081 that logs the `Test` header it
+/// receives, which is where the capture value becomes observable.
+fn config_with(map_entry: &str, location: &str) -> String {
+    format!(
+        r#"events {{
+    worker_connections 1024;
+}}
 error_log /tmp/nginx-err.log info;
-http {
-    map test $my_map {
+http {{
+    log_format capture_probe 'T=[$http_test]';
+
+    map test $my_map {{
         volatile;
-        ~mismatch(.*)  1;
+        {map_entry}
         default        "";
-    }
+    }}
 
-    server {
+    server {{
         listen 8081;
-        location / {
-            root /usr/share/nginx/html;
-        }
-    }
+        access_log /tmp/backend.log capture_probe;
+        location / {{
+            root {root};
+        }}
+    }}
 
-    server {
+    server {{
         listen 80;
 
-        location = /healthz {
+        location = /healthz {{
             return 200 "ok";
-        }
+        }}
 
-        location ~(.*) {
+        {location}
+    }}
+}}
+"#,
+        root = nginx_html_root(),
+    )
+}
+
+/// Vulnerable pattern: a map regex with an **unnamed** capture that mismatches,
+/// feeding a `slice` location that reads `$1`. Exactly the shape the rule flags.
+fn vulnerable_config() -> String {
+    config_with(
+        r#"~mismatch(.*)  1;"#,
+        r#"location ~(.*) {
             slice 50;
             proxy_set_header Test  "[$my_map|$1]";
             proxy_set_header Range $slice_range;
             proxy_pass http://127.0.0.1:8081;
-        }
-    }
-}
-"#
+        }"#,
+    )
 }
 
-/// The vendor mitigation applied fully: named captures in **both** the map
-/// (`(.*)` → `(?<x>.*)`) and the consuming `location` (`~(.*)` → `~(?<p>.*)`,
-/// read as `$p` instead of `$1`). Named captures resolve through a path that
-/// never touches the stale-`ncaptures` read, so the crash disappears on every
-/// affected build. (Naming only the map is not enough — see the module docs.)
-fn safe_config() -> &'static str {
-    r#"events {
-    worker_connections 1024;
-}
-error_log /tmp/nginx-err.log info;
-http {
-    map test $my_map {
-        volatile;
-        ~mismatch(?<x>.*)  1;
-        default            "";
-    }
-
-    server {
-        listen 8081;
-        location / {
-            root /usr/share/nginx/html;
-        }
-    }
-
-    server {
-        listen 80;
-
-        location = /healthz {
-            return 200 "ok";
-        }
-
-        location ~(?<p>.*) {
+/// The vendor mitigation applied fully: named captures in **both** the map and
+/// the consuming `location`, read by name. Naming only the map is NOT enough —
+/// a named group is still a capturing group, so the array is still reallocated.
+fn safe_config() -> String {
+    config_with(
+        r#"~mismatch(?<x>.*)  1;"#,
+        r#"location ~(?<p>.*) {
             slice 50;
             proxy_set_header Test  "[$my_map|$p]";
             proxy_set_header Range $slice_range;
             proxy_pass http://127.0.0.1:8081;
-        }
-    }
-}
-"#
-}
-
-/// The same unnamed-capture map and `$1`-reading `slice` location as
-/// [`vulnerable_config`], with **only** `volatile;` removed.
-///
-/// This stays clean, but note carefully *why* — it is a property of the `slice`
-/// path, not of non-volatile maps in general. Under `slice` the main request
-/// proxies the first slice itself, so it evaluates `$my_map` and caches it
-/// before any clone exists; the clones then read the cached value and never
-/// run the regex. Change the clone source to `proxy_cache_background_update`
-/// and the same non-volatile map *does* crash — see
-/// [`non_volatile_background_update_config`]. Do not read this test as
-/// "non-volatile is safe".
-fn non_volatile_config() -> &'static str {
-    r#"events {
-    worker_connections 1024;
-}
-error_log /tmp/nginx-err.log info;
-http {
-    map test $my_map {
-        ~mismatch(.*)  1;
-        default        "";
-    }
-
-    server {
-        listen 8081;
-        location / {
-            root /usr/share/nginx/html;
-        }
-    }
-
-    server {
-        listen 80;
-
-        location = /healthz {
-            return 200 "ok";
-        }
-
-        location ~(.*) {
-            slice 50;
-            proxy_set_header Test  "[$my_map|$1]";
-            proxy_set_header Range $slice_range;
-            proxy_pass http://127.0.0.1:8081;
-        }
-    }
-}
-"#
-}
-
-/// A **non-volatile** map with an unnamed capture, reached through the *other*
-/// stock `NGX_HTTP_SUBREQUEST_CLONE` caller: `proxy_cache_background_update`
-/// (`ngx_http_upstream.c:1157`, gated at `:941` by `proxy_cache_use_stale
-/// updating` + `proxy_cache_background_update on`).
-///
-/// The hypothesis this config tests: `volatile` is not actually required. What
-/// the bug needs is for the map's regex to *execute* while `realloc_captures`
-/// is set — i.e. inside the clone. `volatile` guarantees that by disabling
-/// caching, but a non-volatile map reaches it too if its **first** evaluation
-/// happens inside the clone, because `sr->variables = r->variables`
-/// (`ngx_http_core_module.c:2508`) makes the variable cache shared, not copied.
-///
-/// On a stale cache hit nginx creates the background clone during
-/// `ngx_http_file_cache_open()` — *before* `create_request` — and then answers
-/// the main request straight from cache, so the main request never evaluates
-/// `proxy_set_header`. That leaves the background subrequest as the first (and
-/// only) evaluator of `$my_map`, with `realloc_captures` already set.
-///
-/// (This is why the `slice` config above stays clean without `volatile`: there
-/// the main request proxies the first slice itself, so it evaluates and caches
-/// the map before any clone exists.)
-fn non_volatile_background_update_config() -> &'static str {
-    r#"events {
-    worker_connections 1024;
-}
-error_log /tmp/nginx-err.log info;
-http {
-    proxy_cache_path /tmp/cache levels=1:2 keys_zone=z:10m inactive=60m;
-
-    log_format probe '$request_uri test=[$http_test]';
-
-    map test $my_map {
-        ~mismatch(.*)  1;
-        default        "";
-    }
-
-    server {
-        listen 8081;
-        access_log /tmp/backend.log probe;
-        location / {
-            root /usr/share/nginx/html;
-        }
-    }
-
-    server {
-        listen 80;
-
-        location = /healthz {
-            return 200 "ok";
-        }
-
-        location ~(.*) {
-            proxy_cache                     z;
-            proxy_cache_valid               200 1s;
-            proxy_cache_use_stale           updating;
-            proxy_cache_background_update   on;
-            add_header X-Cache $upstream_cache_status always;
-            proxy_set_header Test  "[$my_map|$1]";
-            proxy_pass http://127.0.0.1:8081;
-        }
-    }
-}
-"#
+        }"#,
+    )
 }
 
 /// Exactly what the rule's autofix produces from [`vulnerable_config`]: the
-/// map's `(.*)` becomes `(?:.*)`, and **nothing else changes** — the consuming
+/// map's `(.*)` becomes `(?:.*)` and **nothing else changes** — the consuming
 /// `location ~(.*)` still reads an unnamed `$1`. (The map's value is `1`, which
 /// reads no positional capture, so the autofix applies here.)
 ///
-/// This is the sharpest test of the fix's premise. Naming *only* the map is
-/// known NOT to be enough — a named group is still a capturing group, so
-/// `ngx_http_regex_exec()` still reallocates and the crash survives on 1.31.2.
-/// Going non-capturing instead makes `re->ncaptures` zero, so the realloc never
-/// happens for this regex at all, and the crash should disappear even with the
-/// unnamed `$1` consumer left untouched.
-fn autofixed_config() -> &'static str {
-    r#"events {
-    worker_connections 1024;
-}
-error_log /tmp/nginx-err.log info;
-http {
-    map test $my_map {
-        volatile;
-        ~mismatch(?:.*)  1;
-        default          "";
-    }
-
-    server {
-        listen 8081;
-        location / {
-            root /usr/share/nginx/html;
-        }
-    }
-
-    server {
-        listen 80;
-
-        location = /healthz {
-            return 200 "ok";
-        }
-
-        location ~(.*) {
+/// This is the sharpest test of the fix's premise: `ngx_http_regex_exec()`
+/// reallocates only `if (re->ncaptures)`, so a non-capturing group stops the
+/// realloc outright, whereas a named capture would not.
+fn autofixed_config() -> String {
+    config_with(
+        r#"~mismatch(?:.*)  1;"#,
+        r#"location ~(.*) {
             slice 50;
             proxy_set_header Test  "[$my_map|$1]";
             proxy_set_header Range $slice_range;
             proxy_pass http://127.0.0.1:8081;
+        }"#,
+    )
+}
+
+/// Minimal config that loads on every engine, used only to get a container up
+/// so its build options can be read.
+const PROBE_CONFIG: &str = r#"events {
+    worker_connections 1024;
+}
+http {
+    server {
+        listen 80;
+        location = /healthz {
+            return 200 "ok";
         }
     }
 }
-"#
+"#;
+
+/// Whether the image was built with `--with-http_slice_module`.
+///
+/// This repro needs `slice` to create the cloned subrequest, and slice is NOT a
+/// nginx build default (`auto/options`: `HTTP_SLICE=NO`) — it is opt-in. The
+/// official nginx and openresty images enable it; the freenginx image used in
+/// CI does not, and without it `slice 50;` is an unknown directive, so nginx
+/// refuses the whole config and never starts. Detect it rather than hardcoding
+/// which images qualify, so a rebuilt image is picked up automatically.
+///
+/// Costs one throwaway container: the real config cannot load on an image
+/// lacking the module, so this cannot be asked of the container under test.
+///
+/// Note this says nothing about the *rule's* scope. The other stock path into
+/// this bug, `proxy_cache_background_update`, needs no optional module — only
+/// the repro depends on slice.
+async fn has_slice_module() -> bool {
+    let probe = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(PROBE_CONFIG)
+        .await;
+
+    let out = probe.exec(&["nginx", "-V"]).await;
+    format!("{}{}", out.stdout, out.stderr).contains("http_slice_module")
 }
 
-/// Parse `major.minor.patch` and the engine prefix out of `nginx -v` stderr,
-/// e.g. `"nginx version: nginx/1.29.8"` → `("nginx", (1, 29, 8))`.
-fn parse_nginx_version(stderr: &str) -> Option<(String, (u32, u32, u32))> {
-    let after = stderr.split('/').nth(1)?;
-    let ver = after.split_whitespace().next()?;
-    let engine = stderr
-        .split(':')
-        .nth(1)?
-        .trim()
-        .split('/')
-        .next()?
-        .to_string();
+/// Parse `major.minor.patch` out of `nginx -v` output.
+fn parse_nginx_version(output: &str) -> Option<(u32, u32, u32)> {
+    let ver = output.split('/').nth(1)?.split_whitespace().next()?;
     let mut it = ver.split('.');
-    let major = it.next()?.parse().ok()?;
-    let minor = it.next()?.parse().ok()?;
-    let patch = it.next().unwrap_or("0").parse().unwrap_or(0);
-    Some((engine, (major, minor, patch)))
+    Some((
+        it.next()?.parse().ok()?,
+        it.next()?.parse().ok()?,
+        it.next().unwrap_or("0").parse().unwrap_or(0),
+    ))
 }
 
-/// Whether the deterministic crash is observable on the running build. True
-/// for stock nginx in the confirmed vulnerable window: 1.29.x, 1.30.0–1.30.3,
-/// and 1.31.0–1.31.2. Everything else (patched 1.30.4+/1.31.3+, pre-trigger
-/// 1.27/1.28, non-nginx engines) is skipped.
-async fn crash_observable(nginx: &NginxContainer) -> bool {
+/// Whether the running engine is stock nginx, the only one whose fix status is
+/// established here.
+///
+/// openresty and freenginx are skipped rather than judged: they may well carry
+/// the bug, but whether they have picked up the fix has not been established,
+/// so asserting *either* the affected or the fixed behaviour would be a guess.
+/// Skipping is the honest option — treating a fork as fixed just because
+/// `is_affected_build` says so would silently vouch for it.
+fn is_stock_nginx() -> bool {
+    nginx_server_name() == "nginx"
+}
+
+/// Whether the bug is present on the running build: the confirmed window
+/// 1.29.x / 1.30.0-1.30.3 / 1.31.0-1.31.2. Only meaningful for stock nginx.
+async fn is_affected_build(nginx: &NginxContainer) -> bool {
     let out = nginx.exec(&["nginx", "-v"]).await;
-    let combined = format!("{}{}", out.stdout, out.stderr);
-    match parse_nginx_version(&combined) {
-        Some((engine, _)) if engine != "nginx" => false,
-        Some((_, (1, 29, _))) => true,
-        Some((_, (1, 30, patch))) => patch <= 3,
-        Some((_, (1, 31, patch))) => patch <= 2,
+    match parse_nginx_version(&format!("{}{}", out.stdout, out.stderr)) {
+        Some((1, 29, _)) => true,
+        Some((1, 30, patch)) => patch <= 3,
+        Some((1, 31, patch)) => patch <= 2,
         _ => false,
     }
 }
 
-/// Create the upstream document the `slice` subrequests fetch. 200 'A' bytes.
 async fn seed_backend_file(nginx: &NginxContainer) {
     let out = nginx
-        .exec_shell(&format!("yes A | head -200 | tr -d '\\n' > {BACKEND_FILE}"))
+        .exec_shell(&format!(
+            "yes A | head -200 | tr -d '\\n' > {}",
+            backend_file()
+        ))
         .await;
     assert_eq!(out.exit_code, 0, "failed to seed backend file: {out:?}");
 }
 
-/// Count `worker process ... exited on signal` lines in the master's error log.
-async fn worker_crash_count(nginx: &NginxContainer) -> u32 {
-    let out = nginx
-        .exec_shell("grep -ac 'exited on signal' /tmp/nginx-err.log")
-        .await;
-    out.stdout.trim().parse().unwrap_or(0)
+/// Outcome of driving the vulnerable path: what the client saw, and what the
+/// upstream received.
+struct Observed {
+    client_ok: usize,
+    client_failed: usize,
+    /// Upstream requests carrying an **empty** `$1` — the fix's `ncaptures = 0`
+    /// showing through. Only fixed builds produce these.
+    empty_capture_hits: u32,
+    /// Upstream requests carrying the location's real `$1` value. The 8 main
+    /// requests always do; subrequests only when the captures stayed intact.
+    real_capture_hits: u32,
 }
 
-/// Drive the vulnerable path a handful of times. A long query string loads
-/// non-zero bytes into the request pool so the stale-`ncaptures` read lands on
-/// garbage offsets — this single request shape crashes every vulnerable build
-/// (1.29.x, 1.30.0–1.30.3, 1.31.0–1.31.2) deterministically. The requests that
-/// crash the worker fail at the connection level, so errors are expected and
-/// ignored — the crash itself is asserted from the error log, not the client.
-async fn hammer(nginx: &NginxContainer) {
+/// Drive the flagged path a handful of times and collect both signals.
+///
+/// The long query string is what pushes the stale read onto non-zero bytes on
+/// affected builds; without it the read can land on zeroed memory and look
+/// indistinguishable from a fixed build.
+async fn drive(nginx: &NginxContainer, capture_value: &str) -> Observed {
     let query = "D".repeat(800);
+    let (mut client_ok, mut client_failed) = (0, 0);
+
     for _ in 0..8 {
-        let _ = reqwest::get(nginx.url(&format!("/big.txt?q={query}"))).await;
+        match reqwest::get(nginx.url(&format!("/big.txt?q={query}"))).await {
+            Ok(resp) if resp.status().is_success() => client_ok += 1,
+            _ => client_failed += 1,
+        }
     }
+
+    Observed {
+        client_ok,
+        client_failed,
+        empty_capture_hits: count_upstream_hits(nginx, "T=[[|]]").await,
+        real_capture_hits: count_upstream_hits(nginx, &format!("T=[[|{capture_value}]]")).await,
+    }
+}
+
+async fn count_upstream_hits(nginx: &NginxContainer, needle: &str) -> u32 {
+    let out = nginx
+        .exec_shell(&format!("grep -acF '{needle}' /tmp/backend.log"))
+        .await;
+    out.stdout.trim().parse().unwrap_or(0)
 }
 
 // ============================================================================
@@ -377,12 +298,17 @@ async fn hammer(nginx: &NginxContainer) {
 #[tokio::test]
 #[ignore]
 async fn vulnerable_config_is_valid_nginx() {
+    if !has_slice_module().await {
+        eprintln!("SKIP vulnerable_config_is_valid_nginx: image lacks http_slice_module");
+        return;
+    }
+
     // The harness only returns once `/healthz` answers 200, so a successful
-    // start already proves the flagged pattern is a config nginx accepts —
-    // the rule is not flagging something nginx would reject at load time.
+    // start already proves the flagged pattern is a config nginx accepts — the
+    // rule is not flagging something nginx would reject at load time.
     let nginx = NginxContainer::builder()
         .health_path("/healthz")
-        .start(vulnerable_config())
+        .start(vulnerable_config().as_str())
         .await;
 
     let resp = reqwest::get(nginx.url("/healthz")).await.unwrap();
@@ -390,259 +316,127 @@ async fn vulnerable_config_is_valid_nginx() {
 }
 
 // ============================================================================
-// On a vulnerable build, the flagged pattern crashes the worker
+// The flagged pattern breaks on affected builds, and only on affected builds
 // ============================================================================
 
 #[tokio::test]
 #[ignore]
-async fn unnamed_map_capture_crashes_worker() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(vulnerable_config())
-        .await;
-
-    if !crash_observable(&nginx).await {
+async fn unnamed_map_capture_breaks_the_slice_subrequest() {
+    if !is_stock_nginx() {
         eprintln!(
-            "Skipping: crash not observable on this nginx build \
-             (need 1.29.x / 1.30.0-1.30.3 / 1.31.0-1.31.2)"
+            "Skipping: fix status not established for {}",
+            nginx_server_name()
         );
         return;
     }
 
-    seed_backend_file(&nginx).await;
-    hammer(&nginx).await;
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(vulnerable_config().as_str())
+        .await;
 
-    let crashes = worker_crash_count(&nginx).await;
-    assert!(
-        crashes > 0,
-        "expected the unnamed-capture map + slice + $1 pattern to crash a \
-         worker (CVE-2026-42533 stale-captures signature), but saw no \
-         `exited on signal` lines"
+    seed_backend_file(&nginx).await;
+    let seen = drive(&nginx, "/big.txt").await;
+
+    assert_eq!(
+        seen.real_capture_hits, 8,
+        "expected all 8 main requests to reach the upstream regardless of \
+         build — without them this test would prove nothing about the \
+         subrequests"
     );
+
+    if is_affected_build(&nginx).await {
+        assert_eq!(
+            seen.client_ok, 0,
+            "on an affected build every request must fail: reading the stale \
+             capture either faults or makes nginx fail the slice subrequest \
+             internally"
+        );
+        assert_eq!(
+            seen.empty_capture_hits, 0,
+            "an affected build must never deliver an empty `$1` — that is the \
+             fixed behaviour (`ncaptures = 0`)"
+        );
+    } else {
+        assert_eq!(
+            seen.client_failed, 0,
+            "on a fixed build the same config must serve every request"
+        );
+        assert!(
+            seen.empty_capture_hits > 0,
+            "a fixed build must reset `ncaptures`, so the slice subrequests \
+             must reach the upstream with an empty `$1`"
+        );
+    }
 }
 
 // ============================================================================
-// The full mitigation removes the signature on the same vulnerable build
+// The remediations neutralise it on the same affected build
 // ============================================================================
 //
-// Critical: same vulnerable image, no version gate beyond observability.
-// Proves the remediation (named captures, applied to the map and its
-// consumer) actually neutralises the bug rather than merely compiling.
+// Same image, no version gate beyond observability: these prove the fixes
+// actually work rather than merely compiling.
 
 #[tokio::test]
 #[ignore]
-async fn named_captures_remove_crash() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(safe_config())
-        .await;
-
-    if !crash_observable(&nginx).await {
-        eprintln!("Skipping: crash not observable on this nginx build; nothing to neutralise");
+async fn named_captures_keep_the_subrequest_working() {
+    if !has_slice_module().await {
+        eprintln!("SKIP named_captures_keep_the_subrequest_working: image lacks http_slice_module");
         return;
     }
 
-    seed_backend_file(&nginx).await;
-    hammer(&nginx).await;
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(safe_config().as_str())
+        .await;
 
-    let crashes = worker_crash_count(&nginx).await;
+    seed_backend_file(&nginx).await;
+    let seen = drive(&nginx, "/big.txt").await;
+
     assert_eq!(
-        crashes, 0,
-        "using named captures in the map and its consumer must remove the \
-         stale-captures crash on a vulnerable build, but saw {crashes} worker \
-         crash(es)"
+        seen.client_failed, 0,
+        "naming the captures in the map AND its consumer must keep every \
+         request working on an affected build"
     );
 }
 
-// ============================================================================
-// Under `slice` specifically, dropping `volatile` removes the crash
-// ============================================================================
-//
-// Same vulnerable image, same unnamed capture, same `slice` + unnamed `$1`
-// consumer — only `volatile;` is gone. This pins down the mechanism (the map
-// must actually execute inside the clone), but it is NOT a licence to gate the
-// lint rule on `volatile`: the background-update test below crashes with a
-// non-volatile map.
-
 #[tokio::test]
 #[ignore]
-async fn non_volatile_map_does_not_crash() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(non_volatile_config())
-        .await;
-
-    if !crash_observable(&nginx).await {
-        eprintln!("Skipping: crash not observable on this nginx build; nothing to compare against");
+async fn autofix_keeps_the_subrequest_working() {
+    if !has_slice_module().await {
+        eprintln!("SKIP autofix_keeps_the_subrequest_working: image lacks http_slice_module");
         return;
     }
 
-    seed_backend_file(&nginx).await;
-    hammer(&nginx).await;
+    let nginx = NginxContainer::builder()
+        .health_path("/healthz")
+        .start(autofixed_config().as_str())
+        .await;
 
-    let crashes = worker_crash_count(&nginx).await;
+    seed_backend_file(&nginx).await;
+    let seen = drive(&nginx, "/big.txt").await;
+
+    // The consumer still reads an unnamed `$1`; only the map's group changed.
+    // This works solely because a non-capturing group stops the realloc.
     assert_eq!(
-        crashes, 0,
-        "under `slice` the main request evaluates and caches the map before any \
-         clone exists, so a non-volatile map must not crash here, but saw \
-         {crashes} crash(es)"
+        seen.client_failed, 0,
+        "making the map's group non-capturing must fix the request even with \
+         the unnamed `$1` consumer left untouched — this is what the autofix \
+         relies on"
     );
-}
 
-// ============================================================================
-// The rule's autofix neutralises the bug on its own
-// ============================================================================
-
-#[tokio::test]
-#[ignore]
-async fn autofixed_config_removes_crash() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(autofixed_config())
-        .await;
-
-    if !crash_observable(&nginx).await {
-        eprintln!("Skipping: crash not observable on this nginx build; nothing to neutralise");
-        return;
-    }
-
-    seed_backend_file(&nginx).await;
-    hammer(&nginx).await;
-
-    let crashes = worker_crash_count(&nginx).await;
+    // Note the mechanism differs from the upstream fix, and so does what the
+    // upstream sees. A fixed nginx still reallocates and resets the count, so
+    // `$1` comes through empty; here the array is never reallocated, so `$1`
+    // keeps the location's real capture in the subrequests too.
     assert_eq!(
-        crashes, 0,
-        "making the map's group non-capturing must remove the crash even with \
-         the unnamed `$1` consumer untouched (this is what the autofix relies \
-         on), but saw {crashes} worker crash(es)"
+        seen.empty_capture_hits, 0,
+        "no realloc means `ncaptures` is never reset, so `$1` must not come \
+         through empty"
     );
-}
-
-#[tokio::test]
-#[ignore]
-async fn autofixed_config_serves_request() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(autofixed_config())
-        .await;
-
-    seed_backend_file(&nginx).await;
-
-    let resp = reqwest::get(nginx.url("/big.txt")).await.unwrap();
-    assert!(
-        resp.status().is_success(),
-        "autofixed config must still serve the proxied file, got {}",
-        resp.status()
+    assert_eq!(
+        seen.real_capture_hits, 32,
+        "all 8 requests × 4 slices must reach the upstream carrying the \
+         location's real capture"
     );
-}
-
-// ============================================================================
-// Does the bug need `volatile` at all? (background-update clone path)
-// ============================================================================
-
-#[tokio::test]
-#[ignore]
-async fn non_volatile_map_via_background_update() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(non_volatile_background_update_config())
-        .await;
-
-    if !crash_observable(&nginx).await {
-        eprintln!("Skipping: crash not observable on this nginx build");
-        return;
-    }
-
-    seed_backend_file(&nginx).await;
-
-    let query = "D".repeat(800);
-    let path = format!("/big.txt?q={query}");
-
-    // Populate the cache, let the entry go stale, then hit it again: the stale
-    // hit is what spawns the background clone.
-    let mut statuses = Vec::new();
-    for _ in 0..8 {
-        let _ = reqwest::get(nginx.url(&path)).await;
-        nginx.exec_shell("sleep 2").await;
-        if let Ok(resp) = reqwest::get(nginx.url(&path)).await {
-            let status = resp
-                .headers()
-                .get("x-cache")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("<none>")
-                .to_string();
-            statuses.push(status);
-        }
-    }
-    nginx.exec_shell("sleep 1").await;
-
-    // Guard against a vacuous pass: if the second request never reports STALE
-    // or UPDATING, the background clone was never created and this config
-    // proves nothing about the hypothesis.
-    eprintln!("cache statuses on the second request: {statuses:?}");
-    assert!(
-        statuses.iter().any(|s| s == "STALE" || s == "UPDATING"),
-        "background-update path was never exercised (statuses: {statuses:?}) — \
-         this test would pass vacuously"
-    );
-
-    // What the upstream actually received tells us whether the background
-    // clone evaluated the map at all, and what `$1` resolved to there.
-    let backend = nginx.exec_shell("cut -c1-60 /tmp/backend.log").await;
-    eprintln!("--- backend saw ---\n{}\n---", backend.stdout);
-
-    let crashes = worker_crash_count(&nginx).await;
-    assert!(
-        crashes > 0,
-        "expected a NON-volatile map to crash a worker through the \
-         background-update clone path (this is what proves the lint rule must \
-         not gate on `volatile`), but saw no `exited on signal` lines"
-    );
-}
-
-// ============================================================================
-// The fixed config still serves normal traffic (runs on every version)
-// ============================================================================
-
-#[tokio::test]
-#[ignore]
-async fn safe_config_serves_request() {
-    let nginx = NginxContainer::builder()
-        .health_path("/healthz")
-        .start(safe_config())
-        .await;
-
-    seed_backend_file(&nginx).await;
-
-    let resp = reqwest::get(nginx.url("/big.txt")).await.unwrap();
-    assert!(
-        resp.status().is_success(),
-        "safe config must still serve the proxied file, got {}",
-        resp.status()
-    );
-}
-
-#[cfg(test)]
-mod unit {
-    use super::*;
-
-    #[test]
-    fn parses_stock_nginx_version() {
-        let (engine, v) = parse_nginx_version("nginx version: nginx/1.29.8").unwrap();
-        assert_eq!(engine, "nginx");
-        assert_eq!(v, (1, 29, 8));
-    }
-
-    #[test]
-    fn parses_two_component_version() {
-        let (_, v) = parse_nginx_version("nginx version: nginx/1.31").unwrap();
-        assert_eq!(v, (1, 31, 0));
-    }
-
-    #[test]
-    fn parses_openresty_engine() {
-        let (engine, v) = parse_nginx_version("nginx version: openresty/1.29.2.4").unwrap();
-        assert_eq!(engine, "openresty");
-        assert_eq!(v, (1, 29, 2));
-    }
 }

--- a/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
+++ b/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
@@ -153,8 +153,10 @@ fn safe_config() -> String {
 /// reads no positional capture, so the autofix applies here.)
 ///
 /// This is the sharpest test of the fix's premise: `ngx_http_regex_exec()`
-/// reallocates only `if (re->ncaptures)`, so a non-capturing group stops the
-/// realloc outright, whereas a named capture would not.
+/// reallocates only `if (re->ncaptures)`, so removing the regex's last capture
+/// stops the realloc outright, whereas naming it would not (PCRE counts named
+/// groups). Note the premise needs the last capture gone — an entry keeping a
+/// named group alongside the rewritten one still reallocates.
 fn autofixed_config() -> String {
     config_with(
         r#"~mismatch(?:.*)  1;"#,

--- a/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
+++ b/plugins/builtin/security/map_unnamed_capture/tests/container_test.rs
@@ -41,6 +41,11 @@
 //! Measured 8/8 across {arm64, x86_64} × {1.29, 1.30.3, 1.30.4, 1.31.3}, and
 //! the 1.30.3 → 1.30.4 boundary lands exactly on the upstream fix.
 //!
+//! This is not a universal oracle, and the asymmetry matters: a *failure* is
+//! proof of the bug, but a *clean run* only means the stale read happened to
+//! land on zeroed memory. Known builds where that happens despite the bug being
+//! present are skipped rather than declared fixed — see [`is_stock_nginx`].
+//!
 //! # The trigger
 //!
 //! 1. A `map` with a **capturing** regex entry that **mismatches** at runtime
@@ -213,14 +218,21 @@ fn parse_nginx_version(output: &str) -> Option<(u32, u32, u32)> {
     ))
 }
 
-/// Whether the running engine is stock nginx, the only one whose fix status is
-/// established here.
+/// Whether the running engine is stock nginx, the only one this repro can
+/// actually judge.
 ///
-/// openresty and freenginx are skipped rather than judged: they may well carry
-/// the bug, but whether they have picked up the fix has not been established,
-/// so asserting *either* the affected or the fixed behaviour would be a guess.
-/// Skipping is the honest option — treating a fork as fixed just because
-/// `is_affected_build` says so would silently vouch for it.
+/// Forks are skipped, and NOT because their fix status is unknown — as of
+/// 2026-07-17 both carry the bug: openresty 1.31.1.1 bundles nginx 1.31.1 with
+/// no `r->ncaptures = 0;` at the realloc site (its patch set touches only
+/// OpenSSL), and freenginx 1.31.3 is likewise missing it.
+///
+/// They are skipped because **this repro cannot detect that**. On both, the
+/// stale read lands on zeroed memory, so `$1` comes through empty and the
+/// subrequest succeeds — outwardly identical to a fixed build. That is the
+/// honest limit of the signature: it proves the bug when the stale read hits
+/// non-zero memory (as it does on every official nginx image tested), but a
+/// clean run is not evidence of a fix. Asserting the fixed behaviour here would
+/// vouch for builds that are in fact vulnerable.
 fn is_stock_nginx() -> bool {
     nginx_server_name() == "nginx"
 }

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/error/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/error/nginx.conf
@@ -1,0 +1,15 @@
+http {
+    map $host $backend {
+        volatile;
+        default                 default_backend;
+        ~^(.+)\.example\.com$   ${1}_backend;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(.*)$ {
+            proxy_pass http://$backend/$1;
+        }
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/error/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/error/nginx.conf
@@ -2,7 +2,7 @@ http {
     map $host $backend {
         volatile;
         default                 default_backend;
-        ~^(.+)\.example\.com$   ${1}_backend;
+        ~^(.+)\.example\.com$   $1_backend;
     }
 
     server {

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/expected/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/001_basic/expected/nginx.conf
@@ -1,0 +1,15 @@
+http {
+    map $host $backend {
+        volatile;
+        default                          default_backend;
+        ~^(?<sub>.+)\.example\.com$      ${sub}_backend;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(?<rest>.*)$ {
+            proxy_pass http://$backend/$rest;
+        }
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/error/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/error/nginx.conf
@@ -5,7 +5,7 @@
 stream {
     map $ssl_preread_server_name $upstream {
         default             default_backend;
-        ~^(.+)\.internal$   ${1}_backend;
+        ~^(.+)\.internal$   $1_backend;
     }
 
     server {
@@ -18,7 +18,7 @@ stream {
 http {
     map $host $backend {
         default                 default_backend;
-        ~^(.+)\.example\.com$   ${1}_backend;
+        ~^(.+)\.example\.com$   $1_backend;
     }
 
     server {

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/error/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/error/nginx.conf
@@ -1,0 +1,31 @@
+# The `stream` map below uses an unnamed capture too, but it is NOT reported:
+# stream has no subrequests, and `ngx_stream_regex_exec()` allocates
+# `s->captures` only when it is null — the array is never reallocated, so the
+# stale `ncaptures` this CVE depends on cannot arise. Only the `http` map is.
+stream {
+    map $ssl_preread_server_name $upstream {
+        default             default_backend;
+        ~^(.+)\.internal$   ${1}_backend;
+    }
+
+    server {
+        listen 12345;
+        ssl_preread on;
+        proxy_pass $upstream;
+    }
+}
+
+http {
+    map $host $backend {
+        default                 default_backend;
+        ~^(.+)\.example\.com$   ${1}_backend;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(.*)$ {
+            proxy_pass http://$backend/$1;
+        }
+    }
+}

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/expected/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/expected/nginx.conf
@@ -4,7 +4,7 @@
 stream {
     map $ssl_preread_server_name $upstream {
         default             default_backend;
-        ~^(.+)\.internal$   ${1}_backend;
+        ~^(.+)\.internal$   $1_backend;
     }
 
     server {

--- a/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/expected/nginx.conf
+++ b/plugins/builtin/security/map_unnamed_capture/tests/fixtures/002_stream_is_not_reported/expected/nginx.conf
@@ -1,0 +1,30 @@
+# The `stream` map is deliberately left untouched, unnamed capture and all:
+# the bug is unreachable there, so this file must still be clean. Only the
+# `http` map and the `location` that consumes its capture needed fixing.
+stream {
+    map $ssl_preread_server_name $upstream {
+        default             default_backend;
+        ~^(.+)\.internal$   ${1}_backend;
+    }
+
+    server {
+        listen 12345;
+        ssl_preread on;
+        proxy_pass $upstream;
+    }
+}
+
+http {
+    map $host $backend {
+        default                          default_backend;
+        ~^(?<sub>.+)\.example\.com$      ${sub}_backend;
+    }
+
+    server {
+        listen 80;
+
+        location ~ ^/api/(?<rest>.*)$ {
+            proxy_pass http://$backend/$rest;
+        }
+    }
+}

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -26,6 +26,8 @@
 
 use nginx_lint_plugin::prelude::*;
 
+use nginx_lint_plugin::helpers::{find_unnamed_capture_positions, regex_has_named_capture};
+
 #[derive(Default)]
 pub struct NginxRiftPlugin;
 
@@ -284,116 +286,6 @@ fn build_renamed_regex(raw: &str) -> (String, usize) {
     }
     out.push_str(std::str::from_utf8(&bytes[cursor..]).expect("ASCII boundary"));
     (out, positions.len())
-}
-
-/// Detect whether a regex source string contains any named capture group
-/// (`(?<name>...)` or `(?P<name>...)`). Lookbehinds `(?<=...)` / `(?<!...)`
-/// are NOT named captures and don't count.
-///
-/// Used to bail out of autofix on regexes that mix named and unnamed
-/// captures: our cap-numbering (index among unnamed) diverges from PCRE's
-/// positional numbering once a named group is present, so a `$1` could end
-/// up renamed to point at a different capture.
-fn regex_has_named_capture(raw: &str) -> bool {
-    let bytes = raw.as_bytes();
-    let mut i = 0;
-    let mut in_char_class = false;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-
-        if b == b'\\' && i + 1 < bytes.len() {
-            i += 2;
-            continue;
-        }
-
-        if in_char_class {
-            if b == b']' {
-                in_char_class = false;
-            }
-            i += 1;
-            continue;
-        }
-
-        if b == b'[' {
-            in_char_class = true;
-            i += 1;
-            continue;
-        }
-
-        if b == b'(' && i + 3 < bytes.len() && bytes[i + 1] == b'?' {
-            // `(?<name>...)` — named iff the char after `<` is a name-start
-            // byte. `(?<=...)` and `(?<!...)` are lookbehinds; not captures.
-            if bytes[i + 2] == b'<' {
-                let after_lt = bytes[i + 3];
-                if after_lt != b'=' && after_lt != b'!' {
-                    return true;
-                }
-            }
-            // `(?P<name>...)` — Python-style named capture.
-            // (Only `bytes[i + 3]` is read; the outer `i + 3 < bytes.len()`
-            // guard is already sufficient.)
-            if bytes[i + 2] == b'P' && bytes[i + 3] == b'<' {
-                return true;
-            }
-        }
-
-        i += 1;
-    }
-
-    false
-}
-
-/// Find byte offsets of `(` characters that open an unnamed PCRE capture group.
-///
-/// Skips: escapes (`\(`), character classes (`[...]`), the `(?...)` family —
-/// non-capturing `(?:...)`, named `(?<name>...)` / `(?P<name>...)`,
-/// lookarounds `(?=...)` / `(?!...)` / `(?<=...)` / `(?<!...)`, atomic
-/// `(?>...)`, comments `(?#...)`, and inline modifiers `(?i)` — and the
-/// `(*VERB)` family — PCRE control verbs like `(*PRUNE)`, `(*SKIP)`,
-/// `(*FAIL)`, `(*MARK:name)`, etc.
-fn find_unnamed_capture_positions(regex: &str) -> Vec<usize> {
-    let bytes = regex.as_bytes();
-    let mut positions = Vec::new();
-    let mut i = 0;
-    let mut in_char_class = false;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-
-        if b == b'\\' && i + 1 < bytes.len() {
-            // Escaped byte — skip both bytes.
-            i += 2;
-            continue;
-        }
-
-        if in_char_class {
-            if b == b']' {
-                in_char_class = false;
-            }
-            i += 1;
-            continue;
-        }
-
-        if b == b'[' {
-            in_char_class = true;
-            i += 1;
-            continue;
-        }
-
-        if b == b'(' {
-            let next = bytes.get(i + 1).copied();
-            // `(?...)` constructs and `(*VERB)` control verbs are never
-            // unnamed captures.
-            if next != Some(b'?') && next != Some(b'*') {
-                positions.push(i);
-            }
-        }
-
-        i += 1;
-    }
-
-    positions
 }
 
 /// Rewrite `$1`..`$9` and `${1}`..`${9}` references inside a raw argument

--- a/plugins/builtin/security/nginx_rift/src/lib.rs
+++ b/plugins/builtin/security/nginx_rift/src/lib.rs
@@ -1889,4 +1889,73 @@ http {
         assert_eq!(spec.min_nginx_version.as_deref(), Some("0.6.27"));
         assert_eq!(spec.max_nginx_version.as_deref(), Some("1.30.1"));
     }
+
+    /// Regexes whose capture-scanning this plugin gets from
+    /// `nginx_lint_plugin::helpers`, where the scanner used to disagree with
+    /// PCRE. Each autofix below was verified to load on nginx 1.29, as was the
+    /// config it replaces.
+    ///
+    /// The comment case is the one that mattered: the scanner used to report
+    /// the `(` *inside* `(?#(`, so this plugin emitted
+    /// `"^/a(?#(?<cap1>)/(?<cap2>.*)$"` — the comment swallowed `(?<cap1>`, and
+    /// nginx refused to start with `unknown "cap1" variable`.
+    #[test]
+    fn autofix_is_correct_for_regexes_the_scanner_used_to_misread() {
+        let cases = [
+            // (regex, expected rewritten regex)
+            (r"^/a(?# [ )(x)$", r"^/a(?# [ )(?<cap1>x)$"),
+            (r"^/a(*MARK:[)(x)$", r"^/a(*MARK:[)(?<cap1>x)$"),
+            (r"^/a(?#()/(.*)$", r"^/a(?#()/(?<cap1>.*)$"),
+            (r"^/a[]()]/(x)$", r"^/a[]()]/(?<cap1>x)$"),
+            (r"^/a\Q(a)\E/(x)$", r"^/a\Q(a)\E/(?<cap1>x)$"),
+        ];
+
+        for (regex, expected) in cases {
+            let src = format!(
+                "http {{\n  server {{\n    location ~ \"{regex}\" {{\n      \
+                 rewrite \"{regex}\" /internal?migrated=true;\n      \
+                 set $original_endpoint $1;\n    }}\n  }}\n}}\n"
+            );
+            let errors = PluginTestRunner::new(NginxRiftPlugin)
+                .check_string(&src)
+                .expect("check failed");
+            let rewritten: Vec<&str> = errors
+                .iter()
+                .flat_map(|e| e.fixes.iter())
+                .map(|f| f.new_text.as_str())
+                .collect();
+
+            assert!(
+                rewritten.contains(&format!("\"{expected}\"").as_str()),
+                "{regex}: expected the rewrite regex to become {expected}, got {rewritten:?}"
+            );
+        }
+    }
+
+    /// A branch reset makes both parens group 1, so naming them apart is
+    /// invalid PCRE (`different names for subpatterns of the same number`) and
+    /// nginx will not start. This plugin has no guard for it and emits the
+    /// broken fix — pinned as a known bug, tracked separately. Predates the
+    /// helper extraction: the pre-move scanner returned the same positions.
+    #[test]
+    fn known_bug_branch_reset_autofix_is_invalid() {
+        let src = "http {\n  server {\n    location ~ \"^/(?|(a)|(b))$\" {\n      \
+                   rewrite \"^/(?|(a)|(b))$\" /internal?migrated=true;\n      \
+                   set $original_endpoint $1;\n    }\n  }\n}\n";
+        let errors = PluginTestRunner::new(NginxRiftPlugin)
+            .check_string(src)
+            .expect("check failed");
+        let rewritten: Vec<&str> = errors
+            .iter()
+            .flat_map(|e| e.fixes.iter())
+            .map(|f| f.new_text.as_str())
+            .collect();
+
+        assert!(
+            rewritten
+                .iter()
+                .any(|r| r.contains("cap1") && r.contains("cap2")),
+            "expected the (known bad) two-name rewrite, got {rewritten:?}"
+        );
+    }
 }

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -76,6 +76,9 @@ mod embedded {
     /// map-missing-default plugin
     pub const MAP_MISSING_DEFAULT: &[u8] =
         include_bytes!("../../target/builtin-plugins/map_missing_default.wasm");
+    /// map-unnamed-capture plugin
+    pub const MAP_UNNAMED_CAPTURE: &[u8] =
+        include_bytes!("../../target/builtin-plugins/map_unnamed_capture.wasm");
     /// ssl-on-deprecated plugin
     pub const SSL_ON_DEPRECATED: &[u8] =
         include_bytes!("../../target/builtin-plugins/ssl_on_deprecated.wasm");
@@ -303,6 +306,7 @@ const PLUGIN_ENTRIES: &[(&str, &[u8])] = &[
         embedded::CLIENT_MAX_BODY_SIZE_NOT_SET,
     ),
     ("nginx-rift", embedded::NGINX_RIFT),
+    ("map-unnamed-capture", embedded::MAP_UNNAMED_CAPTURE),
 ];
 
 #[cfg(all(test, feature = "wasm-builtin-plugins"))]

--- a/src/plugin/component_rule.rs
+++ b/src/plugin/component_rule.rs
@@ -1310,6 +1310,10 @@ mod tests {
             "plugins/builtin/best_practices/client_max_body_size_not_set",
         ),
         ("nginx_rift", "plugins/builtin/security/nginx_rift"),
+        (
+            "map_unnamed_capture",
+            "plugins/builtin/security/map_unnamed_capture",
+        ),
     ];
 
     /// `ALL_BUILTIN_PLUGIN_DIRS` is a third, hand-maintained table alongside

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -61,6 +61,7 @@ pub const BUILTIN_PLUGIN_NAMES: &[&str] = &[
     "proxy-missing-host-header",
     "client-max-body-size-not-set",
     "nginx-rift",
+    "map-unnamed-capture",
 ];
 
 /// Check if a rule name is a builtin plugin

--- a/src/plugin/native_builtin.rs
+++ b/src/plugin/native_builtin.rs
@@ -23,6 +23,9 @@ pub fn load_native_builtin_plugins() -> Vec<Box<dyn LintRule>> {
             weak_ssl_ciphers_plugin::WeakSslCiphersPlugin,
         >::new()),
         Box::new(NativePluginRule::<nginx_rift_plugin::NginxRiftPlugin>::new()),
+        Box::new(NativePluginRule::<
+            map_unnamed_capture_plugin::MapUnnamedCapturePlugin,
+        >::new()),
         // Style plugins
         Box::new(NativePluginRule::<
             space_before_semicolon_plugin::SpaceBeforeSemicolonPlugin,


### PR DESCRIPTION
Adds a `security/map-unnamed-capture` rule for nginx **CVE-2026-42533** (stale regex captures), plus the helper extraction it needed.

## The bug

`ngx_http_regex_exec()` reallocates the shared `r->captures` array when a *capturing* regex runs with `realloc_captures` set, but — before the fix — leaves `r->ncaptures` at its previous value and returns early on a mismatch. A later read of an unnamed positional capture (`$1`..`$9`) then indexes into the freshly-allocated, uninitialized array: an out-of-bounds read, potential RCE. Upstream fix [`0cca8e055a2d`](https://github.com/nginx/nginx/commit/0cca8e055a2d909f1a00c2071665b502ec2fe94c) adds one line, `r->ncaptures = 0;`, at the realloc site. Fixed in **1.30.4** and **1.31.3**.

## What the rule does

Warns when a `map` regex entry uses an unnamed capture group, and autofixes `(` → `(?:` when that is provably safe.

**Not scoped to `volatile` maps.** `volatile` guarantees the regex re-runs inside the clone, but it is not required: `ngx_http_subrequest()` shares the variable cache rather than copying it (`sr->variables = r->variables`), so a cached map is equally exposed whenever its *first* evaluation lands inside the clone. Two stock callers pass `NGX_HTTP_SUBREQUEST_CLONE` — `slice`, and the background subrequest of `proxy_cache_background_update`. Under the latter the clone is created before `create_request` and the main request then answers from cache without evaluating `proxy_set_header`, leaving the background subrequest as the map's first evaluator. A non-volatile map has been observed crashing a worker that way. Note the reach does not depend on `slice` being compiled in (it is not a build default; the background-update path needs no optional module).

**`stream` is excluded**: `ngx_stream_regex_exec()` allocates `s->captures` only when it is null — no `realloc_captures`, no subrequests, so the stale count cannot arise.

**Version window `1.9.8`..`1.31.2`.** The vulnerability report says 0.9.6+ (when `map` learned regex entries), but the bug also needs a cloned subrequest, and `NGX_HTTP_SUBREQUEST_CLONE` arrived with the slice module in 1.9.8.

### Known blind spot

The rule reports only **unnamed** captures, so a map whose captures are already named is never reported — even though it still reallocates and still arms the bug for any unnamed `$1` read elsewhere. This is not a rounding error: measured on nginx 1.29, a named map capture with an unnamed `$1` consumer fails **100% of requests while the rule reports nothing**. Silence from this rule means "no map regex has an unnamed capture", not "this config is safe". Catching the rest needs the `$1`..`$9` readers checked too, which is out of scope here. `with_why` says so explicitly rather than implying the opposite.

## Autofix

Rewrites each unnamed `(` to `(?:`, but only when the entry's value reads no positional capture **and** the pattern does not reference a group by number. That case is also the *strongest* remediation: `ngx_http_regex_exec()` reallocates only `if (re->ncaptures)`, and PCRE counts named groups, so a named capture still reallocates and only makes its own read safe; removing the last capture stops the realloc outright. `autofix_keeps_the_subrequest_working` shows this end-to-end — the autofixed config works on an affected build **with the unnamed `$1` consumer left untouched**.

Naming a capture cannot be autofixed: the value *and* every consuming `location`/`if`/`rewrite` must change, which block that is depends on runtime regex order, may live in another included file, and needs a collision-free name.

## Container tests

They run the flagged pattern against real nginx and show it breaks on affected builds and works on fixed ones, with the same config either way.

They do **not** assert a SIGSEGV. Whether the out-of-bounds read faults depends on what the uninitialized memory holds, which varies by CPU: the repro crashes 8/8 on arm64 and never on x86_64. What is deterministic on both is that the subrequest breaks — the read either faults (arm64) or makes nginx fail the subrequest internally (x86_64: `unexpected status code 500 in slice response`). The signature is taken from the client (every request fails) and the upstream's access log (an empty `$1`, the fix's `ncaptures = 0`, appears only on fixed builds).

Verified across {arm64, x86_64} × {1.29, 1.30.3, 1.30.4, 1.31.3}; the 1.30.3 → 1.30.4 boundary lands exactly on the upstream fix, and the same test asserts opposite behaviour either side of it.

**The signature is asymmetric and the tests say so.** A failure proves the bug; a clean run only means the stale read missed anything interesting. openresty 1.31.1.1 and freenginx 1.31.3 both ship the *unfixed* code (verified by source — openresty's patch set touches only OpenSSL) yet run this repro clean, because the read lands on zeroed memory. They are skipped rather than declared fixed. Images built without `--with-http_slice_module` are skipped too, detected from `nginx -V`.

## This also changes `nginx_rift`

The rule needed `nginx_rift`'s private regex-capture helpers, so they moved to
`nginx_lint_plugin::helpers` — and the scanner defects fixed here therefore change
`nginx_rift` too, for nine pattern classes:

| pattern | before | after |
|---|---|---|
| `[]()]`, `[^]()]` | `[2]`, `[3]` | `[]` |
| `[[:alpha:]()]`, `[[:^print:]()]` | `[10]`, `[11]` | `[]` |
| `\Q(a)\E` | `[2]` | `[]` |
| `(?# [ )(a)` | `[]` | `[7]` |
| `^/a(?#()/(.*)$` | `[6, 9]` | `[9]` |
| `(*MARK:[)(a)` | `[]` | `[9]` |
| `regex_has_named_capture("(?'a'x)(y)")` | `false` | `true` |

Every one is a fix, and the last two matter most: `nginx_rift` used to emit
`"^/a(?#(?<cap1>)/(?<cap2>.*)$"` for the comment case — the comment swallows
`(?<cap1>`, so nginx refused to start with `unknown "cap1" variable" — and it used
to renumber the groups around a `(?'a'...)`, silently changing a live `rewrite`'s
target. Both are fixed. Original and rewritten configs were checked to load on
nginx 1.29 for each pattern, and `autofix_is_correct_for_regexes_the_scanner_used_to_misread`
fails against the pre-PR scanner.

`nginx_rift`'s 54 existing tests pass, but they never covered these shapes, so
that was not evidence either way — hence the new tests.

**Not affected:** its branch-reset bug (`(?|(a)|(b))` → two names for group 1 →
nginx won't start) predates this PR. The pre-PR scanner returns the same
positions; `known_bug_branch_reset_autofix_is_invalid` passes against both, and
the fix belongs with `nginx_rift`'s rename logic, separately.

## Review notes

Six defects were found and fixed after the initial commit — none by self-review; all by independent audits (one built a C oracle against libpcre2 and differential-fuzzed 40k patterns). Worth flagging because they cluster:

- **The autofix corrupted quoted keys.** The parser returns `name` decoded but `name_span` covering the raw token, so deriving the pattern offset from `name.len()` was off by the opening quote. nginx requires quoting for `{n,m}`, so `"~^/a{2,3}/(x|y)$"` had its `/` rewritten instead of its `(` — unbalanced parens, config won't load.
- **The autofix deleted the target of a backreference.** The gate scanned only the value for `$1`, never the pattern. `~^/(a|b)/\1$` loads; the rewritten `~^/(?:a|b)/\1$` fails with `pcre_compile() failed`.
- **The scanner never skipped `(?#...)` comment bodies**, though its doc claimed it did. A `[` or `\Q` in comment prose opened a class or literal span that never closed, hiding every later capture — a silent false negative on an affected config.
- **Negated POSIX classes `[[:^alpha:]]` ended early**, so `[[:^print:]()]` reported a capture PCRE does not have; the rewrite still compiles, silently adding `?` and `:` as class members.
- **`regex_has_named_capture` didn't know `(?'name'...)`** while `find_unnamed_capture_positions` knows all three syntaxes. The divergence defeats nginx_rift's bail-out; a live `rewrite` silently changed its target from `/out/x` to `/out/y`.
- **Three fixtures were configs nginx refuses to load.** `${1}` is not the braced form of `$1` — `ngx_http_script_compile()` tests the digit before the brace, so `${1}` becomes a variable *named* "1" (`unknown "1" variable`). The worst was `002_stream_is_not_reported/expected`, the exemplary *post-fix* config. They survived because `test_fixtures` only asserts "error/ reports something, expected/ reports nothing" — it never applies fixes and never asks nginx whether the config is real. All fixtures and examples now load on nginx:1.29, checked rather than assumed.

`stream` maps were also a false positive, with a test asserting that behaviour.

Each fix has a regression test verified to fail against the previous code.

## Commits

- `refactor:` move the regex capture helpers out of `nginx_rift` into `nginx_lint_plugin::helpers` (no behaviour change *at that commit* — see above for what the later scanner fixes change)
- `feat:` the rule, its registration, autofix and tests
- `fix:` correct the autofix's source offsets for quoted keys, and exclude `stream`
- `fix:` make the container tests work on x86_64, openresty and freenginx
- `docs:` correct why forks are skipped
- `test:` add a fixture covering the stream scope
- `fix:` three regex-scanner false positives (char classes, POSIX classes, `\Q`)
- `fix:` refuse the autofix when the pattern references a group by number
- `fix:` four more scanner defects found by differential fuzzing
- `fix:` stop shipping fixtures nginx cannot load
- `test:` pin the `nginx_rift` behaviour this PR changes, and rename `find_unescaped_close_paren`
