### PR TITLE
ci: publish the Python SDK to PyPI on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,7 @@ jobs:
               exit 0
             fi
             echo "attempt $attempt failed"
-            sleep 60
+            [ "$attempt" -lt 3 ] && sleep 60
           done
           exit 1
       - name: Check the sdist-built package works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,3 +255,203 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-python-sdist:
+    name: Build Python sdist
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Generate the bindings and bundle the WIT
+        # Neither is committed, and a `tool.maturin.include` glob that matches
+        # nothing is silent, so the build would otherwise produce a
+        # publishable but unusable package
+        working-directory: plugins/python/nginx-lint-plugin
+        run: |
+          python -m pip install --upgrade pip
+          pip install componentize-py==0.25.0
+          make bindings copy-wit
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: plugins/python/nginx-lint-plugin
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-dist-sdist
+          path: plugins/python/nginx-lint-plugin/dist/
+
+  build-python-wheels:
+    name: Build Python wheel (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            manylinux: "2014"
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            manylinux: "2014"
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            manylinux: auto
+          # Cross-compiled from the arm runner; the macOS SDK is universal
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            manylinux: auto
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # The floor the wheel is built against: abi3-py311 means this one
+          # wheel per platform covers every Python >= 3.11
+          python-version: "3.11"
+      - name: Generate the bindings and bundle the WIT
+        working-directory: plugins/python/nginx-lint-plugin
+        run: |
+          python -m pip install --upgrade pip
+          pip install componentize-py==0.25.0
+          make bindings copy-wit
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: build
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          manylinux: ${{ matrix.manylinux }}
+          working-directory: plugins/python/nginx-lint-plugin
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-dist-${{ matrix.target }}
+          path: plugins/python/nginx-lint-plugin/dist/
+
+  verify-python-wheel:
+    name: Verify Python wheel
+    needs: build-python-wheels
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist-x86_64-unknown-linux-gnu
+          path: dist
+      # Everything below runs against the wheel in a venv, never the source
+      # tree: this checkout has no generated bindings and no bundled WIT, so a
+      # wheel missing either fails here rather than after an upload PyPI will
+      # not let us replace.
+      - name: Install the wheel into a clean environment
+        run: |
+          python -m venv "$RUNNER_TEMP/wheel-venv"
+          "$RUNNER_TEMP/wheel-venv/bin/pip" install --upgrade pip
+          "$RUNNER_TEMP/wheel-venv/bin/pip" install dist/*.whl
+      - name: Check the wheel is self-contained
+        run: |
+          "$RUNNER_TEMP/wheel-venv/bin/python" - <<'PY'
+          import componentize_py_types, wit_world  # the generated bindings
+          import nginx_lint_plugin
+          from nginx_lint_plugin import testing  # pulls in the native module
+
+          wit = nginx_lint_plugin.wit_dir() / "nginx-lint-plugin.wit"
+          assert wit.is_file(), f"bundled WIT missing: {wit}"
+          config = testing.parse_config("server { server_tokens on; }")
+          assert config.all_directives_with_context()
+          PY
+      - name: Run the SDK test suite against the wheel
+        working-directory: plugins/python/nginx-lint-plugin
+        run: |
+          "$RUNNER_TEMP/wheel-venv/bin/pip" install pytest
+          "$RUNNER_TEMP/wheel-venv/bin/pytest"
+      - name: Build the example plugin against the wheel
+        # The plugin author's path end to end: type-check, test, and
+        # componentize using only what the wheel ships
+        working-directory: plugins/python/server-tokens-enabled-py
+        run: |
+          "$RUNNER_TEMP/wheel-venv/bin/pip" install --group dev
+          PATH="$RUNNER_TEMP/wheel-venv/bin:$PATH" make typecheck test build
+
+  verify-python-sdist:
+    name: Verify Python sdist
+    # Only after the crates are on crates.io: the sdist depends on them by
+    # version rather than vendoring them, so this is the first moment it can
+    # build the way a user's `pip install` will. Failing here blocks the
+    # upload, which PyPI would not let us replace.
+    needs: [publish-crates, build-python-sdist]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist-sdist
+          path: dist
+      - name: Build and install the sdist from source
+        run: |
+          python -m venv "$RUNNER_TEMP/sdist-venv"
+          "$RUNNER_TEMP/sdist-venv/bin/pip" install --upgrade pip
+          # The crates.io index can lag the publish step, so retry rather
+          # than fail the release on propagation timing
+          for attempt in 1 2 3; do
+            if "$RUNNER_TEMP/sdist-venv/bin/pip" install dist/*.tar.gz; then
+              exit 0
+            fi
+            echo "attempt $attempt failed"
+            sleep 60
+          done
+          exit 1
+      - name: Check the sdist-built package works
+        run: |
+          "$RUNNER_TEMP/sdist-venv/bin/python" - <<'PY'
+          import componentize_py_types, wit_world  # the generated bindings
+          import nginx_lint_plugin
+          from nginx_lint_plugin import testing  # pulls in the native module
+
+          wit = nginx_lint_plugin.wit_dir() / "nginx-lint-plugin.wit"
+          assert wit.is_file(), f"bundled WIT missing: {wit}"
+          config = testing.parse_config("server { server_tokens on; }")
+          assert config.all_directives_with_context()
+          PY
+
+  publish-pypi:
+    name: Publish to PyPI
+    # publish-crates (through verify-python-sdist) already waits on docker
+    needs: [verify-python-wheel, verify-python-sdist]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-dist-*
+          merge-multiple: true
+          path: dist
+      # Trusted publishing, like the crates.io and npm jobs; PyPI's
+      # project-level publisher is configured on pypi.org
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,15 @@ cd crates/nginx-lint-common && cargo build && cargo test
 cd crates/nginx-lint-plugin && cargo build && cargo test
 ```
 
+The Python SDK's crate (`plugins/python/nginx-lint-plugin`) must be built
+from its own directory, never with `--manifest-path` from elsewhere. It
+depends on `nginx-lint-parser` and `nginx-lint-common` by published version,
+and `plugins/python/.cargo/config.toml` patches them back to the working
+tree; cargo discovers that config by walking up from the current directory,
+so building from anywhere else silently compiles against the released crates
+instead (and fails outright between a version bump and its crates.io
+publish).
+
 ### Adding a Native Lint Rule
 
 Native rules are implemented in Rust under `src/rules/`. Use for rules that need access to file system or complex logic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,11 @@ so building from anywhere else silently compiles against the released crates
 instead (and fails outright between a version bump and its crates.io
 publish).
 
+For the same reason Renovate is disabled for that manifest (it runs cargo
+from the repository root), so its `pyo3` and `serde` dependencies are bumped
+by hand. `pyo3` in particular has to stay new enough for the newest released
+CPython: an older one hard-errors on a newer interpreter even with abi3.
+
 ### Adding a Native Lint Rule
 
 Native rules are implemented in Rust under `src/rules/`. Use for rules that need access to file system or complex logic.

--- a/plugins/python/.cargo/config.toml
+++ b/plugins/python/.cargo/config.toml
@@ -1,0 +1,15 @@
+# The SDK depends on nginx-lint-parser / nginx-lint-common by version rather
+# than by path, so that `maturin sdist` produces a standalone source
+# distribution: with path dependencies maturin vendors the two crates and
+# copies the repository's root Cargo.toml alongside them, and that manifest
+# is unusable on its own (it declares the `nginx-lint` package, whose src/ is
+# not shipped), so every source install fails while resolving metadata.
+#
+# In this repository we still want to build against the working tree, so the
+# path override lives here instead. It sits one directory above the crate,
+# because cargo discovers config by walking up from the current directory:
+# that keeps the override out of the sdist, which maturin builds from the
+# crate directory itself.
+[patch.crates-io]
+nginx-lint-common = { path = "../../crates/nginx-lint-common" }
+nginx-lint-parser = { path = "../../crates/nginx-lint-parser" }

--- a/plugins/python/nginx-lint-plugin/Cargo.toml
+++ b/plugins/python/nginx-lint-plugin/Cargo.toml
@@ -13,8 +13,13 @@ name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]
-nginx-lint-common = { path = "../../../crates/nginx-lint-common" }
-nginx-lint-parser = { path = "../../../crates/nginx-lint-parser" }
+# By version rather than by path, and pinned exactly: these crates are
+# released in lockstep with this one, and a path dependency makes
+# `maturin sdist` vendor them next to the repository's root Cargo.toml,
+# which is unusable on its own and fails every source install. The working
+# tree is still what builds here — see ../.cargo/config.toml.
+nginx-lint-common = "=0.19.1"
+nginx-lint-parser = "=0.19.1"
 # abi3-py311: one wheel per platform covers every Python >= 3.11,
 # instead of one per platform x interpreter version. Keep pyo3 new enough
 # for the newest released CPython — an older one hard-errors on a newer

--- a/plugins/python/nginx-lint-plugin/Cargo.toml
+++ b/plugins/python/nginx-lint-plugin/Cargo.toml
@@ -24,6 +24,8 @@ nginx-lint-parser = "=0.19.1"
 # instead of one per platform x interpreter version. Keep pyo3 new enough
 # for the newest released CPython — an older one hard-errors on a newer
 # interpreter even with abi3, which breaks `make install` for contributors.
+# Renovate does not update this manifest (see renovate.json), so bumping it
+# is a manual job.
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py311"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/plugins/python/nginx-lint-plugin/README.md
+++ b/plugins/python/nginx-lint-plugin/README.md
@@ -40,7 +40,11 @@ as a native module.
   `.gitignore`.
 - `Cargo.toml` / `src/lib.rs` — the native parser module (its own cargo
   workspace, excluded from the repository's root workspace; the crate
-  version is the wheel version, kept in sync with the repository version)
+  version is the wheel version, kept in sync with the repository version).
+  It depends on `nginx-lint-parser` and `nginx-lint-common` by exact
+  version rather than by path so that the sdist stands alone; inside this
+  repository `../.cargo/config.toml` patches both back to the working tree,
+  and that file explains why.
 
 ## Install
 

--- a/plugins/python/nginx-lint-plugin/pyproject.toml
+++ b/plugins/python/nginx-lint-plugin/pyproject.toml
@@ -16,8 +16,23 @@ requires-python = ">=3.11"
 # Version comes from Cargo.toml
 dynamic = ["version"]
 
+authors = [{ name = "walf443" }]
+keywords = ["nginx", "lint", "linter", "wasm", "plugin", "component-model"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: System :: Systems Administration",
+    "Typing :: Typed",
+]
+
 [project.urls]
+Homepage = "https://github.com/walf443/nginx-lint"
 Repository = "https://github.com/walf443/nginx-lint"
+Issues = "https://github.com/walf443/nginx-lint/issues"
+Documentation = "https://github.com/walf443/nginx-lint/blob/main/plugins/python/nginx-lint-plugin/README.md"
 
 # Tools the Makefile targets need. `make install` gets maturin through pip's
 # build isolation, but `make develop` and `make bindings` invoke the maturin

--- a/renovate.json
+++ b/renovate.json
@@ -41,29 +41,12 @@
       "enabled": false
     },
     {
-      "description": "The Python SDK's crate pins nginx-lint-parser and nginx-lint-common to the repository version, which scripts/bump-version.sh moves at release time. A bump here is always wrong: it would pin the SDK to a different release than the rest of the workspace.",
+      "description": "Renovate runs cargo from the repository root, which does not pick up plugins/python/.cargo/config.toml (cargo finds config by walking up from the current directory). Any update touching this manifest, a pyo3 bump as much as lockFileMaintenance, refreshes its lockfile from there and rewrites nginx-lint-parser and nginx-lint-common as registry entries, permanently at odds with what in-repo builds produce; between a version bump and its crates.io publish it fails outright. Those two pins are owned by scripts/bump-version.sh anyway, and pyo3 and serde here are bumped by hand from the crate's own directory (see AGENTS.md).",
       "matchManagers": [
         "cargo"
       ],
       "matchFileNames": [
         "plugins/python/nginx-lint-plugin/Cargo.toml"
-      ],
-      "matchDepNames": [
-        "nginx-lint-parser",
-        "nginx-lint-common"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Renovate runs cargo from the repository root, which does not pick up plugins/python/.cargo/config.toml (cargo finds config by walking up from the current directory). Refreshing this lockfile from there would rewrite the two patched crates as registry entries, permanently at odds with what in-repo builds produce, and would fail outright between a version bump and its crates.io publish.",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchFileNames": [
-        "plugins/python/nginx-lint-plugin/Cargo.toml"
-      ],
-      "matchUpdateTypes": [
-        "lockFileMaintenance"
       ],
       "enabled": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,33 @@
         "python"
       ],
       "enabled": false
+    },
+    {
+      "description": "The Python SDK's crate pins nginx-lint-parser and nginx-lint-common to the repository version, which scripts/bump-version.sh moves at release time. A bump here is always wrong: it would pin the SDK to a different release than the rest of the workspace.",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchFileNames": [
+        "plugins/python/nginx-lint-plugin/Cargo.toml"
+      ],
+      "matchDepNames": [
+        "nginx-lint-parser",
+        "nginx-lint-common"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Renovate runs cargo from the repository root, which does not pick up plugins/python/.cargo/config.toml (cargo finds config by walking up from the current directory). Refreshing this lockfile from there would rewrite the two patched crates as registry entries, permanently at odds with what in-repo builds produce, and would fail outright between a version bump and its crates.io publish.",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchFileNames": [
+        "plugins/python/nginx-lint-plugin/Cargo.toml"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -57,6 +57,11 @@ for file in "${CARGO_FILES[@]}"; do
     sed_inplace "s/\(nginx-lint-parser = { version = \"\)[0-9]*\.[0-9]*\.[0-9]*/\1$NEW_VERSION/" "$file"
     sed_inplace "s/\(nginx-lint-common = { version = \"\)[0-9]*\.[0-9]*\.[0-9]*/\1$NEW_VERSION/" "$file"
     sed_inplace "s/\(nginx-lint-plugin = { version = \"\)[0-9]*\.[0-9]*\.[0-9]*/\1$NEW_VERSION/" "$file"
+    # The Python SDK's crate depends on the two library crates by version
+    # only (see plugins/python/.cargo/config.toml for why), so those lines
+    # have no `{ version = ... }` wrapper to match above
+    sed_inplace "s/^\(nginx-lint-parser = \"=\)[0-9]*\.[0-9]*\.[0-9]*/\1$NEW_VERSION/" "$file"
+    sed_inplace "s/^\(nginx-lint-common = \"=\)[0-9]*\.[0-9]*\.[0-9]*/\1$NEW_VERSION/" "$file"
     echo "  Updated $relative"
 done
 
@@ -79,7 +84,7 @@ fi
 # build silently rewrites it.
 PY_SDK_MANIFEST="$ROOT_DIR/plugins/python/nginx-lint-plugin/Cargo.toml"
 if [ -f "$PY_SDK_MANIFEST" ]; then
-    cargo update --manifest-path "$PY_SDK_MANIFEST" --workspace --quiet
+    (cd "$(dirname "$PY_SDK_MANIFEST")" && cargo update --workspace --quiet)
     echo "  Updated plugins/python/nginx-lint-plugin/Cargo.lock"
 fi
 


### PR DESCRIPTION
Groundwork for releasing Python plugin support. The Python SDK is installable only from a checkout today, while its own README and the example plugin's both tell readers to `pip install nginx-lint-plugin`. This adds the release jobs that make that true.

## Jobs added

- `build-python-wheels` — manylinux2014 x86_64 / aarch64, macOS arm64 / x86_64. abi3-py311, so one wheel per platform covers every Python >= 3.11
- `build-python-sdist`
- `verify-python-wheel` — installs the built wheel into a clean venv and runs the SDK suite and the example plugin's typecheck / test / componentize against it, from a checkout that has neither the generated bindings nor the bundled WIT
- `verify-python-sdist` — builds the sdist from source after `publish-crates`; a failure blocks the upload
- `publish-pypi` — trusted publishing, like the crates.io and npm jobs

PyPI never lets a version be re-uploaded, so both verifications have to happen before anything is pushed.

## The sdist did not build at all

With path dependencies, `maturin sdist` vendors `nginx-lint-parser` and `nginx-lint-common` next to the repository's root `Cargo.toml`, and that manifest is unusable on its own — it declares the `nginx-lint` package, whose `src/` is not shipped. Every source install therefore died during metadata generation.

The crate now depends on both by exact version, and `plugins/python/.cargo/config.toml` patches them back to the working tree for in-repo builds. It sits one directory above the crate, so it stays out of the sdist. The consequence is that the sdist can only build once this release's crates are on crates.io, which is why `verify-python-sdist` runs after `publish-crates`.

## Also

- PyPI metadata: authors, keywords, classifiers, project URLs
- `bump-version.sh` handles the new dependency style

## Verified locally

Wheel contents (`wit_world`, `componentize_py_types`, the bundled WIT, both `py.typed` markers), import / parse / 29 SDK tests from a clean venv, `pip install .` through the patch, `cargo fmt` and `clippy`, the macOS x86_64 cross build, and `twine check`.

## Manual step before merging

A PyPI pending publisher has to be configured: project `nginx-lint-plugin`, owner `walf443`, repository `nginx-lint`, workflow `release.yml`, environment `release`.

## Deliberately left out

- Windows wheels — the windows runners have no `make` for the bindings step, and the now-working sdist covers Windows users who have Rust
- Renovate may open bump PRs against the new `= 0.19.1` registry pins. Harmless (the patch wins locally) but noisy; `ignoreDeps` is a one-line follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt91EH2RWfkWCW2BXzQMK2