### PR TITLE
chore: keep Renovate off the Go toolchain, and in step across the Go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,38 @@
       "enabled": false
     },
     {
+      "description": "Same reasoning for Go: CI runs the Go jobs on the lowest toolchain the SDK supports (both go.mod files declare go 1.25.0, and both READMEs promise Go 1.25+), so that anything needing a newer one fails in CI rather than in a downstream build. The Go SDK is consumed as source, so a 1.26 API used by mistake would compile here and break for whoever imports it. Bumping it means raising that floor, which is go.mod, the READMEs and the workflow comment in one change, not an automated update. Scoped to github-actions so a go dependency elsewhere is still updated.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "The Go example plugin requires the SDK through a replace to the working tree, so the SDK's own requirements reach it as indirect ones. Updating only the SDK leaves the example's go.mod stale, and `go vet` there refuses to run until it is tidied — which is what broke #396. Renovate leaves indirect Go dependencies alone by default; enabling them for that one module makes it propose both files together, and they land in one branch because it is the same dependency at the same version.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchFileNames": [
+        "plugins/go/server-tokens-enabled-go/go.mod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Tidy after a Go update, so go.mod and go.sum are left as `go mod tidy` would write them rather than as the minimal edit `go get` makes.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
+    },
+    {
       "description": "Renovate runs cargo from the repository root, which does not pick up plugins/python/.cargo/config.toml (cargo finds config by walking up from the current directory). Any update touching this manifest, a pyo3 bump as much as lockFileMaintenance, refreshes its lockfile from there and rewrites nginx-lint-parser and nginx-lint-common as registry entries, permanently at odds with what in-repo builds produce; between a version bump and its crates.io publish it fails outright. Those two pins are owned by scripts/bump-version.sh anyway, and pyo3 and serde here are bumped by hand from the crate's own directory (see AGENTS.md).",
       "matchManagers": [
         "cargo"

--- a/renovate.json
+++ b/renovate.json
@@ -51,11 +51,12 @@
       "enabled": false
     },
     {
-      "description": "The Go example plugin requires the SDK through a replace to the working tree, so the SDK's own requirements reach it as indirect ones. Updating only the SDK leaves the example's go.mod stale, and `go vet` there refuses to run until it is tidied — which is what broke #396. Renovate leaves indirect Go dependencies alone by default; enabling them for that one module makes it propose both files together, and they land in one branch because it is the same dependency at the same version.",
+      "description": "The Go example plugin requires the SDK through a replace to the working tree, so everything the SDK requires reaches the example as an indirect requirement. Updating one module alone leaves the other's go.mod behind, and `go vet` refuses to run against a stale one — which is what broke #396. Renovate leaves indirect Go dependencies alone by default, so this enables them for both modules rather than one: enabling only the example would fix the direction #396 broke and open the reverse, where a dependency that is indirect in both (golang.org/x/sys today) moves in the example alone and nothing notices, `go vet` being happy with a module that merely requires more than its neighbour. Enabled for both, an update is proposed for each file and they land in one branch, being the same dependency at the same version.",
       "matchManagers": [
         "gomod"
       ],
       "matchFileNames": [
+        "plugins/go/nginx-lint-plugin/go.mod",
         "plugins/go/server-tokens-enabled-go/go.mod"
       ],
       "matchDepTypes": [


### PR DESCRIPTION
Two Renovate rules, each for a PR it has already opened.

## The Go toolchain pin (#397)

`setup-go`'s `go-version` in the Go job is the *lowest* version the SDK supports — both `go.mod` files declare `go 1.25.0`, and both READMEs promise Go 1.25+ — so that anything needing a newer one fails here rather than downstream. The Go SDK is consumed as source, so a 1.26 API used by mistake would compile in CI and break for whoever imports the module.

The repository already states this policy for Python, whose rule explains it in the same terms. There was no equivalent for Go, which is why #397 was generated. Raising the floor is a deliberate change to `go.mod`, both READMEs and the workflow comment together, not an automated bump.

## The two Go modules drifting apart (#396)

#396 bumped `go.bytecodealliance.org/pkg` in the SDK and left the example plugin behind:

```
go vet ./...
go: updates to go.mod needed; to update it:
	go mod tidy
make: *** [Makefile:22: vet] Error 1
```

That is structural, not particular to this dependency. The example requires the SDK through a `replace` to the working tree, so everything the SDK requires *directly* reaches the example as an *indirect* requirement — and Renovate leaves indirect Go dependencies alone by default. Every future update to any SDK dependency would fail the same way.

Enabling indirect updates for that one module makes Renovate propose both files together; they land in one branch, being the same dependency at the same version. `gomodTidy` leaves `go.mod` and `go.sum` as `go mod tidy` would write them rather than as the minimal edit `go get` makes.

## Verification

Reproduced the #396 failure locally before writing the rule — bumping the SDK to v0.2.3 and running the example's `go vet` gives exactly the CI error, and `go mod tidy` in the example is what clears it — and validated the config with `renovate-config-validator` at the current Renovate (44.54.0; an older validator from an npx cache reports a false error on the existing `managerFilePatterns`).

Claude-Session: https://claude.ai/code/session_01Jt91EH2RWfkWCW2BXzQMK2
