### PR TITLE
ci: type-check the host built with embedded WASM plugins

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -120,6 +120,42 @@ jobs:
           path: wasm-components-${{ matrix.chunk }}.tar.gz
           retention-days: 1
 
+  check-wasm-builtin-host:
+    name: Check Host (wasm-builtin-plugins)
+    # The plugin .wasm files are embedded with include_bytes!, so they have
+    # to exist before the host compiles. Reuse the components the build jobs
+    # already produced rather than rebuilding them here.
+    needs: [wasm-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: "check-wasm-builtin-host"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wasm-plugins-*
+          merge-multiple: true
+      - name: Restore plugin components
+        run: |
+          for f in wasm-components-*.tar.gz; do
+            tar xzf "$f"
+          done
+          make collect-plugins-only
+          ls target/builtin-plugins/
+      - name: Type-check the host with embedded WASM plugins
+        # This is the build behind `make build-with-wasm-plugins` and the
+        # README's cargo install line. No other job compiles it, so code
+        # behind the wasm-builtin-plugins cfg could break unnoticed —
+        # `cargo check` catches that without paying for a release build.
+        run: cargo check --no-default-features --features cli,wasm-builtin-plugins
+
   build-host:
     name: Build Host Binaries
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_DIRS := $(wildcard plugins/builtin/*/*/)
 PLUGIN_NAMES := $(foreach dir,$(PLUGIN_DIRS),$(notdir $(patsubst %/,%,$(dir))))
 PLUGIN_WASMS := $(foreach name,$(PLUGIN_NAMES),target/builtin-plugins/$(name).wasm)
 
-.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins build-with-wasm-plugins build-parser-wasm clean test lint lint-plugin-examples doc help
+.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm clean test lint lint-plugin-examples doc help
 
 # Build CLI with native plugins (release, default)
 build:
@@ -63,7 +63,11 @@ build-plugins:
 	@echo "Done building plugins."
 
 # Collect built plugins to target/builtin-plugins/
-collect-plugins: build-plugins
+collect-plugins: build-plugins collect-plugins-only
+
+# The copy half of collect-plugins, without rebuilding. CI restores the
+# components from build artifacts, so it needs the copy on its own.
+collect-plugins-only:
 	@echo "Collecting plugins..."
 	@mkdir -p target/builtin-plugins
 	@for dir in plugins/builtin/*/*/; do \


### PR DESCRIPTION
## Problem

No CI job compiles `--features cli,wasm-builtin-plugins`, so anything behind that cfg can break silently. That is not hypothetical: #382 introduced a helper taking `&dyn LintRule`, but the WASM builtin loader yields concrete `ComponentLintRule`s, so `as_ref()` had no method to resolve. Every CI job stayed green; the review caught it.

The gap matters because that build is what `make build-with-wasm-plugins` produces and what the README's `cargo install` line documents — the breakage would otherwise have surfaced at release time.

## Change

A `Check Host (wasm-builtin-plugins)` job that:

1. downloads the components the existing `wasm-build` chunks already upload,
2. collects them into `target/builtin-plugins/`, where `include_bytes!` looks,
3. runs `cargo check --no-default-features --features cli,wasm-builtin-plugins`.

Reusing the artifacts avoids rebuilding all 28 plugins, and `cargo check` rather than a release build skips compiling wasmtime with optimizations for a gap that is about compilation, not linking.

`collect-plugins` is split so its copy half (`collect-plugins-only`) can run without rebuilding — CI restores the components from artifacts rather than building them in this job.

## Testing

- Ran the job's exact sequence locally: tar the components as the build job does, delete the originals, restore from the tarball, `make collect-plugins-only` (28 collected), then the `cargo check` — passes.
- Confirmed the check is not vacuous: injected a type error inside the `wasm-builtin-plugins`-gated function, watched the default build stay green and this check fail with `error[E0308]`, then reverted.
- `make collect-plugins` still rebuilds and collects as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S