### PR TITLE
fix(ts-sdk): correct the guest fix constructors, and make them testable

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -366,8 +366,12 @@ jobs:
           - name: Install shared library dependencies
             working-directory: plugins/typescript/nginx-lint-plugin
             run: npm install
-      - name: Build parser WASM component
-        run: make build-parser-wasm
+      - name: Build parser and fixer WASM components
+        # The fixer carries the fix applier, which the testing entry uses to
+        # check what a plugin's fixes produce
+        run: |
+          make build-parser-wasm
+          make build-fixer-wasm
       - name: Build shared library
         working-directory: plugins/typescript/nginx-lint-plugin
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,21 +125,30 @@ jobs:
           key: wasm-parser
       - name: Install wasm-tools
         run: cargo install wasm-tools
-      - name: Build parser WASM component
+      - name: Build parser and fixer WASM components
+        # The SDK imports both statically, so a missing fixer fails the whole
+        # package build, not just its fix-testing API
         run: |
           cargo build --manifest-path crates/nginx-lint-parser/Cargo.toml \
             --target wasm32-unknown-unknown --release --features wasm
           wasm-tools component new \
             target/wasm32-unknown-unknown/release/nginx_lint_parser.wasm \
             -o target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm
+          cargo build --manifest-path crates/nginx-lint-common/Cargo.toml \
+            --target wasm32-unknown-unknown --release --features wasm
+          wasm-tools component new \
+            target/wasm32-unknown-unknown/release/nginx_lint_common.wasm \
+            -o target/wasm32-unknown-unknown/release/nginx_lint_common.component.wasm
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
       - name: Install dependencies
         run: npm install
         working-directory: plugins/typescript/nginx-lint-plugin
-      - name: Transpile parser WASM to JS
-        run: npx jco transpile ../../../target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm -o wasm/parser --name parser --instantiation async
+      - name: Transpile parser and fixer WASM to JS
+        run: |
+          npx jco transpile ../../../target/wasm32-unknown-unknown/release/nginx_lint_parser.component.wasm -o wasm/parser --name parser --instantiation async
+          npx jco transpile ../../../target/wasm32-unknown-unknown/release/nginx_lint_common.component.wasm -o wasm/fixer --name fixer --instantiation async
         working-directory: plugins/typescript/nginx-lint-plugin
       - name: Build package
         run: npm run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
+ "wit-bindgen",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,8 @@ help:
 	@echo "  make build-plugins      - Build WASM builtin plugins as WIT components"
 	@echo "  make build-with-wasm-plugins - Build CLI with embedded WASM plugins"
 	@echo "  make build-parser-wasm  - Build parser WASM for TypeScript plugin testing"
+	@echo "  make build-fixer-wasm   - Build fix-applier WASM for TypeScript plugin testing"
+	@echo "                            (the TypeScript SDK imports both; build them together)"
 	@echo "  make build-wasm         - Build WASM for web (without plugins)"
 	@echo "  make build-wasm-with-plugins - Build WASM for web (with plugins)"
 	@echo "  make build-web          - Build web server with embedded WASM (with plugins)"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_DIRS := $(wildcard plugins/builtin/*/*/)
 PLUGIN_NAMES := $(foreach dir,$(PLUGIN_DIRS),$(notdir $(patsubst %/,%,$(dir))))
 PLUGIN_WASMS := $(foreach name,$(PLUGIN_NAMES),target/builtin-plugins/$(name).wasm)
 
-.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm clean test lint lint-plugin-examples doc help
+.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm build-fixer-wasm clean test lint lint-plugin-examples doc help
 
 # Build CLI with native plugins (release, default)
 build:
@@ -87,6 +87,23 @@ build-with-wasm-plugins: collect-plugins
 	@echo "Building nginx-lint with embedded WASM builtin plugins..."
 	cargo build --release --no-default-features --features cli,wasm-builtin-plugins
 	@echo "Done."
