### PR TITLE
fix: point Renovate's wazero lookup at the repository's new home

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,16 @@
       "enabled": true
     },
     {
+      "description": "wazero moved out of the tetratelabs org into its own: github.com/tetratelabs/wazero now 301s to github.com/wazero/wazero. Its go.mod still declares `module github.com/tetratelabs/wazero`, on main as much as on v1.12.0, so the requirement here cannot follow the repository — `go get github.com/wazero/wazero` refuses with \"module declares its path as: github.com/tetratelabs/wazero\". Renovate's lookup does follow the repository, and gets nothing back for the redirected old name, which is the `no-result` on the dependency dashboard. So point the lookup at the new name while the module path stays the declared one. Both Go modules need it: wazero is a direct requirement of the SDK and an indirect one of the example. Drop this rule once upstream renames the module path — at which point the import paths move too, and this becomes a real migration.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "github.com/tetratelabs/wazero"
+      ],
+      "overridePackageName": "github.com/wazero/wazero"
+    },
+    {
       "description": "Tidy after a Go update, so go.mod and go.sum are left as `go mod tidy` would write them rather than as the minimal edit `go get` makes.",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
## Problem

The [dependency dashboard](https://github.com/walf443/nginx-lint/issues/31) has been carrying this warning:

> Renovate failed to look up the following dependencies: `Failed to look up go package github.com/tetratelabs/wazero: no-result`.
>
> Files affected: `plugins/go/nginx-lint-plugin/go.mod`, `plugins/go/server-tokens-enabled-go/go.mod`

wazero moved out of the tetratelabs org into its own, so `github.com/tetratelabs/wazero` now 301s to `github.com/wazero/wazero`. Renovate's Go lookup follows the repository, and gets nothing back for the redirected old name.

## Why not just migrate the import path

That was the first thing I tried, and it does not work. Go identifies a module by the path its `go.mod` declares, not by where the repository lives, and upstream has not renamed it — `module github.com/tetratelabs/wazero` on `main` as much as on `v1.12.0`:

```console
$ go get github.com/wazero/wazero@v1.12.0
go: github.com/wazero/wazero@v1.12.0 requires github.com/wazero/wazero@v1.12.0: parsing go.mod:
	module declares its path as: github.com/tetratelabs/wazero
	        but was required as: github.com/wazero/wazero
```

A `replace` does not get around it either. wazero's own source imports `github.com/tetratelabs/wazero/internal/...`, so the module arrives under both paths:

```console
$ go build ./...
go: github.com/tetratelabs/wazero@v1.12.0 used for two different module paths
    (github.com/tetratelabs/wazero and github.com/wazero/wazero)
```

And even if it built, a `replace` in the SDK's `go.mod` is ignored by anyone importing the SDK — which is consumed as source — so it would pass here and break downstream. The real migration is upstream's to make.

## Fix

Override the lookup name and leave the module path alone:

```json
{
  "matchManagers": ["gomod"],
  "matchDepNames": ["github.com/tetratelabs/wazero"],
  "overridePackageName": "github.com/wazero/wazero"
}
```

No `matchFileNames`: wazero is a direct requirement of the SDK and an indirect one of the example, and the dashboard names both. The `description` records the removal condition — drop the rule once upstream renames the module path, at which point the import paths move too and it becomes a real migration.

## Verification

- `renovate-config-validator` (44.56.3): `Config validated successfully`. Note that a cached `npx renovate` 37.x rejects both `overridePackageName` and the pre-existing `managerFilePatterns`; `renovate@latest` is needed.
- `renovate --platform=local --dry-run=lookup` logs `Overriding packageName from github.com/tetratelabs/wazero to github.com/wazero/wazero` once per `go.mod`, and the dependency now resolves — `"warnings": []`, `sourceUrl: https://github.com/wazero/wazero`, `currentVersion: v1.12.0` — with no `no-result` anywhere in the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnZPzL7FDbz6pLwCwMZYe5