### PR TITLE
feat(why): document externally loaded plugins

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -286,6 +286,16 @@ jobs:
               echo "$output"
               echo "$output" | jq -e '.errors | length == 0' > /dev/null
 
+              # `why` documents externally loaded plugins, and its examples
+              # are the ones in examples/*.conf (app.py reads them at build
+              # time), so the rendered output must contain that file's text.
+              why=$($NGINX_LINT why --plugins target/py-plugins server-tokens-enabled-py 2>&1)
+              echo "$why"
+              echo "$why" | grep -q 'Rule: server-tokens-enabled-py'
+              echo "$why" | grep -q 'hide nginx version\|Server response header'
+              grep -q "$(sed -n 2p plugins/python/server-tokens-enabled-py/examples/bad.conf)" <<<"$why"
+              $NGINX_LINT why --list --plugins target/py-plugins 2>&1 | grep -q 'server-tokens-enabled-py'
+
   typescript-plugin:
     name: TypeScript Plugin
     runs-on: ubuntu-latest

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -329,7 +329,12 @@ jobs:
               echo "$why"
               echo "$why" | grep -q 'Rule: server-tokens-enabled-py'
               echo "$why" | grep -q 'hide nginx version\|Server response header'
-              grep -q "$(sed -n 2p plugins/python/server-tokens-enabled-py/examples/bad.conf)" <<<"$why"
+              # -F, and a non-empty guard: unanchored regex built from file
+              # content would match anything if that line were ever blank,
+              # leaving this assertion passing vacuously.
+              example_line=$(sed -n 2p plugins/python/server-tokens-enabled-py/examples/bad.conf)
+              test -n "${example_line// /}"
+              grep -qF "$example_line" <<<"$why"
               $NGINX_LINT why --list --plugins target/py-plugins 2>&1 | grep -q 'server-tokens-enabled-py'
 
   typescript-plugin:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -54,20 +54,22 @@ pub struct Cli {
     pub context: Option<String>,
 
     /// Directory containing WASM plugins for custom lint rules (requires plugins feature)
+    // global: `why` reads it too, so it has to be accepted after the
+    // subcommand as well as before it
     #[cfg(feature = "plugins")]
-    #[arg(long, value_name = "DIR")]
+    #[arg(long, value_name = "DIR", global = true)]
     pub plugins: Option<PathBuf>,
 
     /// Cache directory for nginx-lint (the WASM plugin compilation cache is stored
     /// under "plugins/" beneath it). Defaults to the per-user cache directory
     /// (e.g. ~/.cache/nginx-lint on Linux). Overrides cache_dir in .nginx-lint.toml.
     #[cfg(feature = "plugins")]
-    #[arg(long, value_name = "DIR", conflicts_with = "no_cache")]
+    #[arg(long, value_name = "DIR", conflicts_with = "no_cache", global = true)]
     pub cache_dir: Option<PathBuf>,
 
     /// Disable the cache (WASM plugins are compiled on every run)
     #[cfg(feature = "plugins")]
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub no_cache: bool,
 
     /// Show profiling information (time spent per rule)

--- a/src/cli/why.rs
+++ b/src/cli/why.rs
@@ -3,11 +3,39 @@ use nginx_lint::docs::RuleDocOwned;
 use nginx_lint_common::nginx_version::format_range;
 use std::process::ExitCode;
 
-/// Collect the documentation for every rule this invocation can see.
+/// Look up one rule, loading plugins only if the name is not a native rule.
 ///
 /// Native rules first, then builtin plugins, then the plugins in a
-/// `--plugins` directory — the same precedence `get_rule_doc_with_plugins`
-/// uses, so a name defined twice resolves to the earlier one.
+/// `--plugins` directory, so a name defined twice resolves to the earlier
+/// one. Checking native rules first also keeps `why <native-rule>` from
+/// compiling and instantiating every builtin WASM component for a name
+/// they cannot supply.
+fn find_rule_doc(name: &str, cli: &Cli) -> Option<RuleDocOwned> {
+    if let Some(doc) = nginx_lint::docs::get_rule_doc(name) {
+        return Some(doc.into());
+    }
+
+    #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
+    if let Some(doc) = nginx_lint::docs::get_rule_doc_with_plugins(name) {
+        return Some(doc);
+    }
+
+    #[cfg(feature = "plugins")]
+    if let Some(doc) = external_plugin_docs(cli)
+        .into_iter()
+        .find(|d| d.name == name)
+    {
+        return Some(doc);
+    }
+
+    let _ = cli;
+    None
+}
+
+/// Collect the documentation for every rule this invocation can see.
+///
+/// Same precedence as [`find_rule_doc`]; used by `--list`, which needs all
+/// of them anyway.
 fn collect_rule_docs(cli: &Cli) -> Vec<RuleDocOwned> {
     // Only the plugin features below extend this
     #[allow(unused_mut)]
@@ -34,32 +62,32 @@ fn collect_rule_docs(cli: &Cli) -> Vec<RuleDocOwned> {
     docs
 }
 
-/// Load the docs for a `--plugins` directory, if one was given.
+/// Resolve the compilation cache from the CLI flags.
 ///
-/// A load failure is reported and treated as "no external rules": the user
-/// then sees why the directory did not contribute, rather than an
-/// unexplained "Unknown rule".
+/// Only the flags are honoured; unlike `lint`, `why` does not read
+/// .nginx-lint.toml, so cache_dir from the config file does not apply.
 #[cfg(feature = "plugins")]
-fn external_plugin_docs(cli: &Cli) -> Vec<RuleDocOwned> {
-    use colored::Colorize;
+fn cache_config(cli: &Cli) -> nginx_lint::plugin::CompilationCache {
     use nginx_lint::plugin::CompilationCache;
 
-    let Some(ref dir) = cli.plugins else {
-        return Vec::new();
-    };
-
-    // Only the cache flags are honoured here; unlike `lint`, `why` does not
-    // read .nginx-lint.toml, so cache_dir from the config file does not
-    // apply.
-    let cache = if cli.no_cache {
+    if cli.no_cache {
         CompilationCache::Disabled
     } else if let Some(ref cache_dir) = cli.cache_dir {
         CompilationCache::Directory(cache_dir.clone())
     } else {
         CompilationCache::Default
+    }
+}
+
+#[cfg(feature = "plugins")]
+fn external_plugin_docs(cli: &Cli) -> Vec<RuleDocOwned> {
+    use colored::Colorize;
+
+    let Some(ref dir) = cli.plugins else {
+        return Vec::new();
     };
 
-    match nginx_lint::docs::external_plugin_docs(dir, cache) {
+    match nginx_lint::docs::external_plugin_docs(dir, cache_config(cli)) {
         Ok(docs) => docs,
         Err(e) => {
             eprintln!(
@@ -76,9 +104,14 @@ fn external_plugin_docs(cli: &Cli) -> Vec<RuleDocOwned> {
 pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
     use colored::Colorize;
 
-    let docs = collect_rule_docs(cli);
+    // The builtin WASM plugins are compiled through a process-global
+    // loader, so the cache flags have to reach it before anything loads
+    // them (mirrors run_lint).
+    #[cfg(all(feature = "wasm-builtin-plugins", feature = "plugins"))]
+    nginx_lint::plugin::builtin::configure_builtin_plugin_cache(cache_config(cli));
 
     if list {
+        let docs = collect_rule_docs(cli);
         eprintln!("{}", "Available rules:".bold());
         eprintln!();
 
@@ -134,9 +167,9 @@ pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
         }
     };
 
-    match docs.iter().find(|doc| doc.name == rule_name) {
+    match find_rule_doc(&rule_name, cli) {
         Some(doc) => {
-            print_rule_doc(doc);
+            print_rule_doc(&doc);
             ExitCode::SUCCESS
         }
         None => {

--- a/src/cli/why.rs
+++ b/src/cli/why.rs
@@ -1,62 +1,119 @@
+use crate::Cli;
+use nginx_lint::docs::RuleDocOwned;
 use nginx_lint_common::nginx_version::format_range;
 use std::process::ExitCode;
 
-pub fn run_why(rule: Option<String>, list: bool) -> ExitCode {
+/// Collect the documentation for every rule this invocation can see.
+///
+/// Native rules first, then builtin plugins, then the plugins in a
+/// `--plugins` directory — the same precedence `get_rule_doc_with_plugins`
+/// uses, so a name defined twice resolves to the earlier one.
+fn collect_rule_docs(cli: &Cli) -> Vec<RuleDocOwned> {
+    // Only the plugin features below extend this
+    #[allow(unused_mut)]
+    let mut docs: Vec<RuleDocOwned> = nginx_lint::docs::all_rule_docs()
+        .iter()
+        .map(|doc| (*doc).into())
+        .collect();
+
+    #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
+    {
+        // all_rule_docs_with_plugins() also includes the native rules, so
+        // take only the plugin half to avoid listing them twice.
+        docs.extend(
+            nginx_lint::docs::all_rule_docs_with_plugins()
+                .into_iter()
+                .filter(|doc| doc.is_plugin),
+        );
+    }
+
+    #[cfg(feature = "plugins")]
+    docs.extend(external_plugin_docs(cli));
+
+    let _ = cli;
+    docs
+}
+
+/// Load the docs for a `--plugins` directory, if one was given.
+///
+/// A load failure is reported and treated as "no external rules": the user
+/// then sees why the directory did not contribute, rather than an
+/// unexplained "Unknown rule".
+#[cfg(feature = "plugins")]
+fn external_plugin_docs(cli: &Cli) -> Vec<RuleDocOwned> {
+    use colored::Colorize;
+    use nginx_lint::plugin::CompilationCache;
+
+    let Some(ref dir) = cli.plugins else {
+        return Vec::new();
+    };
+
+    // Only the cache flags are honoured here; unlike `lint`, `why` does not
+    // read .nginx-lint.toml, so cache_dir from the config file does not
+    // apply.
+    let cache = if cli.no_cache {
+        CompilationCache::Disabled
+    } else if let Some(ref cache_dir) = cli.cache_dir {
+        CompilationCache::Directory(cache_dir.clone())
+    } else {
+        CompilationCache::Default
+    };
+
+    match nginx_lint::docs::external_plugin_docs(dir, cache) {
+        Ok(docs) => docs,
+        Err(e) => {
+            eprintln!(
+                "{} failed to load plugins from {}: {}",
+                "Warning:".yellow().bold(),
+                dir.display(),
+                e
+            );
+            Vec::new()
+        }
+    }
+}
+
+pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
     use colored::Colorize;
 
+    let docs = collect_rule_docs(cli);
+
     if list {
-        // List all rules
         eprintln!("{}", "Available rules:".bold());
         eprintln!();
 
-        #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
-        {
-            use nginx_lint::docs::all_rule_docs_with_plugins;
-            let docs = all_rule_docs_with_plugins();
-            let mut by_category: std::collections::HashMap<&str, Vec<_>> =
-                std::collections::HashMap::new();
-            for doc in &docs {
-                by_category
-                    .entry(doc.category.as_str())
-                    .or_default()
-                    .push(doc);
-            }
+        let mut by_category: std::collections::BTreeMap<&str, Vec<&RuleDocOwned>> =
+            std::collections::BTreeMap::new();
+        for doc in &docs {
+            by_category
+                .entry(doc.category.as_str())
+                .or_default()
+                .push(doc);
+        }
 
-            for category in nginx_lint::RULE_CATEGORIES {
-                if let Some(rules) = by_category.get(category) {
-                    eprintln!("  {} {}", "▸".cyan(), category.bold());
-                    for doc in rules {
-                        let suffix = if doc.is_plugin { " (plugin)" } else { "" };
-                        eprintln!(
-                            "    {} - {}{}",
-                            doc.name.yellow(),
-                            doc.description,
-                            suffix.dimmed()
-                        );
-                    }
-                    eprintln!();
-                }
+        let print_category = |category: &str, rules: &[&RuleDocOwned]| {
+            eprintln!("  {} {}", "▸".cyan(), category.bold());
+            for doc in rules {
+                let suffix = if doc.is_plugin { " (plugin)" } else { "" };
+                eprintln!(
+                    "    {} - {}{}",
+                    doc.name.yellow(),
+                    doc.description,
+                    suffix.dimmed()
+                );
+            }
+            eprintln!();
+        };
+
+        for category in nginx_lint::RULE_CATEGORIES {
+            if let Some(rules) = by_category.remove(category) {
+                print_category(category, &rules);
             }
         }
-        #[cfg(not(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins")))]
-        {
-            use nginx_lint::docs::all_rule_docs;
-            let docs = all_rule_docs();
-            let mut by_category: std::collections::HashMap<&str, Vec<_>> =
-                std::collections::HashMap::new();
-            for doc in docs {
-                by_category.entry(doc.category).or_default().push(doc);
-            }
-
-            for category in nginx_lint::RULE_CATEGORIES {
-                if let Some(rules) = by_category.get(category) {
-                    eprintln!("  {} {}", "▸".cyan(), category.bold());
-                    for doc in rules {
-                        eprintln!("    {} - {}", doc.name.yellow(), doc.description);
-                    }
-                    eprintln!();
-                }
-            }
+        // A plugin may declare a category of its own; print what is left so
+        // it is listed rather than silently dropped.
+        for (category, rules) in by_category {
+            print_category(category, &rules);
         }
 
         eprintln!(
@@ -77,89 +134,24 @@ pub fn run_why(rule: Option<String>, list: bool) -> ExitCode {
         }
     };
 
-    #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
-    {
-        use nginx_lint::docs::get_rule_doc_with_plugins;
-        match get_rule_doc_with_plugins(&rule_name) {
-            Some(doc) => {
-                print_rule_doc_owned(&doc);
-                ExitCode::SUCCESS
-            }
-            None => {
-                eprintln!("{} Unknown rule: {}", "Error:".red().bold(), rule_name);
-                eprintln!();
-                eprintln!(
-                    "Use {} to see all available rules.",
-                    "nginx-lint why --list".cyan()
-                );
-                ExitCode::from(1)
-            }
+    match docs.iter().find(|doc| doc.name == rule_name) {
+        Some(doc) => {
+            print_rule_doc(doc);
+            ExitCode::SUCCESS
         }
-    }
-    #[cfg(not(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins")))]
-    {
-        use nginx_lint::docs::get_rule_doc;
-        match get_rule_doc(&rule_name) {
-            Some(doc) => {
-                print_rule_doc(doc);
-                ExitCode::SUCCESS
-            }
-            None => {
-                eprintln!("{} Unknown rule: {}", "Error:".red().bold(), rule_name);
-                eprintln!();
-                eprintln!(
-                    "Use {} to see all available rules.",
-                    "nginx-lint why --list".cyan()
-                );
-                ExitCode::from(1)
-            }
+        None => {
+            eprintln!("{} Unknown rule: {}", "Error:".red().bold(), rule_name);
+            eprintln!();
+            eprintln!(
+                "Use {} to see all available rules.",
+                "nginx-lint why --list".cyan()
+            );
+            ExitCode::from(1)
         }
     }
 }
 
-#[cfg(not(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins")))]
-fn print_rule_doc(doc: &nginx_lint::docs::RuleDoc) {
-    use colored::Colorize;
-
-    eprintln!();
-    eprintln!("{} {}", "Rule:".bold(), doc.name.yellow());
-    eprintln!("{} {}", "Category:".bold(), doc.category);
-    eprintln!("{} {}", "Severity:".bold(), doc.severity);
-    if let Some(range) = format_range(doc.min_nginx_version, doc.max_nginx_version) {
-        eprintln!("{} {}", "Applies to:".bold(), range);
-    }
-    eprintln!();
-    eprintln!("{}", "Why:".bold());
-    for line in doc.why.lines() {
-        eprintln!("  {}", line);
-    }
-    eprintln!();
-    eprintln!("{}", "Bad Example:".bold().red());
-    eprintln!("{}", "─".repeat(60).dimmed());
-    for line in doc.bad_example.lines() {
-        eprintln!("  {}", line);
-    }
-    eprintln!("{}", "─".repeat(60).dimmed());
-    eprintln!();
-    eprintln!("{}", "Good Example:".bold().green());
-    eprintln!("{}", "─".repeat(60).dimmed());
-    for line in doc.good_example.lines() {
-        eprintln!("  {}", line);
-    }
-    eprintln!("{}", "─".repeat(60).dimmed());
-
-    if !doc.references.is_empty() {
-        eprintln!();
-        eprintln!("{}", "References:".bold());
-        for reference in doc.references {
-            eprintln!("  • {}", reference.cyan());
-        }
-    }
-    eprintln!();
-}
-
-#[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
-fn print_rule_doc_owned(doc: &nginx_lint::docs::RuleDocOwned) {
+fn print_rule_doc(doc: &RuleDocOwned) {
     use colored::Colorize;
 
     eprintln!();

--- a/src/cli/why.rs
+++ b/src/cli/why.rs
@@ -99,18 +99,25 @@ fn external_plugin_docs(cli: &Cli) -> Result<Vec<RuleDocOwned>, ()> {
 pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
     use colored::Colorize;
 
-    // Validate the directory before anything else: looking a native rule up
-    // never loads plugins, so without this the same mistyped --plugins path
-    // would be reported for one rule name and silently ignored for another.
+    // Validate the plugin options before anything else: looking a native
+    // rule up never loads plugins, so without this the same unusable
+    // --plugins or --cache-dir would be reported for one rule name and
+    // silently ignored for another.
     #[cfg(feature = "plugins")]
-    if let Some(ref dir) = cli.plugins
-        && !dir.is_dir()
-    {
-        eprintln!(
-            "Error loading plugins: Plugin directory not found: {}",
-            dir.display()
-        );
-        return ExitCode::from(2);
+    if let Some(ref dir) = cli.plugins {
+        if !dir.is_dir() {
+            eprintln!(
+                "Error loading plugins: Plugin directory not found: {}",
+                dir.display()
+            );
+            return ExitCode::from(2);
+        }
+        // Building the loader validates the cache configuration; it stops
+        // short of compiling any plugin.
+        if let Err(e) = nginx_lint::plugin::PluginLoader::new_with_cache(cache_config(cli)) {
+            eprintln!("Error loading plugins: {}", e);
+            return ExitCode::from(2);
+        }
     }
 
     // The builtin WASM plugins are compiled through a process-global

--- a/src/cli/why.rs
+++ b/src/cli/why.rs
@@ -10,33 +10,33 @@ use std::process::ExitCode;
 /// one. Checking native rules first also keeps `why <native-rule>` from
 /// compiling and instantiating every builtin WASM component for a name
 /// they cannot supply.
-fn find_rule_doc(name: &str, cli: &Cli) -> Option<RuleDocOwned> {
+fn find_rule_doc(name: &str, cli: &Cli) -> Result<Option<RuleDocOwned>, ()> {
     if let Some(doc) = nginx_lint::docs::get_rule_doc(name) {
-        return Some(doc.into());
+        return Ok(Some(doc.into()));
     }
 
     #[cfg(any(feature = "wasm-builtin-plugins", feature = "native-builtin-plugins"))]
     if let Some(doc) = nginx_lint::docs::get_rule_doc_with_plugins(name) {
-        return Some(doc);
+        return Ok(Some(doc));
     }
 
     #[cfg(feature = "plugins")]
-    if let Some(doc) = external_plugin_docs(cli)
+    if let Some(doc) = external_plugin_docs(cli)?
         .into_iter()
         .find(|d| d.name == name)
     {
-        return Some(doc);
+        return Ok(Some(doc));
     }
 
     let _ = cli;
-    None
+    Ok(None)
 }
 
 /// Collect the documentation for every rule this invocation can see.
 ///
 /// Same precedence as [`find_rule_doc`]; used by `--list`, which needs all
 /// of them anyway.
-fn collect_rule_docs(cli: &Cli) -> Vec<RuleDocOwned> {
+fn collect_rule_docs(cli: &Cli) -> Result<Vec<RuleDocOwned>, ()> {
     // Only the plugin features below extend this
     #[allow(unused_mut)]
     let mut docs: Vec<RuleDocOwned> = nginx_lint::docs::all_rule_docs()
@@ -56,10 +56,10 @@ fn collect_rule_docs(cli: &Cli) -> Vec<RuleDocOwned> {
     }
 
     #[cfg(feature = "plugins")]
-    docs.extend(external_plugin_docs(cli));
+    docs.extend(external_plugin_docs(cli)?);
 
     let _ = cli;
-    docs
+    Ok(docs)
 }
 
 /// Resolve the compilation cache from the CLI flags.
@@ -79,30 +79,39 @@ fn cache_config(cli: &Cli) -> nginx_lint::plugin::CompilationCache {
     }
 }
 
+/// Load the docs for a `--plugins` directory, if one was given.
+///
+/// Returns Err after reporting the failure. `lint` exits 2 when a plugin
+/// directory cannot be loaded, and `why` says nothing useful about a rule
+/// it never managed to load, so it fails the same way rather than
+/// pretending the directory contributed nothing.
 #[cfg(feature = "plugins")]
-fn external_plugin_docs(cli: &Cli) -> Vec<RuleDocOwned> {
-    use colored::Colorize;
-
+fn external_plugin_docs(cli: &Cli) -> Result<Vec<RuleDocOwned>, ()> {
     let Some(ref dir) = cli.plugins else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
-    match nginx_lint::docs::external_plugin_docs(dir, cache_config(cli)) {
-        Ok(docs) => docs,
-        Err(e) => {
-            eprintln!(
-                "{} failed to load plugins from {}: {}",
-                "Warning:".yellow().bold(),
-                dir.display(),
-                e
-            );
-            Vec::new()
-        }
-    }
+    nginx_lint::docs::external_plugin_docs(dir, cache_config(cli)).map_err(|e| {
+        eprintln!("Error loading plugins: {}", e);
+    })
 }
 
 pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
     use colored::Colorize;
+
+    // Validate the directory before anything else: looking a native rule up
+    // never loads plugins, so without this the same mistyped --plugins path
+    // would be reported for one rule name and silently ignored for another.
+    #[cfg(feature = "plugins")]
+    if let Some(ref dir) = cli.plugins
+        && !dir.is_dir()
+    {
+        eprintln!(
+            "Error loading plugins: Plugin directory not found: {}",
+            dir.display()
+        );
+        return ExitCode::from(2);
+    }
 
     // The builtin WASM plugins are compiled through a process-global
     // loader, so the cache flags have to reach it before anything loads
@@ -111,7 +120,9 @@ pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
     nginx_lint::plugin::builtin::configure_builtin_plugin_cache(cache_config(cli));
 
     if list {
-        let docs = collect_rule_docs(cli);
+        let Ok(docs) = collect_rule_docs(cli) else {
+            return ExitCode::from(2);
+        };
         eprintln!("{}", "Available rules:".bold());
         eprintln!();
 
@@ -167,7 +178,12 @@ pub fn run_why(rule: Option<String>, list: bool, cli: &Cli) -> ExitCode {
         }
     };
 
-    match find_rule_doc(&rule_name, cli) {
+    let found = match find_rule_doc(&rule_name, cli) {
+        Ok(found) => found,
+        Err(()) => return ExitCode::from(2),
+    };
+
+    match found {
         Some(doc) => {
             print_rule_doc(&doc);
             ExitCode::SUCCESS

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -169,6 +169,48 @@ pub fn get_rule_doc_with_plugins(name: &str) -> Option<RuleDocOwned> {
         .find(|d| d.name == name)
 }
 
+/// Build a [`RuleDocOwned`] from a loaded rule.
+///
+/// Shared by the builtin-plugin and external-plugin doc paths so a plugin
+/// documents itself the same way wherever it was loaded from.
+#[cfg(any(
+    feature = "wasm-builtin-plugins",
+    feature = "native-builtin-plugins",
+    feature = "plugins"
+))]
+fn rule_to_doc(rule: &dyn crate::linter::LintRule) -> RuleDocOwned {
+    RuleDocOwned {
+        name: rule.name().to_string(),
+        category: rule.category().to_string(),
+        description: rule.description().to_string(),
+        severity: rule.severity().unwrap_or("warning").to_string(),
+        why: rule.why().unwrap_or("").to_string(),
+        bad_example: rule.bad_example().unwrap_or("").to_string(),
+        good_example: rule.good_example().unwrap_or("").to_string(),
+        references: rule.references().unwrap_or_default(),
+        is_plugin: true,
+        min_nginx_version: rule.min_nginx_version().map(String::from),
+        max_nginx_version: rule.max_nginx_version().map(String::from),
+    }
+}
+
+/// Get documentation for the plugins in an external `--plugins` directory.
+///
+/// Unlike the builtin plugins these are not compiled in, so the caller has
+/// to say where they live and how to cache their compilation.
+#[cfg(feature = "plugins")]
+pub fn external_plugin_docs(
+    dir: &std::path::Path,
+    cache: crate::plugin::CompilationCache,
+) -> Result<Vec<RuleDocOwned>, crate::plugin::PluginError> {
+    let loader = crate::plugin::PluginLoader::new_with_cache(cache)?;
+    Ok(loader
+        .load_plugins(dir)?
+        .iter()
+        .map(|rule| rule_to_doc(rule.as_ref()))
+        .collect())
+}
+
 /// Get documentation from native plugins
 #[cfg(feature = "native-builtin-plugins")]
 fn get_builtin_plugin_docs() -> Vec<RuleDocOwned> {
@@ -177,20 +219,8 @@ fn get_builtin_plugin_docs() -> Vec<RuleDocOwned> {
 
     let plugins: Vec<Box<dyn LintRule>> = load_native_builtin_plugins();
     plugins
-        .into_iter()
-        .map(|rule| RuleDocOwned {
-            name: rule.name().to_string(),
-            category: rule.category().to_string(),
-            description: rule.description().to_string(),
-            severity: rule.severity().unwrap_or("warning").to_string(),
-            why: rule.why().unwrap_or("").to_string(),
-            bad_example: rule.bad_example().unwrap_or("").to_string(),
-            good_example: rule.good_example().unwrap_or("").to_string(),
-            references: rule.references().unwrap_or_default(),
-            is_plugin: true,
-            min_nginx_version: rule.min_nginx_version().map(String::from),
-            max_nginx_version: rule.max_nginx_version().map(String::from),
-        })
+        .iter()
+        .map(|rule| rule_to_doc(rule.as_ref()))
         .collect()
 }
 
@@ -207,19 +237,7 @@ fn get_builtin_plugin_docs() -> Vec<RuleDocOwned> {
 
     if let Ok(plugins) = load_builtin_plugins() {
         for plugin in plugins {
-            docs.push(RuleDocOwned {
-                name: plugin.name().to_string(),
-                category: plugin.category().to_string(),
-                description: plugin.description().to_string(),
-                severity: plugin.severity().unwrap_or("warning").to_string(),
-                why: plugin.why().unwrap_or("").to_string(),
-                bad_example: plugin.bad_example().unwrap_or("").to_string(),
-                good_example: plugin.good_example().unwrap_or("").to_string(),
-                references: plugin.references().unwrap_or_default(),
-                is_plugin: true,
-                min_nginx_version: plugin.min_nginx_version().map(String::from),
-                max_nginx_version: plugin.max_nginx_version().map(String::from),
-            });
+            docs.push(rule_to_doc(plugin.as_ref()));
         }
     }
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -230,14 +230,15 @@ fn get_builtin_plugin_docs() -> Vec<RuleDocOwned> {
     not(feature = "native-builtin-plugins")
 ))]
 fn get_builtin_plugin_docs() -> Vec<RuleDocOwned> {
-    use crate::linter::LintRule;
     use crate::plugin::builtin::load_builtin_plugins;
 
     let mut docs = Vec::new();
 
+    // load_builtin_plugins yields concrete ComponentLintRules, not boxed
+    // trait objects, so this coerces rather than calling as_ref()
     if let Ok(plugins) = load_builtin_plugins() {
         for plugin in plugins {
-            docs.push(rule_to_doc(plugin.as_ref()));
+            docs.push(rule_to_doc(&plugin));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
         Some(Commands::Config { command }) => cli::config::run_config(command),
         Some(Commands::Guide) => cli::guide::run_guide(),
         Some(Commands::Web { port, open }) => cli::web::run_web(*port, *open),
-        Some(Commands::Why { rule, list }) => cli::why::run_why(rule.clone(), *list),
+        Some(Commands::Why { rule, list }) => cli::why::run_why(rule.clone(), *list, &cli),
         None => cli::lint::run_lint(cli),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,15 @@ use std::process::ExitCode;
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
+    // clap's conflicts_with does not fire when the two flags straddle the
+    // subcommand (`--cache-dir X why --no-cache`), which `global = true`
+    // makes expressible, so enforce it here as well.
+    #[cfg(feature = "plugins")]
+    if cli.no_cache && cli.cache_dir.is_some() {
+        eprintln!("error: the argument '--cache-dir <DIR>' cannot be used with '--no-cache'");
+        return ExitCode::from(2);
+    }
+
     match &cli.command {
         Some(Commands::Config { command }) => cli::config::run_config(command),
         Some(Commands::Guide) => cli::guide::run_guide(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2864,6 +2864,42 @@ fn test_why_reports_plugin_load_failure() {
     }
 }
 
+#[cfg(feature = "plugins")]
+#[test]
+fn test_why_reports_unusable_cache_dir() {
+    use std::process::Command;
+
+    // Same uniformity requirement for --cache-dir: a cache root that cannot
+    // be used must fail whichever rule was asked for, not just the ones that
+    // happen to reach the plugin loader.
+    let dir = tempfile::tempdir().unwrap();
+    let not_a_dir = dir.path().join("cache-root-is-a-file");
+    std::fs::write(&not_a_dir, b"").unwrap();
+    let plugins_dir = dir.path().join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+
+    for rule in ["--list", "indent", "some-plugin-rule"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+            .arg("why")
+            .arg("--plugins")
+            .arg(&plugins_dir)
+            .arg("--cache-dir")
+            .arg(&not_a_dir)
+            .arg(rule)
+            .output()
+            .expect("Failed to run nginx-lint why");
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{} should exit 2 on an unusable cache dir; got {:?}: {}",
+            rule,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 // ============================================================================
 // CLI --fix tests - unfixable errors must still be reported
 // ============================================================================

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2790,6 +2790,65 @@ fn test_why_command_omits_applies_to_for_unversioned_rule() {
     );
 }
 
+// `why` reads --plugins so externally loaded rules are documented too, not
+// just the builtin ones. These cover the plumbing without needing a built
+// component; that a real plugin's metadata renders is covered end-to-end in
+// CI against the Python example plugin.
+#[cfg(feature = "plugins")]
+#[test]
+fn test_why_accepts_plugins_after_the_subcommand() {
+    use std::process::Command;
+
+    // --plugins is global, so `why --plugins DIR RULE` parses. Before that
+    // it was only accepted ahead of the subcommand, which is not where
+    // anyone types it.
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["why", "--list", "--plugins"])
+        .arg(dir.path())
+        .output()
+        .expect("Failed to run nginx-lint why");
+
+    assert!(
+        output.status.success(),
+        "why --list with an empty plugin dir should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("indent"),
+        "native rules must still be listed; got:\n{}",
+        stderr
+    );
+}
+
+#[cfg(feature = "plugins")]
+#[test]
+fn test_why_reports_plugin_load_failure() {
+    use std::process::Command;
+
+    // A directory that cannot be loaded must say so. Reporting nothing and
+    // falling through to "Unknown rule" is what made the missing --plugins
+    // support confusing in the first place.
+    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+        .args(["why", "--plugins", "/nonexistent-plugin-dir", "some-rule"])
+        .output()
+        .expect("Failed to run nginx-lint why");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to load plugins from"),
+        "expected a load failure warning; got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Unknown rule"),
+        "the lookup should still run after the warning; got:\n{}",
+        stderr
+    );
+}
+
 // ============================================================================
 // CLI --fix tests - unfixable errors must still be reported
 // ============================================================================

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2827,26 +2827,41 @@ fn test_why_accepts_plugins_after_the_subcommand() {
 fn test_why_reports_plugin_load_failure() {
     use std::process::Command;
 
-    // A directory that cannot be loaded must say so. Reporting nothing and
-    // falling through to "Unknown rule" is what made the missing --plugins
-    // support confusing in the first place.
-    let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
-        .args(["why", "--plugins", "/nonexistent-plugin-dir", "some-rule"])
-        .output()
-        .expect("Failed to run nginx-lint why");
+    // An unusable --plugins directory fails the same way `lint` does
+    // (exit 2, same message), and does so regardless of which rule was
+    // asked for. Looking up a native rule never loads plugins, so without
+    // an explicit check the same mistyped path would be reported for one
+    // name and silently ignored for another.
+    for args in [
+        vec!["why", "--plugins", "/nonexistent-plugin-dir", "--list"],
+        vec!["why", "--plugins", "/nonexistent-plugin-dir", "indent"],
+        vec![
+            "why",
+            "--plugins",
+            "/nonexistent-plugin-dir",
+            "some-plugin-rule",
+        ],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_nginx-lint"))
+            .args(&args)
+            .output()
+            .expect("Failed to run nginx-lint why");
 
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("failed to load plugins from"),
-        "expected a load failure warning; got:\n{}",
-        stderr
-    );
-    assert!(
-        stderr.contains("Unknown rule"),
-        "the lookup should still run after the warning; got:\n{}",
-        stderr
-    );
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{:?} should exit 2 like lint does; got {:?}",
+            args,
+            output.status.code()
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("Error loading plugins"),
+            "{:?} should report the load failure; got:\n{}",
+            args,
+            stderr
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #379.

## Problem

`nginx-lint why` documented builtin plugins but never received `--plugins`, so a rule that lints perfectly well from an external directory was invisible to both the single-rule lookup and `--list`:

```console
$ nginx-lint --plugins ./my-plugins why server-tokens-enabled-py
Error: Unknown rule: server-tokens-enabled-py
```

Everything `PluginSpec` carries — `why`, `bad_example`, `good_example`, `references`, which both SDKs have builders for and which plugin authors are encouraged to fill in — was effectively write-only for an external plugin. Nothing in the CLI ever displayed it.

## Change

`run_why` now receives the CLI options, loads the `--plugins` directory with `PluginLoader`, and merges those specs into both lookups. Resolution order is native → builtin plugins → external, so a duplicated name picks the earlier one, matching `get_rule_doc_with_plugins`.

Three things came along because leaving them would have reproduced the same class of bug one layer down:

- **`--plugins` / `--cache-dir` / `--no-cache` are now `global`.** They were only accepted ahead of the subcommand, so `why --plugins DIR RULE` — the form everyone types first — was a parse error. Making them global does mean clap's `conflicts_with` stops firing when `--cache-dir` and `--no-cache` straddle the subcommand, so that pairing is now rejected explicitly in `main()` instead.
- **`--list` prints categories outside `RULE_CATEGORIES`.** The loop only printed the five known buckets, so a plugin declaring its own category landed in the map and was never shown. Verified with a plugin whose category is `observability`.
- **An unusable `--plugins` directory fails like it does for `lint`** — exit 2, same message. It previously warned and continued with exit 0, and because looking up a native rule never reaches the plugins, one mistyped path produced three different outcomes depending on the rule name: an error, a warning, or complete silence. A script validating its build with `why --list --plugins ./dist` read a wrong path as success.

Also cleaned up while in here: `why.rs` had two cfg-gated code paths (borrowed docs without plugin features, owned with) that have collapsed into one owned path, and the `LintRule` → `RuleDocOwned` mapping the two builtin doc functions duplicated moved into a shared `docs::rule_to_doc`.

## Scope cut

`why` honours the cache flags but, unlike `lint`, does not read `cache_dir` from `.nginx-lint.toml` — pulling config-file loading into this subcommand seemed disproportionate. Noting it so it is a decision rather than an oversight.

## Testing

Verified against the Python example plugin from #376:

```console
$ nginx-lint why --plugins <dir> server-tokens-enabled-py

Rule: server-tokens-enabled-py (plugin)
Category: security
Severity: warning

Why:
  When server_tokens is 'on' (the default), nginx includes its version number ...

Bad Example:
  http {
      server_tokens on;
  ...
References:
  • https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
```

- Two new integration tests cover the plumbing without needing a built component: `--plugins` parses after the subcommand, and an unusable directory exits 2 for all three invocation shapes (`--list`, a native rule, a plugin rule).
- The `Test Python plugin integration` CI step gained a `why` check that asserts the rendered Bad Example contains a line from `examples/bad.conf` — the two are the same text now that `app.py` reads the file at build time, so this catches them drifting apart.
- Manually checked: `--list` with and without `--plugins`, the flag in both positions, native rules not duplicated, an unknown category shown, and `--cache-dir --no-cache` still rejected.
- Compiles clean across `--no-default-features --features cli`, `cli,plugins`, `cli,wasm-builtin-plugins`, `cli,native-builtin-plugins`, and the default set; `cargo clippy --workspace --features plugins -- -D clippy::all` and `cargo fmt --check` pass.

## Note on the `wasm-builtin-plugins` build

The first version of this PR did not compile under `--features cli,wasm-builtin-plugins`: `load_builtin_plugins()` returns concrete `ComponentLintRule`s rather than boxed trait objects, so the shared `rule_to_doc` helper needed a coercion, not `as_ref()`. That build is the Makefile's `build-with-wasm-plugins` release target and the README's `cargo install` line, but no CI job builds it, so nothing caught it. Fixed here (and verified by reproducing the error, then confirming the fix, after `make collect-plugins`) — but the coverage gap itself is worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S