+
+# Build the fix applier as a WASM Component for TypeScript plugin testing.
+# It lives in nginx-lint-common rather than alongside the parser component
+# because that is where the applier is, and common depends on the parser —
+# the reverse would be a cycle.
+build-fixer-wasm:
+	@command -v wasm-tools >/dev/null 2>&1 || { echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"; exit 1; }
+	cargo build --manifest-path crates/nginx-lint-common/Cargo.toml \
+		--target wasm32-unknown-unknown --release --features wasm
+	wasm-tools component new \
+		target/wasm32-unknown-unknown/release/nginx_lint_common.wasm \
+		-o target/wasm32-unknown-unknown/release/nginx_lint_common.component.wasm
+	cd plugins/typescript/nginx-lint-plugin && \
+		npx jco transpile \
+			../../../target/wasm32-unknown-unknown/release/nginx_lint_common.component.wasm \
+			-o wasm/fixer --name fixer --instantiation async
+	@echo "Fixer component built and transpiled."
 
 # Build nginx-lint-parser as WASM Component for TypeScript plugin testing
 build-parser-wasm:

--- a/crates/nginx-lint-common/Cargo.toml
+++ b/crates/nginx-lint-common/Cargo.toml
@@ -7,8 +7,20 @@ license = "MIT"
 repository = "https://github.com/walf443/nginx-lint"
 authors = ["walf443"]
 
+# cdylib so the `wasm` feature can produce a component (same as the parser
+# crate); rlib keeps it usable as a normal dependency
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Exposes the fix applier as a WASM component (the `fixer` world), which the
+# TypeScript SDK instantiates to test what a plugin's fixes produce
+wasm = ["dep:wit-bindgen"]
+
 [dependencies]
 nginx-lint-parser = { version = "0.19.1", path = "../nginx-lint-parser" }
+wit-bindgen = { version = "0.61.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1.0"

--- a/crates/nginx-lint-common/src/lib.rs
+++ b/crates/nginx-lint-common/src/lib.rs
@@ -50,4 +50,7 @@ pub use linter::{
     normalize_line_fix,
 };
 pub use nginx_lint_parser::{parse_config, parse_string, parse_string_with_errors};
+
+#[cfg(feature = "wasm")]
+mod wasm;
 pub use nginx_version::{NginxVersion, NginxVersionParseError, format_range, is_in_range};

--- a/crates/nginx-lint-common/src/wasm.rs
+++ b/crates/nginx-lint-common/src/wasm.rs
@@ -1,0 +1,46 @@
+//! WASM component exposing the fix applier (the `fixer` world).
+//!
+//! The TypeScript SDK cannot call [`crate::apply_fixes_to_content_detailed`]
+//! directly the way the Python SDK does, so it instantiates this component
+//! instead. Keeping the applier here rather than in a component built from
+//! `nginx-lint-parser` is what avoids a dependency cycle: this crate already
+//! depends on the parser.
+
+wit_bindgen::generate!({
+    path: "../../wit/nginx-lint-plugin.wit",
+    world: "fixer",
+    pub_export_macro: true,
+});
+
+struct FixerComponent;
+
+impl Guest for FixerComponent {
+    fn apply_fixes(
+        content: String,
+        fixes: Vec<nginx_lint::plugin::types::Fix>,
+    ) -> nginx_lint::plugin::fixer_types::FixResult {
+        let fixes: Vec<crate::Fix> = fixes.iter().map(convert_fix).collect();
+        let refs: Vec<&crate::Fix> = fixes.iter().collect();
+        let result = crate::apply_fixes_to_content_detailed(&content, &refs);
+
+        nginx_lint::plugin::fixer_types::FixResult {
+            content: result.content,
+            applied: result.applied as u32,
+            skipped_invalid: result.skipped_invalid as u32,
+        }
+    }
+}
+
+export!(FixerComponent);
+
+fn convert_fix(fix: &nginx_lint::plugin::types::Fix) -> crate::Fix {
+    crate::Fix {
+        line: fix.line as usize,
+        old_text: fix.old_text.clone(),
+        new_text: fix.new_text.clone(),
+        delete_line: fix.delete_line,
+        insert_after: fix.insert_after,
+        start_offset: fix.start_offset.map(|o| o as usize),
+        end_offset: fix.end_offset.map(|o| o as usize),
+    }
+}

--- a/plugins/typescript/nginx-lint-plugin/README.md
+++ b/plugins/typescript/nginx-lint-plugin/README.md
@@ -156,6 +156,14 @@ it("handles included files", () => {
 | `assertErrors(content, count)` | Assert exactly N errors |
 | `assertErrorOnLine(content, line)` | Assert error on a specific line |
 | `testExamples(badConf, goodConf)` | Validate bad config produces errors, good config does not |
+| `fixString(content, opts?)` | Apply every fix this rule reports, returning `{ content, applied, skippedInvalid }` |
+| `assertFixed(content, expected, opts?)` | Assert applying this rule's fixes yields `expected` |
+
+`fixString`/`assertFixed` run the fixes through the linter's own applier, so a
+fix the CLI would normalize into a different operation than intended shows up
+as the wrong output rather than passing unnoticed. `applyFixes(content, fixes)`
+is exported for checking a single fix without a plugin. Note the applier always
+ends its output with a newline.
 
 ### Custom runtimes (Cloudflare Workers / workerd)
 
@@ -169,9 +177,12 @@ instantiated synchronously:
 ```ts
 import { createTesting } from "nginx-lint-plugin/testing/custom";
 import coreModule from "nginx-lint-plugin/wasm/parser/parser.core.wasm";
+// Only needed for fixString()/assertFixed(); omit it and just those throw.
+import fixerCore from "nginx-lint-plugin/wasm/fixer/fixer.core.wasm";
 
 const { parseConfig, PluginTestRunner } = await createTesting({
   getCoreModule: () => coreModule,
+  getFixerCoreModule: () => fixerCore,
   instantiateCore: (module) => new WebAssembly.Instance(module),
 });
 

--- a/plugins/typescript/nginx-lint-plugin/README.md
+++ b/plugins/typescript/nginx-lint-plugin/README.md
@@ -340,6 +340,23 @@ import type {
 }
 ```
 
+## Developing this SDK
+
+The package imports two WASM components — the parser and the fix applier —
+so build both before `npm test` or `npm run build` in a fresh checkout.
+They are gitignored, and TypeScript reports them as missing modules if
+either is absent:
+
+```bash
+# from the repository root
+make build-parser-wasm
+make build-fixer-wasm
+```
+
+The applier is a separate component because it lives in
+`nginx-lint-common`, which depends on `nginx-lint-parser` — the parser
+component cannot export it without a dependency cycle.
+
 ## License
 
 MIT

--- a/plugins/typescript/nginx-lint-plugin/package.json
+++ b/plugins/typescript/nginx-lint-plugin/package.json
@@ -14,7 +14,8 @@
     ".": "./dist/index.js",
     "./testing": "./dist/plugin-test-runner.js",
     "./testing/custom": "./dist/plugin-test-runner-custom.js",
-    "./wasm/parser/parser.core.wasm": "./wasm/parser/parser.core.wasm"
+    "./wasm/parser/parser.core.wasm": "./wasm/parser/parser.core.wasm",
+    "./wasm/fixer/fixer.core.wasm": "./wasm/fixer/fixer.core.wasm"
   },
   "files": [
     "dist",

--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.test.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseConfig } from "./plugin-test-runner.js";
+import { parseConfig, applyFixes } from "./plugin-test-runner.js";
 import { buildConfigFromSnapshot } from "./config-builder.js";
 import type { ConfigSnapshot } from "./generated/interfaces/nginx-lint-plugin-config-api.js";
 
@@ -209,5 +209,72 @@ describe("Directive fix constructors", () => {
 
     assert.equal(ctx.directive.insertBefore("a 1;").newText, "a 1;\n");
     assert.equal(ctx.directive.insertAfter("a 1;").newText, "\na 1;");
+  });
+});
+
+// ── Applying fixes ──────────────────────────────────────────────────
+//
+// The block above pins the Fix records; these check what they do. That is
+// the distinction that mattered: insertBefore's old record looked
+// plausible and only revealed itself once applied.
+
+describe("applyFixes", () => {
+  it("insertBefore keeps the directive it inserts before", () => {
+    const d = serverTokens();
+    const result = applyFixes(NESTED, [d.insertBefore("add_header X-Test 1;")]);
+
+    assert.equal(result.skippedInvalid, 0);
+    assert.equal(
+      result.content,
+      "http {\n    add_header X-Test 1;\n    server_tokens on;\n}\n",
+    );
+  });
+
+  it("the old line-based shape would have replaced the line", () => {
+    // Why the test above is worth having: this is what insertBefore used to
+    // emit. The applier normalizes it into a whole-line replacement, so the
+    // directive disappears.
+    const result = applyFixes(NESTED, [
+      {
+        line: 2, oldText: undefined, newText: "add_header X-Test 1;",
+        deleteLine: false, insertAfter: false,
+        startOffset: undefined, endOffset: undefined,
+      },
+    ]);
+
+    assert.ok(!result.content.includes("server_tokens on;"));
+    assert.equal(result.content, "http {\nadd_header X-Test 1;\n}\n");
+  });
+
+  it("replaceWith preserves indentation", () => {
+    const d = serverTokens();
+    const result = applyFixes(NESTED, [d.replaceWith("server_tokens off;")]);
+
+    assert.equal(result.applied, 1);
+    assert.equal(result.content, "http {\n    server_tokens off;\n}\n");
+  });
+
+  it("insertAfter indents to the directive", () => {
+    const d = serverTokens();
+    const result = applyFixes(NESTED, [d.insertAfter("add_header X-Test 1;")]);
+
+    assert.equal(
+      result.content,
+      "http {\n    server_tokens on;\n    add_header X-Test 1;\n}\n",
+    );
+  });
+
+  it("reports fixes it could not apply instead of returning the input", () => {
+    const result = applyFixes(NESTED, [
+      {
+        line: 1, oldText: undefined, newText: "x",
+        deleteLine: false, insertAfter: false,
+        startOffset: 10000, endOffset: 10001,
+      },
+    ]);
+
+    assert.equal(result.applied, 0);
+    assert.equal(result.skippedInvalid, 1);
+    assert.equal(result.content, NESTED);
   });
 });

--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.test.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.test.ts
@@ -113,3 +113,101 @@ http {
     assert.deepEqual(new Set(names), new Set(["http", "gzip", "server", "listen"]));
   });
 });
