### PR TITLE
fix: ship the WIT so the crates' wit-bindgen features work from crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,13 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace --features plugins -- -D clippy::all
-      - name: Check the parser crate's vendored WIT matches the root
-        # It is vendored so the crate's `wasm` feature works from crates.io;
-        # a stale copy would generate bindings for the wrong interface.
-        run: diff wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
+      - name: Check the vendored WITs match the root
+        # They are vendored so the crates' wit-bindgen features work from
+        # crates.io; a stale copy would generate bindings for the wrong
+        # interface. `make copy-wit` refreshes them.
+        run: |
+          diff wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
+          diff wit/nginx-lint-plugin.wit crates/nginx-lint-plugin/wit/nginx-lint-plugin.wit
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,17 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo clippy --workspace --features plugins -- -D clippy::all
       - name: Check the vendored WITs match the root
-        # They are vendored so the crates' wit-bindgen features work from
+        # Before clippy: wit-export is on for every builtin plugin, so a stale
+        # copy fails there first with raw wit-bindgen type errors and this
+        # step — the one that names the cause — would never run. They are
+        # vendored so the crates' wit-bindgen features work from
         # crates.io; a stale copy would generate bindings for the wrong
         # interface. `make copy-wit` refreshes them.
         run: |
           diff wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
           diff wit/nginx-lint-plugin.wit crates/nginx-lint-plugin/wit/nginx-lint-plugin.wit
+      - run: cargo clippy --workspace --features plugins -- -D clippy::all
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace --features plugins -- -D clippy::all
+      - name: Check the parser crate's vendored WIT matches the root
+        # It is vendored so the crate's `wasm` feature works from crates.io;
+        # a stale copy would generate bindings for the wrong interface.
+        run: diff wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_DIRS := $(wildcard plugins/builtin/*/*/)
 PLUGIN_NAMES := $(foreach dir,$(PLUGIN_DIRS),$(notdir $(patsubst %/,%,$(dir))))
 PLUGIN_WASMS := $(foreach name,$(PLUGIN_NAMES),target/builtin-plugins/$(name).wasm)
 
-.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm build-fixer-wasm clean test lint lint-plugin-examples doc help
+.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm copy-parser-wit build-fixer-wasm clean test lint lint-plugin-examples doc help
 
 # Build CLI with native plugins (release, default)
 build:
@@ -105,8 +105,16 @@ build-fixer-wasm:
 			-o wasm/fixer --name fixer --instantiation async
 	@echo "Fixer component built and transpiled."
 
+# The parser crate vendors the WIT so its `wasm` feature works from the
+# published crate too (the macro cannot read a path outside the package).
+# The copy is committed; CI checks it against the root.
+copy-parser-wit:
+	@mkdir -p crates/nginx-lint-parser/wit
+	@cp wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/
+	@echo "Copied wit/nginx-lint-plugin.wit into the parser crate."
+
 # Build nginx-lint-parser as WASM Component for TypeScript plugin testing
