### PR TITLE
fix: stop Renovate looking up the Go SDK the example replaces

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,16 @@
       "overridePackageName": "github.com/wazero/wazero"
     },
     {
+      "description": "The Go example plugin requires the SDK at the placeholder v0.0.0 and replaces it with the working tree, so there is no released version for Renovate to find — the SDK is a nested module and the repository's tags (v0.20.0 and friends) are the root crate's, not `plugins/go/nginx-lint-plugin/v0.20.0`. The Go proxy answers its version list with nothing, which reaches the dependency dashboard as a `no-result` lookup failure and keeps the warning banner up over the real ones. Nothing here is updatable while the replace stands, so skip the lookup. Drop this rule if the SDK is ever tagged as its own module and the example starts requiring a published version.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Tidy after a Go update, so go.mod and go.sum are left as `go mod tidy` would write them rather than as the minimal edit `go get` makes.",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
## Problem

With the wazero lookup fixed in #403, the [dependency dashboard](https://github.com/walf443/nginx-lint/issues/31) surfaced a second one:

> Failed to look up go package `github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin`: no-result
>
> Files affected: `plugins/go/server-tokens-enabled-go/go.mod`

Unlike #403, nothing here is actually broken.

The example requires the SDK at the placeholder `v0.0.0` and replaces it with the working tree:

```
require github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin v0.0.0

replace github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin => ../nginx-lint-plugin
```

The SDK is a nested module that has never been tagged as one — the repository's tags are the root crate's (`v0.20.0`), not `plugins/go/nginx-lint-plugin/v0.20.0` — so the Go proxy answers its version list with nothing:

```console
$ curl -s -w "HTTP %{http_code}" https://proxy.golang.org/github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin/@v/list
HTTP 200      # empty body
```

There is no released version to find, and none to update to while the replace stands.

## Fix

It still keeps the dashboard's warning banner up over failures that do matter, so skip the lookup:

```json
{
  "matchManagers": ["gomod"],
  "matchDepNames": ["github.com/walf443/nginx-lint/plugins/go/nginx-lint-plugin"],
  "enabled": false
}
```

The `description` records the removal condition — drop the rule if the SDK is ever tagged as its own module and the example starts requiring a published version.

## Verification

- `renovate-config-validator` (44.56.3): `Config validated successfully`.
- `renovate --platform=local --dry-run=lookup` returns the dependency as `"skipReason": "disabled"` with no `sourceUrl` and no `updates`, i.e. no lookup is performed at all, so no warning can be produced. The wazero override from #403 still resolves in the same run (`sourceUrl: https://github.com/wazero/wazero`, no warnings).

Note that the local platform resolves this dependency through the proxy's `@latest` pseudo-version fallback, so the hosted app's failure does not reproduce locally. The fix does not depend on the lookup path: a disabled dependency is never looked up under any datasource.

## Not addressed here

The underlying reason is that the SDK is a nested module with no module-scoped tags, so anyone running `go get` on it gets a pseudo-version. That is a release-process question, separate from this warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnZPzL7FDbz6pLwCwMZYe5