+
+// ── Fix constructors ────────────────────────────────────────────────
+//
+// These pin the exact Fix records the SDK emits against the host's
+// implementations in src/plugin/component_rule.rs (replace_with /
+// delete_line_fix / insert_* on DirectiveResource). They used to differ:
+// insertBefore emitted a line-based shape that the applier normalizes into
+// a whole-line replacement, so it deleted the directive it meant to insert
+// before. Comparing the records catches that; counting findings does not.
+
+const NESTED = `http {
+    server_tokens on;
+}
+`;
+
+function serverTokens() {
+  const cfg = parseConfig(NESTED);
+  const ctx = cfg
+    .allDirectivesWithContext()
+    .find((c) => c.directive.is("server_tokens"));
+  assert.ok(ctx, "expected a server_tokens directive");
+  return ctx.directive;
+}
+
+describe("Directive fix constructors", () => {
+  it("replaceWith spans the leading whitespace and re-adds it", () => {
+    const d = serverTokens();
+    const fix = d.replaceWith("server_tokens off;");
+    const leading = d.leadingWhitespace();
+
+    assert.equal(fix.line, 0);
+    assert.equal(fix.deleteLine, false);
+    assert.equal(fix.insertAfter, false);
+    assert.equal(fix.startOffset, d.startOffset() - leading.length);
+    assert.equal(fix.endOffset, d.endOffset());
+    assert.equal(fix.newText, leading + "server_tokens off;");
+  });
+
+  it("deleteLineFix stays line-based", () => {
+    const d = serverTokens();
+    const fix = d.deleteLineFix();
+
+    assert.equal(fix.line, d.line());
+    assert.equal(fix.deleteLine, true);
+    assert.equal(fix.newText, "");
+    assert.equal(fix.startOffset, undefined);
+    assert.equal(fix.endOffset, undefined);
+  });
+
+  it("insertAfter is a zero-width insert indented to the directive", () => {
+    const d = serverTokens();
+    const fix = d.insertAfter("add_header X-Test 1;");
+
+    assert.equal(fix.startOffset, d.endOffset());
+    assert.equal(fix.endOffset, d.endOffset());
+    assert.equal(fix.newText, "\n    add_header X-Test 1;");
+    assert.equal(fix.line, 0);
+    assert.equal(fix.insertAfter, false);
+  });
+
+  it("insertBefore is a zero-width insert at the line start, not a replacement", () => {
+    const d = serverTokens();
+    const fix = d.insertBefore("add_header X-Test 1;");
+    const lineStart = d.startOffset() - (d.column() - 1);
+
+    // The offsets are what make this an insert: without them the applier
+    // normalizes the record into a whole-line replacement and the directive
+    // is lost.
+    assert.equal(fix.startOffset, lineStart);
+    assert.equal(fix.endOffset, lineStart);
+    assert.equal(fix.newText, "    add_header X-Test 1;\n");
+    assert.equal(fix.line, 0);
+  });
+
+  it("the *Many variants indent every line", () => {
+    const d = serverTokens();
+    const lineStart = d.startOffset() - (d.column() - 1);
+
+    const after = d.insertAfterMany(["a 1;", "b 2;"]);
+    assert.equal(after.startOffset, d.endOffset());
+    assert.equal(after.newText, "\n    a 1;\n    b 2;");
+
+    const before = d.insertBeforeMany(["a 1;", "b 2;"]);
+    assert.equal(before.startOffset, lineStart);
+    assert.equal(before.newText, "    a 1;\n    b 2;\n");
+  });
+
+  it("a top-level directive gets no indent", () => {
+    const cfg = parseConfig("server_tokens on;\n");
+    const ctx = cfg
+      .allDirectivesWithContext()
+      .find((c) => c.directive.is("server_tokens"));
+    assert.ok(ctx);
+
+    assert.equal(ctx.directive.insertBefore("a 1;").newText, "a 1;\n");
+    assert.equal(ctx.directive.insertAfter("a 1;").newText, "\na 1;");
+  });
+});

