### PR TITLE
feat(python-sdk): let plugin tests assert what their fixes produce

### DIFF
--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -10,7 +10,7 @@
 //! - [`Linter`] — collects rules and runs them against a parsed config
 
 use crate::parser::ast::Config;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// Display-ordered list of rule categories for UI output.
@@ -48,25 +48,31 @@ impl std::fmt::Display for Severity {
 }
 
 /// Represents a fix that can be applied to resolve a lint error
-#[derive(Debug, Clone, Serialize)]
+///
+/// Deserialize lets a fix cross a language boundary and come back as the
+/// same struct the applier consumes — the Python SDK sends fixes here to
+/// test what they produce. The fields that are skipped when serializing
+/// default when absent, so the round-trip is lossless.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fix {
     /// Line number where the fix should be applied (1-indexed)
     pub line: usize,
     /// The original text to replace (if None and new_text is empty, delete the line)
+    #[serde(default)]
     pub old_text: Option<String>,
     /// The new text to insert (empty string with old_text=None means delete)
     pub new_text: String,
     /// Whether to delete the entire line
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub delete_line: bool,
     /// Whether to insert new_text as a new line after the specified line
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub insert_after: bool,
     /// Start byte offset for range-based fix (0-indexed, inclusive)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_offset: Option<usize>,
     /// End byte offset for range-based fix (0-indexed, exclusive)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_offset: Option<usize>,
 }
 

