### PR TITLE
Fix comment parsing inside multiline directive

### DIFF
--- a/crates/nginx-lint-parser/src/parser.rs
+++ b/crates/nginx-lint-parser/src/parser.rs
@@ -76,10 +76,14 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Consume whitespace and newline tokens (trivia), adding them to the tree.
+    /// Consume whitespace, newline and comment tokens (trivia), adding them
+    /// to the tree.
     fn eat_trivia(&mut self) {
         while let Some(kind) = self.current() {
-            if kind == SyntaxKind::WHITESPACE || kind == SyntaxKind::NEWLINE {
+            if kind == SyntaxKind::WHITESPACE
+                || kind == SyntaxKind::NEWLINE
+                || kind == SyntaxKind::COMMENT
+            {
                 self.bump();
             } else {
                 break;
@@ -92,7 +96,10 @@ impl<'a> Parser<'a> {
         let mut i = self.pos;
         while i < self.tokens.len() {
             let kind = self.tokens[i].0;
-            if kind != SyntaxKind::WHITESPACE && kind != SyntaxKind::NEWLINE {
+            if kind != SyntaxKind::WHITESPACE
+                && kind != SyntaxKind::NEWLINE
+                && kind != SyntaxKind::COMMENT
+            {
                 return Some(kind);
             }
             i += 1;
@@ -241,12 +248,15 @@ impl<'a> Parser<'a> {
     /// span multiple lines (e.g. `log_format ... '...'\n    "...";`).
     fn parse_arguments(&mut self) {
         loop {
-            // Peek past whitespace and newlines to see if next meaningful token
-            // is an argument.
+            // Peek past whitespace, newlines and comments to see if the next
+            // meaningful token is an argument.
             let mut lookahead = self.pos;
             while lookahead < self.tokens.len() {
                 let kind = self.tokens[lookahead].0;
-                if kind == SyntaxKind::WHITESPACE || kind == SyntaxKind::NEWLINE {
+                if kind == SyntaxKind::WHITESPACE
+                    || kind == SyntaxKind::NEWLINE
+                    || kind == SyntaxKind::COMMENT
+                {
                     lookahead += 1;
                 } else {
                     break;
@@ -258,7 +268,8 @@ impl<'a> Parser<'a> {
             let next_kind = self.tokens[lookahead].0;
 
             if is_argument_kind(next_kind) {
-                // Consume trivia (whitespace + newlines) before the argument
+                // Consume trivia (whitespace + newlines + comments) before
+                // the argument
                 self.eat_trivia();
                 self.bump(); // the argument token
             } else {
@@ -584,6 +595,51 @@ mod tests {
     }
 
     // ── Lossless round-trip tests ───────────────────────────────────
+
+    // ── Comments inside multi-line directives ───────────────────────
+
+    #[test]
+    fn multiline_directive_with_comment_between_args() {
+        let source = "set_by_lua_file $var\narg1\n# Comment\narg2;\n";
+        let root = assert_no_errors(source);
+        assert_lossless(source);
+
+        // Everything up to the semicolon belongs to one directive,
+        // including the comment line between the arguments.
+        let dir = first_directive(&root);
+        let kinds = child_kinds(&dir);
+        assert!(kinds.contains(&SyntaxKind::COMMENT));
+        assert!(kinds.contains(&SyntaxKind::SEMICOLON));
+    }
+
+    #[test]
+    fn comment_before_semicolon() {
+        let source = "listen 80\n# comment\n;";
+        assert_no_errors(source);
+        assert_lossless(source);
+    }
+
+    #[test]
+    fn comment_before_block() {
+        let source = "server # comment\n{\n    listen 80;\n}";
+        let root = assert_no_errors(source);
+        assert_lossless(source);
+
+        let dir = first_directive(&root);
+        assert!(child_kinds(&dir).contains(&SyntaxKind::BLOCK));
+    }
+
+    #[test]
+    fn missing_semicolon_before_standalone_comment_still_error() {
+        let source = "listen 80\n# comment\n";
+        let (root, errors) = parse_source(source);
+        assert_lossless(source);
+        assert!(!errors.is_empty(), "should report missing semicolon");
+
+        // The trailing comment must stay outside the directive node.
+        let dir = first_directive(&root);
+        assert!(!child_kinds(&dir).contains(&SyntaxKind::COMMENT));
+    }
 
     #[test]
     fn lossless_empty() {

--- a/crates/nginx-lint-parser/src/rowan_to_ast.rs
+++ b/crates/nginx-lint-parser/src/rowan_to_ast.rs
@@ -290,8 +290,8 @@ impl<'a> ConvertCtx<'a> {
 
         for child in children.iter().skip(name_idx + 1) {
             match child.kind() {
-                SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE => continue,
-                SyntaxKind::SEMICOLON | SyntaxKind::COMMENT => break,
+                SyntaxKind::WHITESPACE | SyntaxKind::NEWLINE | SyntaxKind::COMMENT => continue,
+                SyntaxKind::SEMICOLON => break,
                 SyntaxKind::BLOCK => break,
                 kind if is_argument_token(kind) => {
                     if let Some(token) = child.as_token() {
@@ -753,6 +753,19 @@ mod tests {
         let d = config.directives().next().unwrap();
         assert!(d.trailing_comment.is_some());
         assert_eq!(d.trailing_comment.as_ref().unwrap().text, "# port");
+    }
+
+    #[test]
+    fn multiline_directive_with_comment_between_args() {
+        let config = parse_and_convert("set_by_lua_file $var\narg1\n# Comment\narg2;\n");
+        let dirs: Vec<_> = config.directives().collect();
+        assert_eq!(dirs.len(), 1);
+        let d = dirs[0];
+        assert_eq!(d.name, "set_by_lua_file");
+        assert_eq!(d.args.len(), 3);
+        assert_eq!(d.args[0].raw, "$var");
+        assert_eq!(d.args[1].raw, "arg1");
+        assert_eq!(d.args[2].raw, "arg2");
     }
 
     #[test]


### PR DESCRIPTION
This commit fixes a syntax-error when using comments for multi-line directives, e.g.:
```nginx
set_by_lua_file file.lua $var
arg1
# Some comment
arg2;
```