### PR TITLE
chore(renovate): stop bumping CI's Python version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,16 @@
         "every weekend"
       ],
       "groupName": "rust dependencies"
+    },
+    {
+      "description": "CI runs the Python jobs on the lowest interpreter the SDK supports (requires-python >=3.11, and it publishes an abi3-py311 wheel), so that anything needing a newer one fails in CI rather than in a contributor's checkout. Bumping it is part of raising that floor, not an automated update. Scoped to github-actions so a python dependency elsewhere (a Dockerfile base image, say) is still updated.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepNames": [
+        "python"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Closes #381 (that PR should be closed rather than merged).

## Why

Renovate opened #381 to change the `Python Plugin` job from `3.11` to `3.14`. That undoes a deliberate pin from `d3eecea` and leaves the comment directly above it describing the opposite of the value:

```yaml
# The lowest version the SDK supports, so CI catches anything that
# needs a newer one. The abi3 wheel it builds runs on 3.11+.
python-version: "3.14"
```

The pin is a **floor**, not a version left behind. Both `pyproject.toml` files declare `requires-python = ">=3.11"` and the SDK ships an `abi3-py311` wheel, so CI deliberately runs the oldest interpreter it claims to support.

What makes this worth a rule rather than a one-off close: on 3.14 everything still passes. pyo3 0.29 and componentize-py 0.25 both support it, so CI goes green either way. The regression is silent — 3.12+-only syntax or stdlib lands in the SDK or the example plugin, `pip install --group dev`, `make install`, `mypy`, `pytest` and the componentize build all succeed, the published wheel still advertises 3.11+, and a user on 3.11 hits `SyntaxError`/`ImportError` at import time.

## The rule

```json
{
  "matchManagers": ["github-actions"],
  "matchDepNames": ["python"],
  "enabled": false
}
```

Raising the CI version is part of raising the declared floor, which is a deliberate change to both `pyproject.toml` files and the wheel's ABI tag — not something to take as an automated bump. The rule carries that reasoning in its `description` so the next person to read the config sees why.

Scoped to the `github-actions` manager (Renovate detected #381 as depName `python`, type `uses-with`, from `setup-python`'s input) so a `python` dependency elsewhere — a Dockerfile base image, for instance — keeps getting updates.

## Testing

`renovate-config-validator` 44.50.3: `Config validated successfully`.

(The validator that `npx --package renovate` resolves by default is 37.x, which predates `managerFilePatterns` and reports two errors against the existing `customManagers` block — those are on `main` too and are artifacts of the stale validator, not of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S