--- a/crates/nginx-lint-common/src/linter.rs
+++ b/crates/nginx-lint-common/src/linter.rs
@@ -53,7 +53,14 @@ impl std::fmt::Display for Severity {
 /// same struct the applier consumes — the Python SDK sends fixes here to
 /// test what they produce. The fields that are skipped when serializing
 /// default when absent, so the round-trip is lossless.
+///
+/// `deny_unknown_fields` keeps that guarantee honest: were the WIT `fix`
+/// record's fields ever renamed, silently dropping the unknown key would
+/// default e.g. `insert_after` to false and turn an insert into a
+/// whole-line replacement — the exact failure this round-trip exists to
+/// catch. Rejecting the input surfaces the drift instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Fix {
     /// Line number where the fix should be applied (1-indexed)
     pub line: usize,

--- a/plugins/python/nginx-lint-plugin/Cargo.lock
+++ b/plugins/python/nginx-lint-plugin/Cargo.lock
@@ -15,16 +15,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "itoa"
@@ -54,6 +82,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nginx-lint-common"
+version = "0.19.1"
+dependencies = [
+ "nginx-lint-parser",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "nginx-lint-parser"
 version = "0.19.1"
 dependencies = [
@@ -66,6 +106,7 @@ dependencies = [
 name = "nginx-lint-plugin-py"
 version = "0.19.1"
 dependencies = [
+ "nginx-lint-common",
  "nginx-lint-parser",
  "pyo3",
  "serde",
@@ -160,13 +201,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "rowan"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b574c58582fa59fa43a2feb6608b8744184659f08a2e0117e4b8224d95ed61"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.14.5",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -177,6 +238,31 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "serde"
@@ -209,6 +295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +316,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -276,10 +382,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/plugins/python/nginx-lint-plugin/Cargo.toml
+++ b/plugins/python/nginx-lint-plugin/Cargo.toml
@@ -13,6 +13,7 @@ name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]
+nginx-lint-common = { path = "../../../crates/nginx-lint-common" }
 nginx-lint-parser = { path = "../../../crates/nginx-lint-parser" }
 # abi3-py311: one wheel per platform covers every Python >= 3.11,
 # instead of one per platform x interpreter version. Keep pyo3 new enough

--- a/plugins/python/nginx-lint-plugin/README.md
+++ b/plugins/python/nginx-lint-plugin/README.md
@@ -18,7 +18,9 @@ as a native module.
     dataclasses have no defaults, so without these a spec means spelling out
     all eleven fields and every error repeats the plugin's rule and category.
   - `testing` — `parse_config()` and `PluginTestRunner` for plain-pytest
-    unit tests against the real Rust parser
+    unit tests against the real Rust parser, plus `apply_fixes()` and
+    `PluginTestRunner.assert_fixed()` to check what a rule's fixes actually
+    produce, through the same applier `nginx-lint --fix` uses
   - `config_builder` — reconstructs method-based `Config`/`Directive`
     objects (matching the componentize-py binding surface, e.g.
     `directive.is_(...)`) from parser output or a host snapshot
@@ -110,6 +112,15 @@ def test_detects_server_tokens_on():
 def test_include_context():
     cfg = parse_config("server_tokens on;", include_context=["http"])
     assert len(plugin.check(cfg, "test.conf")) == 1
+
+def test_fix():
+    # Asserting on the applied output, not just the reported findings: a fix
+    # the linter normalizes into a different operation than intended shows up
+    # here rather than in a user's config.
+    runner.assert_fixed(
+        "http {\n    server_tokens on;\n}\n",
+        "http {\n    server_tokens off;\n}\n",
+    )
 ```
 
 The same `WitWorld` class runs unmodified under pytest and inside the WASM

--- a/plugins/python/nginx-lint-plugin/python/nginx_lint_plugin/testing.py
+++ b/plugins/python/nginx-lint-plugin/python/nginx_lint_plugin/testing.py
@@ -175,6 +175,11 @@ def apply_fixes(content: str, fixes: List[Fix]) -> FixResult:
     Runs the linter's own applier rather than reimplementing it, so a fix
     that the CLI would normalize into a different operation than intended
     shows up here as the wrong output instead of passing unnoticed.
+
+    The applier always ends its output with a newline, so a config written
+    without a trailing one comes back with it added — including when no fix
+    applied, where the result is the input plus that newline rather than
+    the input itself.
     """
     raw = _native.apply_fixes_json(content, json.dumps([asdict(f) for f in fixes]))
     result = json.loads(raw)
@@ -242,6 +247,11 @@ class PluginTestRunner:
         All of the rule's fixes go through the applier in one call, as
         `nginx-lint --fix --rule-only <rule>` does, so overlapping fixes
         resolve the same way here as in production.
+
+        One difference from the CLI: this calls the plugin's ``check``
+        directly, so findings the linter would have suppressed — an
+        ``# nginx-lint-disable`` comment in `content`, say — still
+        contribute their fixes here.
         """
         errors = self.check_string(content, include_context)
         fixes = [fix for error in errors for fix in error.fixes]
@@ -266,9 +276,15 @@ class PluginTestRunner:
                 f"fixes the linter rejects"
             )
         if result.content != expected:
+            hint = ""
+            if result.content == expected + "\n":
+                hint = (
+                    "\n(the only difference is the trailing newline the applier "
+                    "always adds; include it in the expected text)"
+                )
             raise AssertionError(
                 f'Applying {result.applied} fix(es) from "{self._spec().name}" gave:\n'
-                f"{result.content!r}\nexpected:\n{expected!r}"
+                f"{result.content!r}\nexpected:\n{expected!r}{hint}"
             )
 
     def test_examples(self, bad_conf: str, good_conf: str) -> None:

--- a/plugins/python/nginx-lint-plugin/python/nginx_lint_plugin/testing.py
+++ b/plugins/python/nginx-lint-plugin/python/nginx_lint_plugin/testing.py
@@ -16,7 +16,8 @@ the production linter uses. Usage:
 """
 
 import json
-from typing import Callable, List, Optional, cast
+from dataclasses import asdict
+from typing import Callable, List, NamedTuple, Optional, cast
 
 from wit_world.imports.config_api import Config
 from wit_world.imports import parser_types
@@ -28,7 +29,7 @@ from wit_world.imports.data_types import (
     DirectiveData,
 )
 from wit_world.imports.parser_types import ParseOutput
-from wit_world.imports.types import LintError, PluginSpec
+from wit_world.imports.types import Fix, LintError, PluginSpec
 
 from . import _native
 from .config_builder import build_config_from_parse_output
@@ -152,6 +153,38 @@ def parse_config(
     return cast(Config, built)
 
 
+# ── Applying fixes ──────────────────────────────────────────────────
+
+
+class FixResult(NamedTuple):
+    """What the linter's fix applier did with a set of fixes."""
+
+    content: str
+    """The config after the fixes were applied."""
+    applied: int
+    """How many fixes were applied."""
+    skipped_invalid: int
+    """How many were dropped as unapplicable — bad offsets, or a line-based
+    fix whose line or ``old_text`` did not match. A fix counted here did
+    nothing, which is easy to mistake for a fix that had nothing to do."""
+
+
+def apply_fixes(content: str, fixes: List[Fix]) -> FixResult:
+    """Apply fixes to a config the way ``nginx-lint --fix`` would.
+
+    Runs the linter's own applier rather than reimplementing it, so a fix
+    that the CLI would normalize into a different operation than intended
+    shows up here as the wrong output instead of passing unnoticed.
+    """
+    raw = _native.apply_fixes_json(content, json.dumps([asdict(f) for f in fixes]))
+    result = json.loads(raw)
+    return FixResult(
+        content=result["content"],
+        applied=result["applied"],
+        skipped_invalid=result["skipped_invalid"],
+    )
+
+
 # ── Test runner ─────────────────────────────────────────────────────
 
 SpecFn = Callable[[], PluginSpec]
@@ -199,6 +232,43 @@ class PluginTestRunner:
             raise AssertionError(
                 f'Expected error on line {line} from "{self._spec().name}", '
                 f"got errors on lines: {lines!r}"
+            )
+
+    def fix_string(
+        self, content: str, include_context: Optional[List[str]] = None
+    ) -> FixResult:
+        """Apply every fix this rule reports for `content`.
+
+        All of the rule's fixes go through the applier in one call, as
+        `nginx-lint --fix --rule-only <rule>` does, so overlapping fixes
+        resolve the same way here as in production.
+        """
+        errors = self.check_string(content, include_context)
+        fixes = [fix for error in errors for fix in error.fixes]
+        return apply_fixes(content, fixes)
+
+    def assert_fixed(
+        self,
+        content: str,
+        expected: str,
+        include_context: Optional[List[str]] = None,
+    ) -> None:
+        """Assert that applying this rule's fixes to `content` yields `expected`.
+
+        Fails if any fix was unapplicable rather than comparing the output
+        of a fix that silently did nothing.
+        """
+        result = self.fix_string(content, include_context)
+        if result.skipped_invalid:
+            raise AssertionError(
+                f'{result.skipped_invalid} fix(es) from "{self._spec().name}" could '
+                f"not be applied (applied {result.applied}); the rule is producing "
+                f"fixes the linter rejects"
+            )
+        if result.content != expected:
+            raise AssertionError(
+                f'Applying {result.applied} fix(es) from "{self._spec().name}" gave:\n'
+                f"{result.content!r}\nexpected:\n{expected!r}"
             )
 
     def test_examples(self, bad_conf: str, good_conf: str) -> None:

--- a/plugins/python/nginx-lint-plugin/src/lib.rs
+++ b/plugins/python/nginx-lint-plugin/src/lib.rs
@@ -276,8 +276,34 @@ fn parse_config_json(source: &str, include_context: Vec<String>) -> PyResult<Str
     serde_json::to_string(&output).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
+/// Apply fixes to a config, returning the result as a JSON string.
+///
+/// `fixes_json` is a list of the WIT `fix` records, whose field names match
+/// `nginx_lint_common::Fix`, so they deserialize into the very struct the
+/// linter applies — the point being that a plugin's fixes are tested
+/// through the production applier rather than a reimplementation of it.
+///
+/// The returned object carries `content`, `applied` and `skipped_invalid`;
+/// a caller that ignores the last one cannot tell a fix that did nothing
+/// from a fix that was silently dropped.
+#[pyfunction]
+fn apply_fixes_json(content: &str, fixes_json: &str) -> PyResult<String> {
+    let fixes: Vec<nginx_lint_common::Fix> =
+        serde_json::from_str(fixes_json).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let refs: Vec<&nginx_lint_common::Fix> = fixes.iter().collect();
+    let result = nginx_lint_common::apply_fixes_to_content_detailed(content, &refs);
+
+    let out = serde_json::json!({
+        "content": result.content,
+        "applied": result.applied,
+        "skipped_invalid": result.skipped_invalid,
+    });
+    serde_json::to_string(&out).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_config_json, m)?)?;
+    m.add_function(wrap_pyfunction!(apply_fixes_json, m)?)?;
     Ok(())
 }

--- a/plugins/python/nginx-lint-plugin/tests/test_apply_fixes.py
+++ b/plugins/python/nginx-lint-plugin/tests/test_apply_fixes.py
@@ -1,0 +1,166 @@
+"""Tests for applying fixes through the linter's own applier.
+
+The fix constructors are pinned field-by-field against the host in
+test_config_builder.py, but that compares the Fix records rather than what
+they do. These tests compare outcomes, which is the check that was missing
+when `insert_before` shipped as a whole-line replacement: it deleted the
+directive it meant to insert before, and every unit test stayed green.
+"""
+
+import pytest
+
+from nginx_lint_plugin import Fix
+from nginx_lint_plugin.testing import apply_fixes, parse_config
+
+NESTED = "http {\n    server_tokens on;\n}\n"
+
+
+def _directive(source: str, name: str):
+    cfg = parse_config(source)
+    return next(
+        c.directive for c in cfg.all_directives_with_context() if c.directive.is_(name)
+    )
+
+
+# ── The regression this module exists for ───────────────────────────
+
+
+def test_insert_before_keeps_the_directive_it_inserts_before():
+    d = _directive(NESTED, "server_tokens")
+    result = apply_fixes(NESTED, [d.insert_before("add_header X-Test 1;")])
+
+    assert result.skipped_invalid == 0
+    assert result.content == (
+        "http {\n    add_header X-Test 1;\n    server_tokens on;\n}\n"
+    )
+
+
+def test_a_line_based_insert_shape_would_replace_the_line():
+    # Why the test above is worth having: the shape the guest constructors
+    # emitted before they were matched to the host — a line number, no
+    # offsets — normalizes into a whole-line replacement, so the directive
+    # disappears. Comparing Fix records cannot see this; comparing output
+    # can.
+    broken = Fix(
+        line=2,
+        old_text=None,
+        new_text="add_header X-Test 1;",
+        delete_line=False,
+        insert_after=False,
+        start_offset=None,
+        end_offset=None,
+    )
+    result = apply_fixes(NESTED, [broken])
+
+    assert "server_tokens on;" not in result.content
+    assert result.content == "http {\nadd_header X-Test 1;\n}\n"
+
+
+# ── The other constructors, by outcome ──────────────────────────────
+
+
+def test_replace_with_preserves_indentation():
+    d = _directive(NESTED, "server_tokens")
+    result = apply_fixes(NESTED, [d.replace_with("server_tokens off;")])
+
+    assert result.applied == 1
+    assert result.content == "http {\n    server_tokens off;\n}\n"
+
+
+def test_insert_after_indents_to_the_directive():
+    d = _directive(NESTED, "server_tokens")
+    result = apply_fixes(NESTED, [d.insert_after("add_header X-Test 1;")])
+
+    assert result.content == (
+        "http {\n    server_tokens on;\n    add_header X-Test 1;\n}\n"
+    )
+
+
+def test_insert_before_many_and_after_many():
+    d = _directive(NESTED, "server_tokens")
+
+    before = apply_fixes(NESTED, [d.insert_before_many(["a 1;", "b 2;"])])
+    assert before.content == (
+        "http {\n    a 1;\n    b 2;\n    server_tokens on;\n}\n"
+    )
+
+    after = apply_fixes(NESTED, [d.insert_after_many(["a 1;", "b 2;"])])
+    assert after.content == (
+        "http {\n    server_tokens on;\n    a 1;\n    b 2;\n}\n"
+    )
+
+
+def test_delete_line_fix_removes_the_directive():
+    d = _directive(NESTED, "server_tokens")
+    result = apply_fixes(NESTED, [d.delete_line_fix()])
+
+    assert result.applied == 1
+    assert "server_tokens" not in result.content
+
+
+# ── Multiple fixes ──────────────────────────────────────────────────
+
+
+def test_two_fixes_at_different_positions_both_apply():
+    source = "http {\n    server_tokens on;\n    autoindex on;\n}\n"
+    cfg = parse_config(source)
+    directives = {
+        c.directive.name(): c.directive for c in cfg.all_directives_with_context()
+    }
+    result = apply_fixes(
+        source,
+        [
+            directives["server_tokens"].replace_with("server_tokens off;"),
+            directives["autoindex"].replace_with("autoindex off;"),
+        ],
+    )
+
+    assert result.applied == 2
+    assert result.skipped_invalid == 0
+    assert result.content == "http {\n    server_tokens off;\n    autoindex off;\n}\n"
+
+
+def test_overlapping_fixes_skip_rather_than_corrupt():
+    # Two fixes over the same directive: the applier keeps one and drops the
+    # other instead of splicing both into the same range.
+    d = _directive(NESTED, "server_tokens")
+    result = apply_fixes(
+        NESTED,
+        [d.replace_with("server_tokens off;"), d.replace_with("server_tokens build;")],
+    )
+
+    assert result.applied == 1
+    assert result.content in (
+        "http {\n    server_tokens off;\n}\n",
+        "http {\n    server_tokens build;\n}\n",
+    )
+
+
+# ── Unapplicable fixes are reported, not swallowed ──────────────────
+
+
+def test_unapplicable_fix_is_counted_as_skipped():
+    # Offsets past the end of the file: the applier cannot use them, and
+    # says so rather than silently returning the input unchanged.
+    bogus = Fix(
+        line=1,
+        old_text=None,
+        new_text="x",
+        delete_line=False,
+        insert_after=False,
+        start_offset=10_000,
+        end_offset=10_001,
+    )
+    result = apply_fixes(NESTED, [bogus])
+
+    assert result.applied == 0
+    assert result.skipped_invalid == 1
+    assert result.content == NESTED
+
+
+def test_apply_fixes_rejects_a_malformed_fix():
+    with pytest.raises(ValueError):
+        # line and new_text are required; a Fix missing them cannot be a fix
+        from nginx_lint_plugin.testing import _native
+
+        _native.apply_fixes_json(NESTED, '[{"old_text": null}]')

--- a/plugins/python/nginx-lint-plugin/tests/test_apply_fixes.py
+++ b/plugins/python/nginx-lint-plugin/tests/test_apply_fixes.py
@@ -164,3 +164,35 @@ def test_apply_fixes_rejects_a_malformed_fix():
         from nginx_lint_plugin.testing import _native
 
         _native.apply_fixes_json(NESTED, '[{"old_text": null}]')
+
+
+# ── Documented edge cases ───────────────────────────────────────────
+
+
+def test_output_always_ends_with_a_newline():
+    # The applier appends one, so a config written without a trailing
+    # newline comes back with it — including when nothing applied, where
+    # the result is the input plus that newline rather than the input.
+    source = "http { server_tokens on; }"
+    d = _directive(source, "server_tokens")
+
+    fixed = apply_fixes(source, [d.replace_with("server_tokens off;")])
+    assert fixed.content == "http { server_tokens off; }\n"
+
+    untouched = apply_fixes(source, [])
+    assert untouched.applied == 0
+    assert untouched.content == source + "\n"
+
+
+def test_a_fix_with_an_unknown_field_is_rejected():
+    # The JSON deserializes into the applier's own Fix struct, and unknown
+    # keys are refused rather than dropped: a renamed WIT field would
+    # otherwise default insert_after to false, turning an insert into a
+    # whole-line replacement while the test kept passing.
+    from nginx_lint_plugin.testing import _native
+
+    with pytest.raises(ValueError):
+        _native.apply_fixes_json(
+            NESTED,
+            '[{"line": 2, "new_text": "x", "insert_after_renamed": true}]',
+        )

--- a/plugins/python/server-tokens-enabled-py/test_plugin.py
+++ b/plugins/python/server-tokens-enabled-py/test_plugin.py
@@ -125,6 +125,17 @@ def test_ignores_file_included_from_stream_context():
     assert len(errors) == 0
 
 
+def test_fixing_bad_conf_produces_good_conf():
+    # The examples are not just illustrative: applying this rule's fix to
+    # bad.conf must yield good.conf byte for byte. That makes the documented
+    # before/after pair an executable claim, and it goes through the same
+    # applier `nginx-lint --fix` uses.
+    runner.assert_fixed(
+        (EXAMPLES_DIR / "bad.conf").read_text(),
+        (EXAMPLES_DIR / "good.conf").read_text(),
+    )
+
+
 def test_examples_bad_good_conf():
     bad_conf = (EXAMPLES_DIR / "bad.conf").read_text()
     good_conf = (EXAMPLES_DIR / "good.conf").read_text()


### PR DESCRIPTION
Part of #378 — the Python half only. #378 stays open for the TypeScript side, which cannot reuse this work directly (see Scope). Deliberately no closing keyword anywhere in this PR or its commit.

## Problem

`PluginTestRunner` could assert the number of findings, their line, and their message — but nothing about the `Fix` attached to them. That is precisely how the `insert_before` bug shipped in #376: the guest constructors emitted a shape the applier normalizes into a **whole-line replacement**, so an "insert before this directive" fix *deleted* the directive, and every unit test stayed green. Code review caught it; tests could not.

#376 pinned the constructors field-by-field against the host's, which is a decent proxy, but it compares the records that describe a fix rather than what the fix does.

## Change

Expose the linter's own applier to the SDK:

```python
from nginx_lint_plugin.testing import apply_fixes

result = apply_fixes(content, fixes)   # -> FixResult(content, applied, skipped_invalid)
runner.assert_fixed(before, after)     # all of this rule's fixes, in one pass
```

Fixes go through `nginx_lint_common::apply_fixes_to_content_detailed` — the function the CLI uses — so a fix that production would normalize into a different operation than intended shows up as the wrong output instead of passing unnoticed. `assert_fixed` collects every fix the rule reports and applies them in one call, as `--fix --rule-only <rule>` does, so overlap resolution behaves identically.

`skipped_invalid` is surfaced, and `assert_fixed` fails on it: otherwise a rule emitting fixes the linter rejects would look the same as a rule with nothing to fix.

`Fix` gains `Deserialize` (with `#[serde(default)]` on the fields that are skipped when serializing) so the JSON crossing the language boundary lands in the struct the applier consumes. That removes the risk the issue called out — "the conversion has to preserve the range-vs-line distinction exactly" — because there is no conversion left to get wrong.

## Testing

The test that could not exist before, and the one that says why it matters:

```python
def test_insert_before_keeps_the_directive_it_inserts_before(): ...
def test_a_line_based_insert_shape_would_replace_the_line(): ...
```

The second constructs the pre-#376 shape by hand and pins that it eats the directive (`http {\nadd_header X-Test 1;\n}\n` — `server_tokens on;` gone). Comparing `Fix` records cannot see that; comparing output can.

Ten SDK tests cover the six constructors by outcome, multiple fixes at different positions, overlapping fixes (one applied, one skipped rather than both spliced into the same range), and an unapplicable fix being counted rather than silently returning the input unchanged.

The example plugin now asserts `bad.conf` → `good.conf` byte for byte, which makes the documented before/after pair executable — and it passed on the first run, so the pair really was accurate.

**Verified this is the production path, not a lookalike:** applying the rule's fix to `bad.conf` through the SDK and through `nginx-lint --fix --rule-only server-tokens-enabled-py` produces byte-identical output, both equal to `good.conf`.

Full gauntlet: 27 SDK tests, 18 plugin tests, `make typecheck`, `make test-e2e`, the SDK crate's `cargo fmt --check` / `clippy -D warnings`, and the main workspace across `cli`, `cli,plugins`, `cli,wasm-builtin-plugins` plus its 275 + 94 tests.

## Scope

Python only, and the TypeScript half is not a copy of this one.

The Python SDK is a native extension, so exposing the applier was a matter of adding `nginx-lint-common` as a path dependency. The TypeScript SDK reaches the parser as a WASM component instead, and the obvious move — adding an `apply-fixes` export to the existing `parser` world — does not work: the applier lives in `nginx-lint-common`, which depends on `nginx-lint-parser` (`crates/nginx-lint-common/Cargo.toml:11`), so the parser crate cannot depend back on it. TS needs a second component built from a crate that depends on `nginx-lint-common`, shipped alongside `wasm/parser/`.

That belongs with #377's PR, where the TS fix constructors get corrected — the applier is what would prove the correction, the same way it does here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S