-build-parser-wasm:
+build-parser-wasm: copy-parser-wit
 	@command -v wasm-tools >/dev/null 2>&1 || { echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"; exit 1; }
 	cargo build --manifest-path crates/nginx-lint-parser/Cargo.toml \
 		--target wasm32-unknown-unknown --release --features wasm

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,11 @@ SHARED_PLUGIN_TARGET := target/wasm-plugins
 # Build all WASM builtin plugins as WIT components (requires: wasm-tools)
 # Uses a shared target directory so nginx-lint-plugin and other dependencies
 # are compiled only once instead of per-plugin.
-build-plugins:
+# copy-wit first: these compile the plugin SDK, which reads its vendored WIT,
+# while the host reads the root one — building against a stale copy yields
+# components that fail to instantiate with a component-type mismatch rather
+# than anything that names the cause.
+build-plugins: copy-wit
 	@command -v wasm-tools >/dev/null 2>&1 || { echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"; exit 1; }
 	@echo "Building plugins (shared target: $(SHARED_PLUGIN_TARGET))..."
 	@for dir in $(PLUGIN_DIRS); do \
@@ -192,6 +196,7 @@ help:
 	@echo "  make build-plugins      - Build WASM builtin plugins as WIT components"
 	@echo "  make build-with-wasm-plugins - Build CLI with embedded WASM plugins"
 	@echo "  make build-parser-wasm  - Build parser WASM for TypeScript plugin testing"
+	@echo "  make copy-wit           - Refresh the WIT vendored into the parser/plugin crates"
 	@echo "  make build-fixer-wasm   - Build fix-applier WASM for TypeScript plugin testing"
 	@echo "                            (the TypeScript SDK imports both; build them together)"
 	@echo "  make build-wasm         - Build WASM for web (without plugins)"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_DIRS := $(wildcard plugins/builtin/*/*/)
 PLUGIN_NAMES := $(foreach dir,$(PLUGIN_DIRS),$(notdir $(patsubst %/,%,$(dir))))
 PLUGIN_WASMS := $(foreach name,$(PLUGIN_NAMES),target/builtin-plugins/$(name).wasm)
 
-.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm copy-parser-wit build-fixer-wasm clean test lint lint-plugin-examples doc help
+.PHONY: build build-wasm build-wasm-with-plugins build-web build-plugins collect-plugins collect-plugins-only build-with-wasm-plugins build-parser-wasm copy-wit build-fixer-wasm clean test lint lint-plugin-examples doc help
 
 # Build CLI with native plugins (release, default)
 build:
@@ -105,16 +105,17 @@ build-fixer-wasm:
 			-o wasm/fixer --name fixer --instantiation async
 	@echo "Fixer component built and transpiled."
 
-# The parser crate vendors the WIT so its `wasm` feature works from the
-# published crate too (the macro cannot read a path outside the package).
-# The copy is committed; CI checks it against the root.
-copy-parser-wit:
-	@mkdir -p crates/nginx-lint-parser/wit
+# The parser and plugin crates vendor the WIT so their wit-bindgen features
+# work from the published crates too (the macro cannot read a path outside
+# the package). The copies are committed; CI checks them against the root.
+copy-wit:
+	@mkdir -p crates/nginx-lint-parser/wit crates/nginx-lint-plugin/wit
 	@cp wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/
-	@echo "Copied wit/nginx-lint-plugin.wit into the parser crate."
+	@cp wit/nginx-lint-plugin.wit crates/nginx-lint-plugin/wit/
+	@echo "Copied wit/nginx-lint-plugin.wit into the parser and plugin crates."
 
 # Build nginx-lint-parser as WASM Component for TypeScript plugin testing
-build-parser-wasm: copy-parser-wit
+build-parser-wasm: copy-wit
 	@command -v wasm-tools >/dev/null 2>&1 || { echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"; exit 1; }
 	cargo build --manifest-path crates/nginx-lint-parser/Cargo.toml \
 		--target wasm32-unknown-unknown --release --features wasm

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,19 @@ build-fixer-wasm:
 # The parser and plugin crates vendor the WIT so their wit-bindgen features
 # work from the published crates too (the macro cannot read a path outside
 # the package). The copies are committed; CI checks them against the root.
+
+# Only copy when the content differs: wit-bindgen tracks the WIT through an
+# include_bytes!, so bumping its mtime alone rebuilds the SDK and every
+# plugin that depends on it — which build-plugins would then do every run.
 copy-wit:
 	@mkdir -p crates/nginx-lint-parser/wit crates/nginx-lint-plugin/wit
-	@cp wit/nginx-lint-plugin.wit crates/nginx-lint-parser/wit/
-	@cp wit/nginx-lint-plugin.wit crates/nginx-lint-plugin/wit/
-	@echo "Copied wit/nginx-lint-plugin.wit into the parser and plugin crates."
+	@for dir in crates/nginx-lint-parser crates/nginx-lint-plugin; do \
+		dest="$$dir/wit/nginx-lint-plugin.wit"; \
+		if ! cmp -s wit/nginx-lint-plugin.wit "$$dest"; then \
+			cp wit/nginx-lint-plugin.wit "$$dest"; \
+			echo "  Refreshed $$dest"; \
+		fi; \
+	done
 
 # Build nginx-lint-parser as WASM Component for TypeScript plugin testing
 build-parser-wasm: copy-wit

--- a/crates/nginx-lint-common/Cargo.toml
+++ b/crates/nginx-lint-common/Cargo.toml
@@ -15,7 +15,11 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = []
 # Exposes the fix applier as a WASM component (the `fixer` world), which the
-# TypeScript SDK instantiates to test what a plugin's fixes produce
+# TypeScript SDK instantiates to test what a plugin's fixes produce.
+# Repository-internal: builds this crate as a WASM component for the
+# TypeScript SDK. It cannot be enabled from the published crate — the macro
+# reads ../../wit/nginx-lint-plugin.wit, which lives outside the packaged
+# directory. Use `make build-fixer-wasm` in a checkout instead. (#388)
 wasm = ["dep:wit-bindgen"]
 
 [dependencies]

--- a/crates/nginx-lint-common/src/lib.rs
+++ b/crates/nginx-lint-common/src/lib.rs
@@ -4,6 +4,15 @@
 //! ecosystem: lint rule definitions, error reporting, configuration management,
 //! and ignore comment support.
 //!
+//! # The `wasm` feature
+//!
+//! `wasm` builds this crate as a WASM component for the TypeScript SDK, and
+//! only works inside a repository checkout: the `wit_bindgen::generate!`
+//! invocation reads `wit/nginx-lint-plugin.wit` from the repository root,
+//! which is not part of the published crate. Enabling it on a dependency
+//! from crates.io fails with a missing-file error. Build the component with
+//! `make build-fixer-wasm` instead.
+//!
 //! # Modules
 //!
 //! - [`linter`] — Core lint types: [`LintRule`] trait, [`LintError`], [`Severity`], [`Fix`]

--- a/crates/nginx-lint-parser/Cargo.toml
+++ b/crates/nginx-lint-parser/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
+# Repository-internal: builds this crate as a WASM component for the
+# TypeScript SDK. It cannot be enabled from the published crate — the macro
+# reads ../../wit/nginx-lint-plugin.wit, which lives outside the packaged
+# directory. Use `make build-parser-wasm` in a checkout instead. (#388)
 wasm = ["dep:wit-bindgen"]
 
 [dependencies]

--- a/crates/nginx-lint-parser/Cargo.toml
+++ b/crates/nginx-lint-parser/Cargo.toml
@@ -7,15 +7,18 @@ license = "MIT"
 repository = "https://github.com/walf443/nginx-lint"
 authors = ["walf443"]
 
+include = ["src/**/*", "wit/*.wit", "Cargo.toml", "README.md"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
-# Repository-internal: builds this crate as a WASM component for the
-# TypeScript SDK. It cannot be enabled from the published crate — the macro
-# reads ../../wit/nginx-lint-plugin.wit, which lives outside the packaged
-# directory. Use `make build-parser-wasm` in a checkout instead. (#388)
+# Builds this crate as a WASM component exporting the `parser` world. The
+# WIT it generates from is vendored into wit/ and shipped in the package
+# (see `include` above), so this works from crates.io as well as in a
+# checkout — keep the copy in sync with the repository root's via
+# `make copy-parser-wit`.
 wasm = ["dep:wit-bindgen"]
 
 [dependencies]

--- a/crates/nginx-lint-parser/Cargo.toml
+++ b/crates/nginx-lint-parser/Cargo.toml
@@ -7,7 +7,11 @@ license = "MIT"
 repository = "https://github.com/walf443/nginx-lint"
 authors = ["walf443"]
 
-include = ["src/**/*", "wit/*.wit", "Cargo.toml", "README.md"]
+# Anchored so these match only at the crate root: unanchored gitignore-style
+# patterns match at any depth, and setting `include` also stops cargo from
+# filtering by .gitignore — together those shipped a stale wasm-pack pkg/.
+# tests/ is listed to keep `cargo test` working from the packaged crate.
+include = ["/src/**", "/tests/**", "/wit/*.wit", "/Cargo.toml", "/README.md"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/nginx-lint-parser/Cargo.toml
+++ b/crates/nginx-lint-parser/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 # WIT it generates from is vendored into wit/ and shipped in the package
 # (see `include` above), so this works from crates.io as well as in a
 # checkout — keep the copy in sync with the repository root's via
-# `make copy-parser-wit`.
+# `make copy-wit`.
 wasm = ["dep:wit-bindgen"]
 
 [dependencies]

--- a/crates/nginx-lint-parser/src/lib.rs
+++ b/crates/nginx-lint-parser/src/lib.rs
@@ -7,12 +7,12 @@
 //!
 //! # The `wasm` feature
 //!
-//! `wasm` builds this crate as a WASM component for the TypeScript SDK, and
-//! only works inside a repository checkout: the `wit_bindgen::generate!`
-//! invocation reads `wit/nginx-lint-plugin.wit` from the repository root,
-//! which is not part of the published crate. Enabling it on a dependency
-//! from crates.io fails with a missing-file error. Build the component with
-//! `make build-parser-wasm` instead.
+//! `wasm` builds this crate as a WASM component exporting the `parser`
+//! world — `parse-config(source, include-context)` returning the AST as a
+//! flat, index-based record tree. The nginx-lint TypeScript SDK uses it to
+//! parse configs in-process; it is published rather than repository-only,
+//! so anything that wants nginx parsing in a component-model host can use
+//! it the same way.
 //!
 //! # Quick Start
 //!

--- a/crates/nginx-lint-parser/src/lib.rs
+++ b/crates/nginx-lint-parser/src/lib.rs
@@ -5,6 +5,15 @@
 //! extension modules (ngx_headers_more, lua-nginx-module, etc.) are supported
 //! without special configuration.
 //!
+//! # The `wasm` feature
+//!
+//! `wasm` builds this crate as a WASM component for the TypeScript SDK, and
+//! only works inside a repository checkout: the `wit_bindgen::generate!`
+//! invocation reads `wit/nginx-lint-plugin.wit` from the repository root,
+//! which is not part of the published crate. Enabling it on a dependency
+//! from crates.io fails with a missing-file error. Build the component with
+//! `make build-parser-wasm` instead.
+//!
 //! # Quick Start
 //!
 //! ```

--- a/crates/nginx-lint-parser/src/wasm.rs
+++ b/crates/nginx-lint-parser/src/wasm.rs
@@ -2,7 +2,7 @@ use crate::ast::{Argument, ArgumentValue, Comment, Config, ConfigItem, Directive
 
 // Generate guest-side bindings from the WIT file for the parser world
 wit_bindgen::generate!({
-    path: "../../wit/nginx-lint-plugin.wit",
+    path: "wit/nginx-lint-plugin.wit",
     world: "parser",
     pub_export_macro: true,
 });

--- a/crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
+++ b/crates/nginx-lint-parser/wit/nginx-lint-plugin.wit
@@ -1,0 +1,333 @@
+package nginx-lint:plugin@4.0.0;
+
+interface types {
+    enum severity {
+        error,
+        warning,
+    }
+
+    record fix {
+        line: u32,
+        old-text: option<string>,
+        new-text: string,
+        delete-line: bool,
+        insert-after: bool,
+        start-offset: option<u32>,
+        end-offset: option<u32>,
+    }
+
+    record lint-error {
+        rule: string,
+        category: string,
+        message: string,
+        severity: severity,
+        line: option<u32>,
+        column: option<u32>,
+        fixes: list<fix>,
+    }
+
+    record plugin-spec {
+        name: string,
+        category: string,
+        description: string,
+        api-version: string,
+        severity: option<string>,
+        why: option<string>,
+        bad-example: option<string>,
+        good-example: option<string>,
+        references: option<list<string>>,
+        min-nginx-version: option<string>,
+        max-nginx-version: option<string>,
+    }
+}
+
+/// Shared data types used by both the plugin config-api (resource-based)
+/// and the parser output (record-based).
+interface data-types {
+    /// Argument value type
+    enum argument-type {
+        literal,
+        quoted-string,
+        single-quoted-string,
+        variable,
+    }
+
+    /// Argument data (returned as a record since it's small)
+    record argument-info {
+        value: string,
+        raw: string,
+        arg-type: argument-type,
+        line: u32,
+        column: u32,
+        start-offset: u32,
+        end-offset: u32,
+    }
+
+    /// Comment data
+    record comment-info {
+        text: string,
+        line: u32,
+        column: u32,
+        leading-whitespace: string,
+        trailing-whitespace: string,
+        start-offset: u32,
+        end-offset: u32,
+    }
+
+    /// Blank line data
+    record blank-line-info {
+        line: u32,
+        content: string,
+        start-offset: u32,
+    }
+
+    /// All flat properties of a directive (for bulk retrieval)
+    record directive-data {
+        name: string,
+        args: list<argument-info>,
+        line: u32,
+        column: u32,
+        start-offset: u32,
+        end-offset: u32,
+        end-line: u32,
+        end-column: u32,
+        leading-whitespace: string,
+        trailing-whitespace: string,
+        space-before-terminator: string,
+        has-block: bool,
+        block-is-raw: bool,
+        /// Actual raw content for raw blocks (e.g., lua code); none if not a raw block
+        block-raw-content: option<string>,
+        /// Leading whitespace before the closing brace; none if no block
+        closing-brace-leading-whitespace: option<string>,
+        /// Trailing whitespace after the closing brace; none if no block
+        block-trailing-whitespace: option<string>,
+        /// Text of the trailing comment on the directive line; none if no comment
+        trailing-comment-text: option<string>,
+        /// End column of the name token (1-based)
+        name-end-column: u32,
+        /// End byte offset of the name token (0-based)
+        name-end-offset: u32,
+        /// Start line of the block's opening brace (1-based); none if no block
+        block-start-line: option<u32>,
+        /// Start column of the block's opening brace (1-based); none if no block
+        block-start-column: option<u32>,
+        /// Start byte offset of the block's opening brace (0-based); none if no block
+        block-start-offset: option<u32>,
+    }
+}
+
+interface config-api {
+    use types.{fix};
+    use data-types.{argument-type, argument-info, comment-info, blank-line-info, directive-data};
+    use parser-types.{config-item as flat-item};
+
+    /// The entire config as one flat value (see the `snapshot` function)
+    record config-snapshot {
+        /// Flat array of all config items (DFS order); directive items
+        /// reference their block children via child-indices
+        all-items: list<flat-item>,
+        /// Indices of top-level items in all-items
+        top-level-indices: list<u32>,
+        /// Include context (parent block names from the include directive)
+        include-context: list<string>,
+    }
+
+    /// A config item (directive, comment, or blank line)
+    variant config-item {
+        directive-item(directive),
+        comment-item(comment-info),
+        blank-line-item(blank-line-info),
+    }
+
+    /// A directive paired with its parent block context
+    record directive-context {
+        directive: directive,
+        parent-stack: list<string>,
+        depth: u32,
+    }
+
+    /// An nginx directive (resource backed by host data)
+    resource directive {
+        /// Get all flat properties in a single call (optimized for reconstruction)
+        data: func() -> directive-data;
+        /// Get the directive name
+        name: func() -> string;
+        /// Check if the directive has the given name
+        is: func(name: string) -> bool;
+
+        /// Get the first argument value
+        first-arg: func() -> option<string>;
+        /// Check if the first argument equals the given value
+        first-arg-is: func(value: string) -> bool;
+        /// Get the argument at the given index
+        arg-at: func(index: u32) -> option<string>;
+        /// Get the last argument value
+        last-arg: func() -> option<string>;
+        /// Check if any argument equals the given value
+        has-arg: func(value: string) -> bool;
+        /// Return the number of arguments
+        arg-count: func() -> u32;
+        /// Get all arguments as records
+        args: func() -> list<argument-info>;
+
+        /// Get the start line number (1-based)
+        line: func() -> u32;
+        /// Get the start column number (1-based)
+        column: func() -> u32;
+        /// Get the start byte offset (0-based)
+        start-offset: func() -> u32;
+        /// Get the end byte offset (0-based)
+        end-offset: func() -> u32;
+        /// Get the leading whitespace before the directive
+        leading-whitespace: func() -> string;
+        /// Get the trailing whitespace after the directive
+        trailing-whitespace: func() -> string;
+        /// Get the space before the terminator (; or {)
+        space-before-terminator: func() -> string;
+
+        /// Check if the directive has a block
+        has-block: func() -> bool;
+        /// Get the items inside the directive's block
+        block-items: func() -> list<config-item>;
+        /// Check if the block contains raw content (e.g., lua blocks)
+        block-is-raw: func() -> bool;
+
+        /// Create a fix that replaces this directive with new text
+        replace-with: func(new-text: string) -> fix;
+        /// Create a fix that deletes this directive's line
+        delete-line-fix: func() -> fix;
+        /// Create a fix that inserts a new line after this directive
+        insert-after: func(new-text: string) -> fix;
+        /// Create a fix that inserts a new line before this directive
+        insert-before: func(new-text: string) -> fix;
+        /// Create a fix that inserts multiple lines after this directive
+        insert-after-many: func(lines: list<string>) -> fix;
+        /// Create a fix that inserts multiple lines before this directive
+        insert-before-many: func(lines: list<string>) -> fix;
+    }
+
+    /// The parsed nginx configuration (resource backed by host data)
+    resource config {
+        /// Get the entire config as one flat snapshot in a single call.
+        /// Bulk alternative to walking items/data/block-items per directive:
+        /// one host call transfers everything, which avoids per-directive
+        /// call overhead when reconstructing the whole tree guest-side.
+        snapshot: func() -> config-snapshot;
+        /// Get a snapshot pruned to directives whose name is in `names`,
+        /// plus the ancestor directives needed to preserve block-context
+        /// queries (e.g. `is-inside("http")`) for the matches. Directives
+        /// outside every match's ancestor chain are dropped entirely, so
+        /// the transferred/reconstructed tree is proportional to how much
+        /// of the config is actually relevant, not its total size.
+        /// Comments and blank lines are always omitted from this snapshot.
+        snapshot-filtered: func(names: list<string>) -> config-snapshot;
+        /// Iterate over all directives recursively with parent context
+        all-directives-with-context: func() -> list<directive-context>;
+        /// Iterate over all directives recursively
+        all-directives: func() -> list<directive>;
+        /// Get the top-level config items
+        items: func() -> list<config-item>;
+
+        /// Get the include context (parent block names from include directive)
+        include-context: func() -> list<string>;
+        /// Check if this config is included from within a specific context
+        is-included-from: func(context: string) -> bool;
+        /// Check if included from http context
+        is-included-from-http: func() -> bool;
+        /// Check if included from http > server context
+        is-included-from-http-server: func() -> bool;
+        /// Check if included from http > ... > location context
+        is-included-from-http-location: func() -> bool;
+        /// Check if included from stream context
+        is-included-from-stream: func() -> bool;
+        /// Get the immediate parent context
+        immediate-parent-context: func() -> option<string>;
+    }
+}
+
+/// Record-based types for parser output (no resources, no recursion).
+/// Uses index-based references to represent the tree structure:
+/// all config items are stored in a flat array, with child-indices
+/// pointing to children within that array.
+interface parser-types {
+    use data-types.{comment-info, blank-line-info, directive-data};
+
+    /// The kind of a config item (non-recursive)
+    variant config-item-value {
+        directive-item(directive-data),
+        comment-item(comment-info),
+        blank-line-item(blank-line-info),
+    }
+
+    /// A config item in the flat all-items array.
+    /// For directive items with blocks, child-indices contains the indices
+    /// of child items within the all-items array.
+    record config-item {
+        value: config-item-value,
+        child-indices: list<u32>,
+    }
+
+    /// A directive paired with its parent block context
+    record directive-context {
+        data: directive-data,
+        /// Indices of block items in the all-items array
+        block-item-indices: list<u32>,
+        parent-stack: list<string>,
+        depth: u32,
+    }
+
+    /// Complete parser output
+    record parse-output {
+        directives-with-context: list<directive-context>,
+        include-context: list<string>,
+        /// Flat array of all config items (DFS order)
+        all-items: list<config-item>,
+        /// Indices of top-level items in all-items
+        top-level-indices: list<u32>,
+    }
+}
+
+world plugin {
+    use types.{plugin-spec, lint-error};
+    use config-api.{config};
+    import config-api;
+
+    /// Return plugin metadata
+    export spec: func() -> plugin-spec;
+
+    /// Check config and return lint errors
+    export check: func(cfg: borrow<config>, path: string) -> list<lint-error>;
+}
+
+/// What the fix applier reports back. Kept out of `types` so the `plugin`
+/// world's import surface is unchanged and existing components stay
+/// loadable without recompiling.
+interface fixer-types {
+    record fix-result {
+        /// The config after the fixes were applied
+        content: string,
+        /// How many fixes were applied
+        applied: u32,
+        /// How many were dropped as unapplicable — bad offsets, or a
+        /// line-based fix whose line or old-text did not match. Does not
+        /// include fixes skipped for overlapping an applied one.
+        skipped-invalid: u32,
+    }
+}
+
+/// Applies fixes the way `nginx-lint --fix` does, so an SDK can test what
+/// a plugin's fixes produce rather than what their records say.
+world fixer {
+    use types.{fix};
+    use fixer-types.{fix-result};
+
+    export apply-fixes: func(content: string, fixes: list<fix>) -> fix-result;
+}
+
+world parser {
+    use parser-types.{parse-output};
+
+    /// Parse nginx config source and return structured output
+    export parse-config: func(source: string, include-context: list<string>) -> result<parse-output, string>;
+}

--- a/crates/nginx-lint-plugin/Cargo.toml
+++ b/crates/nginx-lint-plugin/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT"
 repository = "https://github.com/walf443/nginx-lint"
 authors = ["walf443"]
 
+# Anchored, and listing the vendored WIT: wit-export is on by default and is
+# what third-party plugins build against, so the interface definition has to
+# be in the package (see crates/nginx-lint-parser for the same treatment).
+include = ["/src/**", "/tests/**", "/wit/*.wit", "/Cargo.toml", "/README.md"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/crates/nginx-lint-plugin/src/wit_guest.rs
+++ b/crates/nginx-lint-plugin/src/wit_guest.rs
@@ -5,7 +5,7 @@
 
 // Generate guest-side bindings from the WIT file
 wit_bindgen::generate!({
-    path: "../../wit/nginx-lint-plugin.wit",
+    path: "wit/nginx-lint-plugin.wit",
     world: "plugin",
     pub_export_macro: true,
 });

--- a/crates/nginx-lint-plugin/wit/nginx-lint-plugin.wit
+++ b/crates/nginx-lint-plugin/wit/nginx-lint-plugin.wit
@@ -1,0 +1,333 @@
+package nginx-lint:plugin@4.0.0;
+
+interface types {
+    enum severity {
+        error,
+        warning,
+    }
+
+    record fix {
+        line: u32,
+        old-text: option<string>,
+        new-text: string,
+        delete-line: bool,
+        insert-after: bool,
+        start-offset: option<u32>,
+        end-offset: option<u32>,
+    }
+
+    record lint-error {
+        rule: string,
+        category: string,
+        message: string,
+        severity: severity,
+        line: option<u32>,
+        column: option<u32>,
+        fixes: list<fix>,
+    }
+
+    record plugin-spec {
+        name: string,
+        category: string,
+        description: string,
+        api-version: string,
+        severity: option<string>,
+        why: option<string>,
+        bad-example: option<string>,
+        good-example: option<string>,
+        references: option<list<string>>,
+        min-nginx-version: option<string>,
+        max-nginx-version: option<string>,
+    }
+}
+
+/// Shared data types used by both the plugin config-api (resource-based)
+/// and the parser output (record-based).
+interface data-types {
+    /// Argument value type
+    enum argument-type {
+        literal,
+        quoted-string,
+        single-quoted-string,
+        variable,
+    }
+
+    /// Argument data (returned as a record since it's small)
+    record argument-info {
+        value: string,
+        raw: string,
+        arg-type: argument-type,
+        line: u32,
+        column: u32,
+        start-offset: u32,
+        end-offset: u32,
+    }
+
+    /// Comment data
+    record comment-info {
+        text: string,
+        line: u32,
+        column: u32,
+        leading-whitespace: string,
+        trailing-whitespace: string,
+        start-offset: u32,
+        end-offset: u32,
+    }
+
+    /// Blank line data
+    record blank-line-info {
+        line: u32,
+        content: string,
+        start-offset: u32,
+    }
+
+    /// All flat properties of a directive (for bulk retrieval)
+    record directive-data {
+        name: string,
+        args: list<argument-info>,
+        line: u32,
+        column: u32,
+        start-offset: u32,
+        end-offset: u32,
+        end-line: u32,
+        end-column: u32,
+        leading-whitespace: string,
+        trailing-whitespace: string,
+        space-before-terminator: string,
+        has-block: bool,
+        block-is-raw: bool,
+        /// Actual raw content for raw blocks (e.g., lua code); none if not a raw block
+        block-raw-content: option<string>,
+        /// Leading whitespace before the closing brace; none if no block
+        closing-brace-leading-whitespace: option<string>,
+        /// Trailing whitespace after the closing brace; none if no block
+        block-trailing-whitespace: option<string>,
+        /// Text of the trailing comment on the directive line; none if no comment
+        trailing-comment-text: option<string>,
+        /// End column of the name token (1-based)
+        name-end-column: u32,
+        /// End byte offset of the name token (0-based)
+        name-end-offset: u32,
+        /// Start line of the block's opening brace (1-based); none if no block
+        block-start-line: option<u32>,
+        /// Start column of the block's opening brace (1-based); none if no block
+        block-start-column: option<u32>,
+        /// Start byte offset of the block's opening brace (0-based); none if no block
+        block-start-offset: option<u32>,
+    }
+}
+
+interface config-api {
+    use types.{fix};
+    use data-types.{argument-type, argument-info, comment-info, blank-line-info, directive-data};
+    use parser-types.{config-item as flat-item};
+
+    /// The entire config as one flat value (see the `snapshot` function)
+    record config-snapshot {
+        /// Flat array of all config items (DFS order); directive items
+        /// reference their block children via child-indices
+        all-items: list<flat-item>,
+        /// Indices of top-level items in all-items
+        top-level-indices: list<u32>,
+        /// Include context (parent block names from the include directive)
+        include-context: list<string>,
+    }
+
+    /// A config item (directive, comment, or blank line)
+    variant config-item {
+        directive-item(directive),
+        comment-item(comment-info),
+        blank-line-item(blank-line-info),
+    }
+
+    /// A directive paired with its parent block context
+    record directive-context {
+        directive: directive,
+        parent-stack: list<string>,
+        depth: u32,
+    }
+
+    /// An nginx directive (resource backed by host data)
+    resource directive {
+        /// Get all flat properties in a single call (optimized for reconstruction)
+        data: func() -> directive-data;
+        /// Get the directive name
+        name: func() -> string;
+        /// Check if the directive has the given name
+        is: func(name: string) -> bool;
+
+        /// Get the first argument value
+        first-arg: func() -> option<string>;
+        /// Check if the first argument equals the given value
+        first-arg-is: func(value: string) -> bool;
+        /// Get the argument at the given index
+        arg-at: func(index: u32) -> option<string>;
+        /// Get the last argument value
+        last-arg: func() -> option<string>;
+        /// Check if any argument equals the given value
+        has-arg: func(value: string) -> bool;
+        /// Return the number of arguments
+        arg-count: func() -> u32;
+        /// Get all arguments as records
+        args: func() -> list<argument-info>;
+
+        /// Get the start line number (1-based)
+        line: func() -> u32;
+        /// Get the start column number (1-based)
+        column: func() -> u32;
+        /// Get the start byte offset (0-based)
+        start-offset: func() -> u32;
+        /// Get the end byte offset (0-based)
+        end-offset: func() -> u32;
+        /// Get the leading whitespace before the directive
+        leading-whitespace: func() -> string;
+        /// Get the trailing whitespace after the directive
+        trailing-whitespace: func() -> string;
+        /// Get the space before the terminator (; or {)
+        space-before-terminator: func() -> string;
+
+        /// Check if the directive has a block
+        has-block: func() -> bool;
+        /// Get the items inside the directive's block
+        block-items: func() -> list<config-item>;
+        /// Check if the block contains raw content (e.g., lua blocks)
+        block-is-raw: func() -> bool;
+
+        /// Create a fix that replaces this directive with new text
+        replace-with: func(new-text: string) -> fix;
+        /// Create a fix that deletes this directive's line
+        delete-line-fix: func() -> fix;
+        /// Create a fix that inserts a new line after this directive
+        insert-after: func(new-text: string) -> fix;
+        /// Create a fix that inserts a new line before this directive
+        insert-before: func(new-text: string) -> fix;
+        /// Create a fix that inserts multiple lines after this directive
+        insert-after-many: func(lines: list<string>) -> fix;
+        /// Create a fix that inserts multiple lines before this directive
+        insert-before-many: func(lines: list<string>) -> fix;
+    }
+
+    /// The parsed nginx configuration (resource backed by host data)
+    resource config {
+        /// Get the entire config as one flat snapshot in a single call.
+        /// Bulk alternative to walking items/data/block-items per directive:
+        /// one host call transfers everything, which avoids per-directive
+        /// call overhead when reconstructing the whole tree guest-side.
+        snapshot: func() -> config-snapshot;
+        /// Get a snapshot pruned to directives whose name is in `names`,
+        /// plus the ancestor directives needed to preserve block-context
+        /// queries (e.g. `is-inside("http")`) for the matches. Directives
+        /// outside every match's ancestor chain are dropped entirely, so
+        /// the transferred/reconstructed tree is proportional to how much
+        /// of the config is actually relevant, not its total size.
+        /// Comments and blank lines are always omitted from this snapshot.
+        snapshot-filtered: func(names: list<string>) -> config-snapshot;
+        /// Iterate over all directives recursively with parent context
+        all-directives-with-context: func() -> list<directive-context>;
+        /// Iterate over all directives recursively
+        all-directives: func() -> list<directive>;
+        /// Get the top-level config items
+        items: func() -> list<config-item>;
+
+        /// Get the include context (parent block names from include directive)
+        include-context: func() -> list<string>;
+        /// Check if this config is included from within a specific context
+        is-included-from: func(context: string) -> bool;
+        /// Check if included from http context
+        is-included-from-http: func() -> bool;
+        /// Check if included from http > server context
+        is-included-from-http-server: func() -> bool;
+        /// Check if included from http > ... > location context
+        is-included-from-http-location: func() -> bool;
+        /// Check if included from stream context
+        is-included-from-stream: func() -> bool;
+        /// Get the immediate parent context
+        immediate-parent-context: func() -> option<string>;
+    }
+}
+
+/// Record-based types for parser output (no resources, no recursion).
+/// Uses index-based references to represent the tree structure:
+/// all config items are stored in a flat array, with child-indices
+/// pointing to children within that array.
+interface parser-types {
+    use data-types.{comment-info, blank-line-info, directive-data};
+
+    /// The kind of a config item (non-recursive)
+    variant config-item-value {
+        directive-item(directive-data),
+        comment-item(comment-info),
+        blank-line-item(blank-line-info),
+    }
+
+    /// A config item in the flat all-items array.
+    /// For directive items with blocks, child-indices contains the indices
+    /// of child items within the all-items array.
+    record config-item {
+        value: config-item-value,
+        child-indices: list<u32>,
+    }
+
+    /// A directive paired with its parent block context
+    record directive-context {
+        data: directive-data,
+        /// Indices of block items in the all-items array
+        block-item-indices: list<u32>,
+        parent-stack: list<string>,
+        depth: u32,
+    }
+
+    /// Complete parser output
+    record parse-output {
+        directives-with-context: list<directive-context>,
+        include-context: list<string>,
+        /// Flat array of all config items (DFS order)
+        all-items: list<config-item>,
+        /// Indices of top-level items in all-items
+        top-level-indices: list<u32>,
+    }
+}
+
+world plugin {
+    use types.{plugin-spec, lint-error};
+    use config-api.{config};
+    import config-api;
+
+    /// Return plugin metadata
+    export spec: func() -> plugin-spec;
+
+    /// Check config and return lint errors
+    export check: func(cfg: borrow<config>, path: string) -> list<lint-error>;
+}
+
+/// What the fix applier reports back. Kept out of `types` so the `plugin`
+/// world's import surface is unchanged and existing components stay
+/// loadable without recompiling.
+interface fixer-types {
+    record fix-result {
+        /// The config after the fixes were applied
+        content: string,
+        /// How many fixes were applied
+        applied: u32,
+        /// How many were dropped as unapplicable — bad offsets, or a
+        /// line-based fix whose line or old-text did not match. Does not
+        /// include fixes skipped for overlapping an applied one.
+        skipped-invalid: u32,
+    }
+}
+
+/// Applies fixes the way `nginx-lint --fix` does, so an SDK can test what
+/// a plugin's fixes produce rather than what their records say.
+world fixer {
+    use types.{fix};
+    use fixer-types.{fix-result};
+
+    export apply-fixes: func(content: string, fixes: list<fix>) -> fix-result;
+}
+
+world parser {
+    use parser-types.{parse-output};
+
+    /// Parse nginx config source and return structured output
+    export parse-config: func(source: string, include-context: list<string>) -> result<parse-output, string>;
+}


### PR DESCRIPTION
Closes #388.

## The problem

Three published crates expand `wit_bindgen::generate!` with `path: "../../wit/nginx-lint-plugin.wit"` — a path outside their own packaged directory — so the features that use it cannot be enabled from crates.io. `cargo publish` succeeds regardless, because its verification build does not turn those features on.

The instance that matters most is **`nginx-lint-plugin`**, the Plugin SDK. Its README tells third-party plugin authors to depend on it from crates.io with `wit-export` **enabled by default** — precisely the configuration that fails with a missing-file error. In-repo plugins use path dependencies, so nothing in CI ever exercised the published shape.

## What this does

**`nginx-lint-parser` and `nginx-lint-plugin` — made to work.** The WIT is vendored into each crate and shipped via `include`, so the macro reads a path inside the package.

Verified rather than assumed, for both: package the crate, extract the tarball outside the workspace, and build it with the feature on. Both compile; on `main` the same steps fail.

The copies are **committed** rather than generated at publish time. `publish-crates` (`release.yml:77`) runs no build that would create them, so a generated copy would simply be absent when `cargo publish` runs and the crates would ship without the WIT again, silently. npm can gitignore its equivalent copy because `prepublishOnly` guarantees it; cargo has no such hook. CI diffs both copies against the root WIT (verified that it catches an injected change), and `make copy-wit` refreshes them.

**`nginx-lint-common` — documented as internal.** Its `fixer` world exists only so the TypeScript SDK can test what a plugin's fixes produce; nothing outside this repository has a reason to build it. The feature declaration and crate docs (so it renders on docs.rs) say so and point at `make build-fixer-wasm`.

## Two things the `include` additions broke, and fixed

Adding `include` has side effects worth calling out, both caught in review:

- **Unanchored globs.** gitignore-style patterns match at any depth, and setting `include` also stops cargo filtering by `.gitignore` — so a stale wasm-pack `pkg/README.md` ended up inside the parser's tarball. The patterns are now anchored to the crate root.
- **`tests/` dropped.** `cargo package` reported two `ignoring test ... is not included in the published package` warnings, which would have fired on every publish and left the packaged crate untestable. `tests/` is listed explicitly.

## Testing

- Packaged-crate builds with the feature enabled, outside the workspace: `nginx-lint-parser --features wasm` and `nginx-lint-plugin --features wit-export`. Both pass here, both fail on `main`.
- The drift check catches an injected change; `make copy-wit` restores both copies.
- Packaged contents audited: WIT present, no `pkg/` artifacts, `tests/` included, no publish warnings.
- `make build-parser-wasm` / `make build-fixer-wasm` still succeed; the TS SDK's 18 tests pass against the regenerated component; workspace clean across fmt, clippy and 275 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S