--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
@@ -27,6 +27,25 @@ import type {
 
 // ── Wrap DirectiveData with Directive interface ─────────────────────
 
+/** Mirror of the host's `make_range_fix`: a zero-`line` range-based fix. */
+function rangeFix(start: number, end: number, newText: string): Fix {
+  return {
+    line: 0, oldText: undefined, newText,
+    deleteLine: false, insertAfter: false,
+    startOffset: start, endOffset: end,
+  };
+}
+
+/** The indent the host prefixes to each inserted line: `" ".repeat(column - 1)`. */
+function indentOf(data: DirectiveData): string {
+  return " ".repeat(Math.max(data.column - 1, 0));
+}
+
+/** Offset of the start of the directive's line, as the host computes it. */
+function lineStartOffset(data: DirectiveData): number {
+  return Math.max(data.startOffset - (data.column - 1), 0);
+}
+
 function wrapDirective(
   data: DirectiveData,
   resolveBlockItems: () => ConfigItem[],
@@ -54,12 +73,18 @@ function wrapDirective(
     hasBlock() { return data.hasBlock; },
     blockItems(): ConfigItem[] { return resolveBlockItems(); },
     blockIsRaw() { return data.blockIsRaw; },
+    // The fix constructors below must produce byte-identical Fix records to
+    // the host's implementations in src/plugin/component_rule.rs
+    // (replace_with / delete_line_fix / insert_* on DirectiveResource), so a
+    // plugin gets the same --fix result whether its Config came from the
+    // host resource or from a reconstructed snapshot.
     replaceWith(newText: string): Fix {
-      return {
-        line: data.line, oldText: undefined, newText,
-        deleteLine: false, insertAfter: false,
-        startOffset: data.startOffset, endOffset: data.endOffset,
-      };
+      const leading = data.leadingWhitespace;
+      return rangeFix(
+        data.startOffset - leading.length,
+        data.endOffset,
+        leading + newText,
+      );
     },
     deleteLineFix(): Fix {
       return {
@@ -69,32 +94,22 @@ function wrapDirective(
       };
     },
     insertAfter(newText: string): Fix {
-      return {
-        line: data.line, oldText: undefined, newText,
-        deleteLine: false, insertAfter: true,
-        startOffset: undefined, endOffset: undefined,
-      };
+      return rangeFix(data.endOffset, data.endOffset, `\n${indentOf(data)}${newText}`);
     },
     insertBefore(newText: string): Fix {
-      return {
-        line: data.line, oldText: undefined, newText,
-        deleteLine: false, insertAfter: false,
-        startOffset: undefined, endOffset: undefined,
-      };
+      const offset = lineStartOffset(data);
+      return rangeFix(offset, offset, `${indentOf(data)}${newText}\n`);
     },
     insertAfterMany(lines: string[]): Fix {
-      return {
-        line: data.line, oldText: undefined, newText: lines.join("\n"),
-        deleteLine: false, insertAfter: true,
-        startOffset: undefined, endOffset: undefined,
-      };
+      const indent = indentOf(data);
+      const text = lines.map((line) => `\n${indent}${line}`).join("");
+      return rangeFix(data.endOffset, data.endOffset, text);
     },
     insertBeforeMany(lines: string[]): Fix {
-      return {
-        line: data.line, oldText: undefined, newText: lines.join("\n"),
-        deleteLine: false, insertAfter: false,
-        startOffset: undefined, endOffset: undefined,
-      };
+      const indent = indentOf(data);
+      const text = lines.map((line) => `${indent}${line}\n`).join("");
+      const offset = lineStartOffset(data);
+      return rangeFix(offset, offset, text);
     },
   } as Directive;
 }

--- a/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
@@ -12,18 +12,24 @@
  * // wrangler/esbuild compiles a .wasm import to a WebAssembly.Module:
  * import coreModule from "nginx-lint-plugin/wasm/parser/parser.core.wasm";
  *
+ * // Optional: only needed to test what a rule's fixes produce.
+ * import fixerCore from "nginx-lint-plugin/wasm/fixer/fixer.core.wasm";
+ *
  * const { parseConfig, PluginTestRunner } = await createTesting({
  *   getCoreModule: () => coreModule,
- *   // The core module has no imports, so it can be instantiated synchronously.
+ *   getFixerCoreModule: () => fixerCore,
+ *   // The core modules have no imports, so they can be instantiated synchronously.
  *   instantiateCore: (module) => new WebAssembly.Instance(module),
  * });
  * ```
  */
 
 import { instantiate } from "../wasm/parser/parser.js";
+import { instantiate as instantiateFixer } from "../wasm/fixer/fixer.js";
 import {
   makeParseConfig,
   makePluginTestRunner,
+  type ApplyFixesFn,
   type ParseConfigFn,
   type PluginTestRunnerClass,
 } from "./testing-core.js";
@@ -45,6 +51,15 @@ export interface CreateTestingOptions {
     module: WebAssembly.Module,
     imports: Record<string, unknown>,
   ) => WebAssembly.Instance | Promise<WebAssembly.Instance>;
+  /**
+   * Compile the fix applier's core WASM module ("fixer.core.wasm"), enabling
+   * `PluginTestRunner.fixString()` / `assertFixed()`. Optional: omit it and
+   * those two throw with instructions, leaving everything else working — so
+   * a caller that only parses need not bundle a second module.
+   */
+  getFixerCoreModule?: (
+    path: string,
+  ) => WebAssembly.Module | Promise<WebAssembly.Module>;
 }
 
 export interface Testing {
@@ -67,6 +82,25 @@ export async function createTesting(
     options.instantiateCore,
   );
   const parseConfig = makeParseConfig(root.parseConfig);
-  const PluginTestRunner = makePluginTestRunner(parseConfig);
+
+  let applyFixes: ApplyFixesFn;
+  if (options.getFixerCoreModule) {
+    const fixer = await instantiateFixer(
+      options.getFixerCoreModule,
+      {} as never,
+      options.instantiateCore,
+    );
+    applyFixes = fixer.applyFixes;
+  } else {
+    applyFixes = () => {
+      throw new Error(
+        "Testing fixes needs the applier component: pass getFixerCoreModule " +
+          '(e.g. import coreModule from "nginx-lint-plugin/wasm/fixer/fixer.core.wasm") ' +
+          "to createTesting().",
+      );
+    };
+  }
+
+  const PluginTestRunner = makePluginTestRunner(parseConfig, applyFixes);
   return { parseConfig, PluginTestRunner };
 }

--- a/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner-custom.ts
@@ -65,6 +65,11 @@ export interface CreateTestingOptions {
 export interface Testing {
   parseConfig: ParseConfigFn;
   PluginTestRunner: PluginTestRunnerClass;
+  /**
+   * Apply fixes without going through a runner. Throws unless
+   * {@link CreateTestingOptions.getFixerCoreModule} was supplied.
+   */
+  applyFixes: ApplyFixesFn;
 }
 
 /**
@@ -102,5 +107,5 @@ export async function createTesting(
   }
 
   const PluginTestRunner = makePluginTestRunner(parseConfig, applyFixes);
-  return { parseConfig, PluginTestRunner };
+  return { parseConfig, PluginTestRunner, applyFixes };
 }

--- a/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/plugin-test-runner.ts
@@ -15,6 +15,7 @@
  */
 
 import { instantiate } from "../wasm/parser/parser.js";
+import { instantiate as instantiateFixer } from "../wasm/fixer/fixer.js";
 import { makeParseConfig, makePluginTestRunner } from "./testing-core.js";
 
 // When `getCoreModule` is omitted, jco's generated glue falls back to its
@@ -26,6 +27,11 @@ const { parseConfig: parseConfigWasm } = await instantiate(
   undefined as never,
   {} as never,
 );
+
+// The fix applier, instantiated the same way. It is a second component
+// because the applier lives in nginx-lint-common, which depends on
+// nginx-lint-parser — the parser component cannot export it.
+const { applyFixes } = await instantiateFixer(undefined as never, {} as never);
 
 /**
  * Parse an nginx configuration string into a WIT-compatible Config object.
@@ -51,5 +57,11 @@ export const parseConfig = makeParseConfig(parseConfigWasm);
  * runner.assertErrors("http { server_tokens off; }", 0);
  * ```
  */
-export const PluginTestRunner = makePluginTestRunner(parseConfig);
+export const PluginTestRunner = makePluginTestRunner(parseConfig, applyFixes);
+
+/**
+ * Apply fixes to a config the way `nginx-lint --fix` would, using the
+ * linter's own applier rather than a reimplementation of it.
+ */
+export { applyFixes };
 export type PluginTestRunner = InstanceType<typeof PluginTestRunner>;

--- a/plugins/typescript/nginx-lint-plugin/src/testing-core.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/testing-core.ts
@@ -18,12 +18,20 @@ import type {
   PluginSpec,
 } from "./generated/interfaces/nginx-lint-plugin-types.js";
 import type { ParseOutput } from "../wasm/parser/interfaces/nginx-lint-plugin-parser-types.js";
+import type { Fix } from "./generated/interfaces/nginx-lint-plugin-types.js";
+import type { FixResult } from "../wasm/fixer/interfaces/nginx-lint-plugin-fixer-types.js";
 
 /** The raw component export: parse a config string into the flat ParseOutput. */
 export type WasmParseConfig = (
   source: string,
   includeContext: string[],
 ) => ParseOutput;
+
+/** What the linter's fix applier did with a set of fixes. */
+export type { FixResult };
+
+/** Apply fixes the way `nginx-lint --fix` would. */
+export type ApplyFixesFn = (content: string, fixes: Fix[]) => FixResult;
 
 /** High-level parse: returns the method-based Config used by plugins. */
 export type ParseConfigFn = (
@@ -52,6 +60,14 @@ export interface PluginTestRunner {
   assertErrorOnLine(content: string, line: number): void;
   /** Assert `badConf` produces errors and `goodConf` produces none. */
   testExamples(badConf: string, goodConf: string): void;
+  /** Apply every fix this rule reports for `content`. */
+  fixString(content: string, opts?: { includeContext?: string[] }): FixResult;
+  /** Assert that applying this rule's fixes to `content` yields `expected`. */
+  assertFixed(
+    content: string,
+    expected: string,
+    opts?: { includeContext?: string[] },
+  ): void;
 }
 
 /** Constructor of {@link PluginTestRunner}. */
@@ -62,6 +78,7 @@ export interface PluginTestRunnerClass {
 /** Build the PluginTestRunner class bound to a given `parseConfig`. */
 export function makePluginTestRunner(
   parseConfig: ParseConfigFn,
+  applyFixes: ApplyFixesFn,
 ): PluginTestRunnerClass {
   // The explicit PluginTestRunnerClass return type keeps the anonymous class's
   // private members out of re-exporters' declaration files (TS4094).
@@ -110,6 +127,53 @@ export function makePluginTestRunner(
         const lines = errors.map((e) => e.line);
         throw new Error(
           `Expected error on line ${line} from "${this.specFn().name}", got errors on lines: ${JSON.stringify(lines)}`,
+        );
+      }
+    }
+
+    /**
+     * Apply every fix this rule reports for `content`.
+     *
+     * All of the rule's fixes go through the applier in one call, as
+     * `nginx-lint --fix --rule-only <rule>` does, so overlapping fixes
+     * resolve the same way here as in production. One difference: this
+     * calls the plugin's `check` directly, so findings the linter would
+     * have suppressed via an ignore comment still contribute their fixes.
+     */
+    fixString(content: string, opts?: { includeContext?: string[] }): FixResult {
+      const errors = this.checkString(content, opts);
+      const fixes = errors.flatMap((e) => e.fixes);
+      return applyFixes(content, fixes);
+    }
+
+    /**
+     * Assert that applying this rule's fixes to `content` yields `expected`.
+     *
+     * Fails if any fix was unapplicable rather than comparing the output of
+     * a fix that silently did nothing. The applier always ends its output
+     * with a newline, so a config written without a trailing one comes back
+     * with it added.
+     */
+    assertFixed(
+      content: string,
+      expected: string,
+      opts?: { includeContext?: string[] },
+    ): void {
+      const result = this.fixString(content, opts);
+      if (result.skippedInvalid > 0) {
+        throw new Error(
+          `${result.skippedInvalid} fix(es) from "${this.specFn().name}" could not be applied ` +
+            `(applied ${result.applied}); the rule is producing fixes the linter rejects`,
+        );
+      }
+      if (result.content !== expected) {
+        const hint =
+          result.content === `${expected}\n`
+            ? "\n(the only difference is the trailing newline the applier always adds)"
+            : "";
+        throw new Error(
+          `Applying ${result.applied} fix(es) from "${this.specFn().name}" gave:\n` +
+            `${JSON.stringify(result.content)}\nexpected:\n${JSON.stringify(expected)}${hint}`,
         );
       }
     }

--- a/plugins/typescript/server-tokens-enabled-ts/src/plugin.test.ts
+++ b/plugins/typescript/server-tokens-enabled-ts/src/plugin.test.ts
@@ -146,6 +146,16 @@ server {
     assert.equal(errors.length, 0);
   });
 
+  it("fixing bad.conf produces good.conf", () => {
+    // The examples are not just illustrative: applying this rule's fix to
+    // bad.conf must yield good.conf byte for byte, through the same applier
+    // `nginx-lint --fix` uses.
+    runner.assertFixed(
+      readFileSync(resolve(examplesDir, "bad.conf"), "utf-8"),
+      readFileSync(resolve(examplesDir, "good.conf"), "utf-8"),
+    );
+  });
+
   it("testExamples with bad/good conf", () => {
     const badConf = readFileSync(resolve(examplesDir, "bad.conf"), "utf-8");
     const goodConf = readFileSync(resolve(examplesDir, "good.conf"), "utf-8");

--- a/wit/nginx-lint-plugin.wit
+++ b/wit/nginx-lint-plugin.wit
@@ -300,6 +300,31 @@ world plugin {
     export check: func(cfg: borrow<config>, path: string) -> list<lint-error>;
 }
 
+/// What the fix applier reports back. Kept out of `types` so the `plugin`
+/// world's import surface is unchanged and existing components stay
+/// loadable without recompiling.
+interface fixer-types {
+    record fix-result {
+        /// The config after the fixes were applied
+        content: string,
+        /// How many fixes were applied
+        applied: u32,
+        /// How many were dropped as unapplicable — bad offsets, or a
+        /// line-based fix whose line or old-text did not match. Does not
+        /// include fixes skipped for overlapping an applied one.
+        skipped-invalid: u32,
+    }
+}
+
+/// Applies fixes the way `nginx-lint --fix` does, so an SDK can test what
+/// a plugin's fixes produce rather than what their records say.
+world fixer {
+    use types.{fix};
+    use fixer-types.{fix-result};
+
+    export apply-fixes: func(content: string, fixes: list<fix>) -> fix-result;
+}
+
 world parser {
     use parser-types.{parse-output};
 


### PR DESCRIPTION
Fixes #377. Also the TypeScript half of #378.

Two commits: the bug, then the thing that proves it is fixed.

## 1. The constructors (`1a27114`)

`buildConfigFromSnapshot`'s `Directive` built `Fix` records that differed from the host's (`src/plugin/component_rule.rs`), so a plugin using the snapshot path produced different `--fix` results than the same plugin reading the host resource.

`insertBefore` / `insertBeforeMany` were the damaging pair: a line number with no offsets is a shape the applier normalizes into a **whole-line replacement**, so an "insert before this directive" fix *deleted* the directive. `insertAfter` lost the directive's indentation. `replaceWith` serialized a different payload than the host — the applied text matched, but the `Fix` records in `--format json` did not.

Ported the host's arithmetic (zero-width range fixes with `line: 0`, per-line indent from the directive's column, leading-whitespace expansion in `replaceWith`) — the same correction the Python SDK got in #376, with tests pinning each record the way that SDK's do.

## 2. Making it testable (`8d73cb9`)

Pinning the records is a proxy; the bug was only visible in what they *do*. So the SDK now runs fixes through the linter's own applier:

```ts
const result = applyFixes(content, fixes);   // { content, applied, skippedInvalid }
runner.assertFixed(before, after);
```

**Why a second component.** The obvious move — add `apply-fixes` to the existing `parser` world — does not work: the applier is in `nginx-lint-common`, and `nginx-lint-common` depends on `nginx-lint-parser`, so the parser crate cannot depend back on it. Instead `nginx-lint-common` gains a `wasm` feature carrying a new `fixer` world, exactly mirroring how the parser crate exposes its own, transpiled to `wasm/fixer/` next to `wasm/parser/`.

The WIT addition is a sibling world plus its own `fixer-types` interface, deliberately **not** touching `types`, so the `plugin` world's import surface is unchanged and existing `.wasm` components stay loadable without recompiling. Verified by linting with the already-built Python component after the change.

**Why not fold the parser into it instead**, now that `nginx-lint-common` can host a world (it depends on the parser, so one component could export both) — measured rather than assumed:

- There is no duplication to reclaim today. The fixer is 67 KB and carries essentially no parser code (1 parser/rowan symbol vs the parser component's 27): the applier never calls the parser, so the linker drops it. Merging would save only the shared Rust runtime, on the order of 20–30 KB against the current 114 + 67.
- It would make the main case worse. A workerd consumer that only parses ships 114 KB today, because `getFixerCoreModule` is optional; merged, everyone carries the applier.
- `nginx-lint-common` would have to implement `parse-config`, and the 211-line conversion in the parser's `wasm.rs` is bound to the types `wit_bindgen` generates per world — so a merged world means duplicating that conversion or refactoring it to be shared. Duplicating it adds exactly the drift the Python SDK's mirror already costs us.

If the two components ever do become a burden, the order is: make the conversion shareable first, then merge.

For the workerd entry (`testing/custom`) the fixer is **optional**: omit `getFixerCoreModule` and only `fixString`/`assertFixed` throw, with a message saying what to pass. Existing callers keep working without bundling a second module.

## Testing

The two tests this PR exists to make possible, mirroring the Python ones:

```ts
it("insertBefore keeps the directive it inserts before", ...)
it("the old line-based shape would have replaced the line", ...)
```

The second builds the pre-fix record by hand and pins that it eats the directive (`http {\nadd_header X-Test 1;\n}\n` — `server_tokens on;` gone).

- SDK: 18 tests (6 constructor-record tests, 5 outcome tests, existing snapshot tests)
- Example plugin: 18 tests, now including `bad.conf` → `good.conf` byte for byte
- **Byte-identical to production**: applying the rule's fix through the SDK and through `nginx-lint --fix --rule-only server-tokens-enabled-ts` gives the same output, both equal to `good.conf`
- No fallout elsewhere: Python SDK (29) and plugin (18) tests pass after regenerating bindings from the changed WIT, `make test-e2e` OK, and the Rust workspace is clean across fmt / clippy / 275 + 94 tests
- CI builds the new component alongside the parser in the TypeScript Plugin job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S
