### PR TITLE
refactor(ts-sdk): make the reconstructed Directive a class

### DIFF
--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
@@ -46,72 +46,98 @@ function lineStartOffset(data: DirectiveData): number {
   return Math.max(data.startOffset - (data.column - 1), 0);
 }
 
+/**
+ * Duck-typed stand-in for the host-backed `config-api.directive` resource.
+ *
+ * A class rather than an object literal of closures: the methods live on the
+ * prototype, so reconstructing a snapshot allocates one object per directive
+ * instead of one closure per method per directive. On a 10k-line config that
+ * was the difference between ~87µs and a few µs of reconstruction per kept
+ * directive. It also matches the shape of the real resource, which jco
+ * generates as a class — the literal made `Object.keys()`, spread and
+ * destructuring behave differently on the two paths.
+ */
+class BuiltDirective implements Directive {
+  readonly #data: DirectiveData;
+  readonly #resolveBlockItems: () => ConfigItem[];
+  readonly #argValues: string[];
+
+  constructor(data: DirectiveData, resolveBlockItems: () => ConfigItem[]) {
+    this.#data = data;
+    this.#resolveBlockItems = resolveBlockItems;
+    this.#argValues = data.args.map((a) => a.value);
+  }
+
+  data(): DirectiveData { return this.#data; }
+  name(): string { return this.#data.name; }
+  is(name: string): boolean { return this.#data.name === name; }
+  firstArg(): string | undefined { return this.#argValues[0] ?? undefined; }
+  firstArgIs(value: string): boolean { return this.#argValues[0] === value; }
+  argAt(index: number): string | undefined { return this.#argValues[index] ?? undefined; }
+  lastArg(): string | undefined {
+    return this.#argValues.length > 0 ? this.#argValues[this.#argValues.length - 1] : undefined;
+  }
+  hasArg(value: string): boolean { return this.#argValues.includes(value); }
+  argCount(): number { return this.#argValues.length; }
+  args(): ArgumentInfo[] { return this.#data.args; }
+  line(): number { return this.#data.line; }
+  column(): number { return this.#data.column; }
+  startOffset(): number { return this.#data.startOffset; }
+  endOffset(): number { return this.#data.endOffset; }
+  leadingWhitespace(): string { return this.#data.leadingWhitespace; }
+  trailingWhitespace(): string { return this.#data.trailingWhitespace; }
+  spaceBeforeTerminator(): string { return this.#data.spaceBeforeTerminator; }
+  hasBlock(): boolean { return this.#data.hasBlock; }
+  blockItems(): ConfigItem[] { return this.#resolveBlockItems(); }
+  blockIsRaw(): boolean { return this.#data.blockIsRaw; }
+
+  // The fix constructors below must produce byte-identical Fix records to
+  // the host's implementations in src/plugin/component_rule.rs
+  // (replace_with / delete_line_fix / insert_* on DirectiveResource), so a
+  // plugin gets the same --fix result whether its Config came from the
+  // host resource or from a reconstructed snapshot.
+  replaceWith(newText: string): Fix {
+    const leading = this.#data.leadingWhitespace;
+    return rangeFix(
+      this.#data.startOffset - leading.length,
+      this.#data.endOffset,
+      leading + newText,
+    );
+  }
+  deleteLineFix(): Fix {
+    return {
+      line: this.#data.line, oldText: undefined, newText: "",
+      deleteLine: true, insertAfter: false,
+      startOffset: undefined, endOffset: undefined,
+    };
+  }
+  insertAfter(newText: string): Fix {
+    const offset = this.#data.endOffset;
+    return rangeFix(offset, offset, `\n${indentOf(this.#data)}${newText}`);
+  }
+  insertBefore(newText: string): Fix {
+    const offset = lineStartOffset(this.#data);
+    return rangeFix(offset, offset, `${indentOf(this.#data)}${newText}\n`);
+  }
+  insertAfterMany(lines: string[]): Fix {
+    const indent = indentOf(this.#data);
+    const text = lines.map((line) => `\n${indent}${line}`).join("");
+    const offset = this.#data.endOffset;
+    return rangeFix(offset, offset, text);
+  }
+  insertBeforeMany(lines: string[]): Fix {
+    const indent = indentOf(this.#data);
+    const text = lines.map((line) => `${indent}${line}\n`).join("");
+    const offset = lineStartOffset(this.#data);
+    return rangeFix(offset, offset, text);
+  }
+}
+
 function wrapDirective(
   data: DirectiveData,
   resolveBlockItems: () => ConfigItem[],
 ): Directive {
-  const argValues = data.args.map((a) => a.value);
-
-  return {
-    data() { return data; },
-    name() { return data.name; },
-    is(name: string) { return data.name === name; },
-    firstArg() { return argValues[0] ?? undefined; },
-    firstArgIs(value: string) { return argValues[0] === value; },
-    argAt(index: number) { return argValues[index] ?? undefined; },
-    lastArg() { return argValues.length > 0 ? argValues[argValues.length - 1] : undefined; },
-    hasArg(value: string) { return argValues.includes(value); },
-    argCount() { return argValues.length; },
-    args(): ArgumentInfo[] { return data.args; },
-    line() { return data.line; },
-    column() { return data.column; },
-    startOffset() { return data.startOffset; },
-    endOffset() { return data.endOffset; },
-    leadingWhitespace() { return data.leadingWhitespace; },
-    trailingWhitespace() { return data.trailingWhitespace; },
-    spaceBeforeTerminator() { return data.spaceBeforeTerminator; },
-    hasBlock() { return data.hasBlock; },
-    blockItems(): ConfigItem[] { return resolveBlockItems(); },
-    blockIsRaw() { return data.blockIsRaw; },
-    // The fix constructors below must produce byte-identical Fix records to
-    // the host's implementations in src/plugin/component_rule.rs
-    // (replace_with / delete_line_fix / insert_* on DirectiveResource), so a
-    // plugin gets the same --fix result whether its Config came from the
-    // host resource or from a reconstructed snapshot.
-    replaceWith(newText: string): Fix {
-      const leading = data.leadingWhitespace;
-      return rangeFix(
-        data.startOffset - leading.length,
-        data.endOffset,
-        leading + newText,
-      );
-    },
-    deleteLineFix(): Fix {
-      return {
-        line: data.line, oldText: undefined, newText: "",
-        deleteLine: true, insertAfter: false,
-        startOffset: undefined, endOffset: undefined,
-      };
-    },
-    insertAfter(newText: string): Fix {
-      return rangeFix(data.endOffset, data.endOffset, `\n${indentOf(data)}${newText}`);
-    },
-    insertBefore(newText: string): Fix {
-      const offset = lineStartOffset(data);
-      return rangeFix(offset, offset, `${indentOf(data)}${newText}\n`);
-    },
-    insertAfterMany(lines: string[]): Fix {
-      const indent = indentOf(data);
-      const text = lines.map((line) => `\n${indent}${line}`).join("");
-      return rangeFix(data.endOffset, data.endOffset, text);
-    },
-    insertBeforeMany(lines: string[]): Fix {
-      const indent = indentOf(data);
-      const text = lines.map((line) => `${indent}${line}\n`).join("");
-      const offset = lineStartOffset(data);
-      return rangeFix(offset, offset, text);
-    },
-  } as Directive;
+  return new BuiltDirective(data, resolveBlockItems);
 }
 
 // ── Resolve index-based items to ConfigItem tree ────────────────────

--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
@@ -54,11 +54,12 @@ function lineStartOffset(data: DirectiveData): number {
  * made `Object.keys()`, spread and destructured methods behave differently
  * depending on which path a plugin's Config came from.
  *
- * Prototype methods also mean one object per directive instead of one
- * closure per method per directive, but that is a small effect — measured at
- * ~6% of per-check time on a 10k-line config (601 kept directives). Guest
- * side reconstruction still costs ~58µs per directive after this change, so
- * closure allocation was not what dominated it.
+ * Not a performance change, despite the shape suggesting one. Profiling a
+ * 10k-line config found per-check time dominated by the component boundary,
+ * not by guest-side allocation: lowering the returned LintErrors accounted
+ * for over half of it and lifting the snapshot for most of the rest, while
+ * everything this class does — walking the tree, allocating the directive
+ * objects — came to a few milliseconds in total.
  */
 class BuiltDirective implements Directive {
   readonly #data: DirectiveData;

--- a/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
+++ b/plugins/typescript/nginx-lint-plugin/src/config-builder.ts
@@ -49,13 +49,16 @@ function lineStartOffset(data: DirectiveData): number {
 /**
  * Duck-typed stand-in for the host-backed `config-api.directive` resource.
  *
- * A class rather than an object literal of closures: the methods live on the
- * prototype, so reconstructing a snapshot allocates one object per directive
- * instead of one closure per method per directive. On a 10k-line config that
- * was the difference between ~87µs and a few µs of reconstruction per kept
- * directive. It also matches the shape of the real resource, which jco
- * generates as a class — the literal made `Object.keys()`, spread and
- * destructuring behave differently on the two paths.
+ * A class rather than an object literal of closures, so that it matches the
+ * shape of the real resource: jco generates that as a class, and the literal
+ * made `Object.keys()`, spread and destructured methods behave differently
+ * depending on which path a plugin's Config came from.
+ *
+ * Prototype methods also mean one object per directive instead of one
+ * closure per method per directive, but that is a small effect — measured at
+ * ~6% of per-check time on a 10k-line config (601 kept directives). Guest
+ * side reconstruction still costs ~58µs per directive after this change, so
+ * closure allocation was not what dominated it.
  */
 class BuiltDirective implements Directive {
   readonly #data: DirectiveData;


### PR DESCRIPTION
Found while benchmarking the Rust / TypeScript / Python implementations of the same rule.

## The inconsistency

jco generates the host-backed `directive` resource as `export class Directive`, so its methods live on the prototype. The snapshot-path stand-in built by `buildConfigFromSnapshot` was an object literal of 26 closures, which made the two paths observably different at runtime:

| | host resource | reconstructed (before) | reconstructed (after) |
|---|---|---|---|
| `Object.keys(d).length` | 0 | 26 | 0 |
| `{...d}` keeps methods | no | yes | no |
| destructured `is()` works | no | yes | no |

A plugin relying on any of those worked on the snapshot path and broke on the host path — which is the production one for `allDirectivesWithContext()`. The Python SDK's `BuiltDirective` has always been a class; this brings TypeScript in line.

Nothing public changes: `wrapDirective` is internal, and both shapes satisfy the generated `Directive` type.

## This is not a performance change

It started as one — the hypothesis was that allocating 26 closures per directive dominated reconstruction. **It does not**, and the earlier revisions of this PR overstated the effect. Attributing the cost properly, on a 10k-line config where 601 directives survive `snapshotFiltered` and 300 findings are reported:

| stage | cumulative | delta |
|---|---|---|
| fixed cost (host call, filter keeps nothing) | 3.50 ms | 3.50 ms |
| + lifting 601 records into JS | 17.09 ms | **13.59 ms** |
| + DFS walk over the lifted tree | 17.32 ms | 0.23 ms |
| + array churn (`Array.from`, `parentStack` copies) | 21.30 ms | 3.98 ms |
| + per-directive object allocation | 22.07 ms | 0.77 ms |
| + full SDK reconstruction | 22.80 ms | 0.73 ms |
| + the plugin's own loop | 24.15 ms | 1.35 ms |
| + returning 300 LintErrors to the host | 52.17 ms | **28.02 ms** |

Measured by building probe plugins that peel off one layer at a time; the last row is the same plugin doing identical work but returning `[]`.

So roughly 41 of 52ms is the component boundary — 28ms lowering the results, 13.6ms lifting the input — and everything guest-side comes to about 6ms. What this PR changes is a slice of the 0.77ms row.

That also explains why TypeScript measured slower than Python on the same rule despite being faster when the filtered snapshot is empty: the difference is jco/StarlingMonkey's marshalling, not the SDK code, and it scales with findings reported rather than config size.

## Testing

SDK 20 tests, example plugin 18 tests, and the plugin still reports the same 300 findings on the benchmark config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vswikio3DwgzxDpbAFrd4S